### PR TITLE
Replace getAll() in ProfileVisibilityHandler

### DIFF
--- a/htdocs/modules/profile/admin/visibility.php
+++ b/htdocs/modules/profile/admin/visibility.php
@@ -59,10 +59,11 @@ $opform->addElement($op_select);
 $opform->display();
 
 $criteria = new CriteriaCompo();
-$criteria->setGroupBy('field_id, user_group, profile_group');
-$criteria->setSort('field_id');
+//$criteria->setGroupBy('field_id, user_group, profile_group');
+$criteria->setSort('field_id, user_group, profile_group');
 $criteria->setOrder('DESC');
-$visibilities = $visibility_handler->getAll($criteria, false, false, true);
+
+$visibilities = $visibility_handler->getAllByFieldId($criteria);
 
 $member_handler = xoops_getHandler('member');
 $groups         = $member_handler->getGroupList();
@@ -96,4 +97,3 @@ $GLOBALS['xoopsTpl']->display('db:profile_admin_visibility.tpl');
 
 include_once __DIR__ . '/admin_footer.php';
 //xoops_cp_footer();
-

--- a/htdocs/modules/profile/class/visibility.php
+++ b/htdocs/modules/profile/class/visibility.php
@@ -60,7 +60,7 @@ class ProfileVisibilityHandler extends XoopsPersistableObjectHandler
     public function getVisibleFields($profile_groups, $user_groups = null)
     {
         $profile_groups[] = $user_groups[] = 0;
-        $sql              = "SELECT field_id FROM {$this->table} WHERE profile_group IN (" . implode(',', $profile_groups) . ')';
+        $sql  = "SELECT field_id FROM {$this->table} WHERE profile_group IN (" . implode(',', $profile_groups) . ')';
         $sql .= ' AND user_group IN (' . implode(',', $user_groups) . ')';
         $field_ids = array();
         if ($result = $this->db->query($sql)) {
@@ -70,5 +70,52 @@ class ProfileVisibilityHandler extends XoopsPersistableObjectHandler
         }
 
         return $field_ids;
+    }
+
+    /**
+     * get all rows matching a condition
+     *
+     * @param  CriteriaElement $criteria  {@link CriteriaElement} to match
+     *
+     * @return array of row arrays, indexed by field_id
+     */
+    public function getAllByFieldId(CriteriaElement $criteria = null)
+    {
+        $rawRows = parent::getAll($criteria, null, false, false);
+
+        usort($rawRows, array($this, 'visibilitySort'));
+
+        $rows = array();
+        foreach ($rawRows as $rawRow) {
+            $rows[$rawRow['field_id']][] = $rawRow;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * compare two arrays, each a row from profile_visibility
+     * The comparison is on three columns, 'field_id', 'user_group', 'profile_group' considered in that
+     * order for comparison
+     *
+     * @param array $a associative array with 3 numeric entries 'field_id', 'user_group', 'profile_group'
+     * @param array $b associative array with 3 numeric entries 'field_id', 'user_group', 'profile_group'
+     *
+     * @return int integer less that zero if $a is less than $b
+     *              integer zero if $a and $b are equal
+     *              integer greater than zero if $a is greater than $b
+     */
+    protected function visibilitySort($a, $b)
+    {
+        $fieldDiff = $a['field_id'] - $b['field_id'];
+        $userDiff  = $a['user_group'] - $b['user_group'];
+        $profDiff  = $a['profile_group'] - $b['profile_group'];
+        if (0 != $fieldDiff) {
+            return $fieldDiff;
+        } elseif (0 !== $userDiff) {
+            return $userDiff;
+        } else {
+            return $profDiff;
+        }
     }
 }


### PR DESCRIPTION
Since the profile_visibility table does not have a single unique column, the *id_as_key* logic will not work correctly. Added a `getAllByFieldId()` method to return an array of arrays of rows, which is what the template was expecting.

With this change, we now get a complete set of visibilities for each field.

Fixes #43 