### PR TITLE
XoopsMailer PHP4 same name constructor shim

### DIFF
--- a/htdocs/class/xoopsmailer.php
+++ b/htdocs/class/xoopsmailer.php
@@ -103,7 +103,18 @@ class XoopsMailer
         $this->reset();
     }
 
-    // public     // reset all properties to default
+    /**
+     * PHP 4 style constructor compatibility shim
+     *
+     * @deprecated all callers should be using parent::__construct()
+     */
+    public function XoopsMailer()
+    {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        trigger_error("Should call parent::__construct in {$trace[0]['file']} line {$trace[0]['line']},");
+        self::__construct();
+    }
+
     /**
      * @param bool $value
      */

--- a/htdocs/language/english/xoopsmailerlocal.php
+++ b/htdocs/language/english/xoopsmailerlocal.php
@@ -25,12 +25,10 @@ defined('XOOPS_ROOT_PATH') || exit('Restricted access');
  * The English localization is solely for demonstration
  */
 // Do not change the class name
-class xoopsmailerlocal extends XoopsMailer
+class XoopsMailerLocal extends XoopsMailer
 {
     /**
-     * Constructer
-     *
-     * @return XoopsMailerLocal
+     * Constructor
      */
     public function __construct()
     {
@@ -40,8 +38,10 @@ class xoopsmailerlocal extends XoopsMailer
         // You MUST specify the language code value so that the file exists: XOOPS_ROOT_PAT/class/mail/phpmailer/language/lang-["your-language-code"].php
         $this->multimailer->setLanguage('en');
     }
-    // Multibyte languages are encouraged to make their proper method for encoding FromName
+
     /**
+     * Multibyte languages are encouraged to make their proper method for encoding FromName
+     *
      * @param $text
      *
      * @return mixed
@@ -52,8 +52,11 @@ class xoopsmailerlocal extends XoopsMailer
         // $text = "=?{$this->charSet}?B?".base64_encode($text)."?=";
         return $text;
     }
-    // Multibyte languages are encouraged to make their proper method for encoding Subject
+
+
     /**
+     * Multibyte languages are encouraged to make their proper method for encoding Subject
+     *
      * @param $text
      *
      * @return mixed


### PR DESCRIPTION
Adds a compatibility shim to support calls to XoopsMailer::XoopsMailer() in XoopsMailerLocal implementations. Fixes #115 

The older style XoopsMailerLocal code looks like this:
```
    function XoopsMailerLocal()
    {
        $this->XoopsMailer();
        // It is supposed no need to change the charset
        $this->charSet = strtolower(_CHARSET);
        // You MUST specify the language code value so that the file exists: XOOPS_ROOT_PAT/class/mail/phpmailer/language/lang-["your-language-code"].php
        $this->multimailer->SetLanguage("en");
    }
```

The old style constructors with the same name as the class are **deprecated** and all support for them [will be removed from PHP](http://php.net/manual/en/language.oop5.decon.php) in the future.

The preferred and fully supported style looks like this:
```
public function __construct()
    {
        parent::__construct();
        // It is supposed no need to change the charset
        $this->charSet = strtolower(_CHARSET);
        // You MUST specify the language code value so that the file exists: XOOPS_ROOT_PAT/class/mail/phpmailer/language/lang-["your-language-code"].php
        $this->multimailer->setLanguage('en');
    }

```

This patch allows existing XoopsMailerLocal implementations to continue to work, but they will issue a deprecation warning to assist maintainers in locating and fixing this issue.