### PR TITLE
XoopsFormDateTime - time only option

### DIFF
--- a/htdocs/class/xoopsform/formdatetime.php
+++ b/htdocs/class/xoopsform/formdatetime.php
@@ -24,32 +24,59 @@ defined('XOOPS_ROOT_PATH') || exit('Restricted access');
  * @author         Kazumi Ono <onokazu@xoops.org>
  * @package        kernel
  * @subpackage     form
- * @access         public
  */
 class XoopsFormDateTime extends XoopsFormElementTray
 {
+    const SHOW_BOTH = 1;
+    const SHOW_DATE = 0;
+    const SHOW_TIME = 2;
+
     /**
      * XoopsFormDateTime::XoopsFormDateTime()
      *
-     * @param mixed   $caption
-     * @param mixed   $name
-     * @param integer $size
-     * @param integer $value
-     * @param mixed   $showtime
+     * @param mixed   $caption  form field caption
+     * @param mixed   $name     form variable name
+     * @param integer $size     size of date select
+     * @param integer $value    unix timestamp, defaults to now
+     * @param mixed   $showtime control display of date and time elements
+     *                           SHOW_BOTH, true  - show both date and time selectors
+     *                           SHOW_DATE, false - only show date selector
+     *                           SHOW_TIME        - only show time selector
      */
     public function __construct($caption, $name, $size = 15, $value = 0, $showtime = true)
     {
         parent::__construct($caption, '&nbsp;');
+        switch ((int) $showtime) {
+            case static::SHOW_DATE:
+                $displayDate = true;
+                $displayTime = false;
+                break;
+            case static::SHOW_TIME:
+                $displayDate = false;
+                $displayTime = true;
+                break;
+            default:
+                $displayDate = true;
+                $displayTime = true;
+                break;
+        }
         $value    = (int)$value;
         $value    = ($value > 0) ? $value : time();
         $datetime = getdate($value);
-        $this->addElement(new XoopsFormTextDateSelect('', $name . '[date]', $size, $value, $showtime));
+        if ($displayDate) {
+            $this->addElement(new XoopsFormTextDateSelect('', $name . '[date]', $size, $value));
+        } else {
+            $value = !is_numeric($value) ? time() : (int)$value;
+            $value = ($value == 0) ? time() : $value;
+            $displayValue = date(_SHORTDATESTRING, $value);
+            $this->addElement(new XoopsFormHidden($name . '[date]', $displayValue));
+        }
 
-        if ($showtime) {
+        if ($displayTime) {
             $timearray = array();
             for ($i = 0; $i < 24; ++$i) {
                 for ($j = 0; $j < 60; $j += 10) {
-                    $key             = ($i * 3600) + ($j * 60);
+                    $key = ($i * 3600) + ($j * 60);
                     $timearray[$key] = ($j != 0) ? $i . ':' . $j : $i . ':0' . $j;
                 }
             }


### PR DESCRIPTION
Implements static constants, SHOW_BOTH, SHOW_DATE and SHOW_TIME, to expand the $showtime parameter to add a time only option.

This replaces #106. A time only element can be specified like this:

```php
new XoopsFormDateTime('', 'name', 15, $time, XoopsFormDateTime::SHOW_TIME);
```