### PR TITLE
Docblock fix for getHandler functions

### DIFF
--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -23,7 +23,7 @@ defined('XOOPS_ROOT_PATH') || exit('Restricted access');
  * @param mixed $name
  * @param mixed $optional
  *
- * @return bool
+ * @return XoopsObjectHandler|false
  */
 function xoops_getHandler($name, $optional = false)
 {
@@ -56,7 +56,7 @@ function xoops_getHandler($name, $optional = false)
  * @param mixed $name
  * @param mixed $module_dir
  * @param mixed $optional
- * @return bool
+ * @return XoopsObjectHandler|false
  */
 function xoops_getModuleHandler($name = null, $module_dir = null, $optional = false)
 {

--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -1094,6 +1094,7 @@ class XoopsObjectHandler
      * creates a new object
      *
      * @abstract
+     * @return XoopsObject
      */
     public function create()
     {
@@ -1104,6 +1105,7 @@ class XoopsObjectHandler
      *
      * @param int $int_id
      * @abstract
+     * @return XoopsObject
      */
     public function get($int_id)
     {


### PR DESCRIPTION
Eliminate some spurious errors reported by some qa tools.