### PR TITLE
Make mb_* calls conditional on function exists

### DIFF
--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -586,7 +586,9 @@ class MyTextSanitizer
     public function &displayTarea($text, $html = 0, $smiley = 1, $xcode = 1, $image = 1, $br = 1)
     {
         $charset = (defined('_CHARSET') ? _CHARSET : 'UTF-8');
-        $text    = mb_convert_encoding($text, $charset, mb_detect_encoding($text, $charset . ', ISO-8859-1', true));
+        if (function_exists('mb_convert_encoding')) {
+            $text = mb_convert_encoding($text, $charset, mb_detect_encoding($text, mb_detect_order(), true));
+        }
         if ($html != 1) {
             // html not allowed
             $text = $this->htmlSpecialChars($text, ENT_COMPAT, $charset);


### PR DESCRIPTION
Appears we have accidentally had a requirement for ext-mbstring since 2.5.6 :frowning: 

This fixes that, and also adds more complete detection when using mb_detect_encoding().