### PR TITLE
Highlight Update System Module in upgrade

### DIFF
--- a/upgrade/check_version.php
+++ b/upgrade/check_version.php
@@ -69,7 +69,10 @@ if ($needUpgrade && !empty($files)) {
 </table>
 <?php
 if (!$needUpgrade) {
-    $update_link = '<a href="' . XOOPS_URL . '/modules/system/admin.php?fct=modulesadmin&amp;op=update&amp;module=system">' . _UPDATE_SYSTEM_MODULE . '</a>';
+    $update_link = '<form style="display: inline;" method="POST" action="'
+    . XOOPS_URL . '/modules/system/admin.php?fct=modulesadmin&amp;op=update&amp;module=system">'
+    . '<button type="submit" style="color:red;">' . _UPDATE_SYSTEM_MODULE . '</button></form>';
+    //$update_link = '<a href="' . XOOPS_URL . '/modules/system/admin.php?fct=modulesadmin&amp;op=update&amp;module=system">' . _UPDATE_SYSTEM_MODULE . '</a>';
     echo '<div class="x2-note">' . sprintf(_NO_NEED_UPGRADE, $update_link) . '</div>';
 
     return null;


### PR DESCRIPTION
The instruction to "update system module" presented at the end of the upgrade process is a link, but it is often overlooked. This change makes the instructions into a button with red letters, hopefully driving up the number of smooth successful upgrades.