### PR TITLE
Re captcha 2

### DIFF
--- a/htdocs/class/captcha/config.php
+++ b/htdocs/class/captcha/config.php
@@ -25,7 +25,7 @@ defined('XOOPS_ROOT_PATH') || exit('Restricted access');
  */
 return $config = array(
     'disabled'    => false,  // Disable CAPTCHA
-    'mode'        => 'text',  // default mode, you can choose 'text', 'image', 'recaptcha'(requires api key)
+    'mode'        => 'text',  // default mode, you can choose 'text', 'image', 'recaptcha'(requires api key), 'recaptcha_2'(requires api key)
     'name'        => 'xoopscaptcha',  // captcha name
     'skipmember'  => true,  // Skip CAPTCHA check for members
     'maxattempts' => 10,  // Maximum attempts for each session

--- a/htdocs/class/captcha/config.recaptcha_2.php
+++ b/htdocs/class/captcha/config.recaptcha_2.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+ 
+/**
+ * CAPTCHA configurations for Recaptcha 2 mode
+ *
+ * @package     class
+ * @subpackage  CAPTCHA
+ * @author      Grégory Mage
+ * @copyright   2016 XOOPS Project (http://xoops.org)
+ * @license     GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @link        http://xoops.org
+ */
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
+
+return $config = array(
+    'website_key' => 'YourWebsiteKey', //https://www.google.com/recaptcha/intro/index.html YourWebsiteKey
+    'secret_key'  => 'YourSecretKey',); //https://www.google.com/recaptcha/intro/index.html YourSecretKey

--- a/htdocs/class/captcha/recaptcha.php
+++ b/htdocs/class/captcha/recaptcha.php
@@ -41,6 +41,7 @@ class XoopsCaptchaRecaptcha extends XoopsCaptchaMethod
      */
     public function render()
     {
+        trigger_error("recaptcha is outdated , use recaptcha_2 in \class\captcha\config.php", E_USER_WARNING);
         require_once __DIR__ . '/recaptcha/recaptchalib.php';
         $form = "<script type=\"text/javascript\">
             var RecaptchaOptions = {
@@ -60,7 +61,7 @@ class XoopsCaptchaRecaptcha extends XoopsCaptchaMethod
      *
      * @return bool
      */
-    public function verify($sessionName)
+    public function verify($sessionName = null)
     {
         $is_valid = false;
         require_once __DIR__ . '/recaptcha/recaptchalib.php';

--- a/htdocs/class/captcha/recaptcha_2.php
+++ b/htdocs/class/captcha/recaptcha_2.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+ 
+/**
+ * CAPTCHA for Recaptcha mode
+ *
+ * @package     class
+ * @subpackage  CAPTCHA
+ * @author      Grégory Mage
+ * @copyright   2016 XOOPS Project (http://xoops.org)
+ * @license     GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @link        http://xoops.org
+ */
+
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
+
+/**
+ * Class XoopsCaptchaRecaptcha_2
+ */
+class XoopsCaptchaRecaptcha_2 extends XoopsCaptchaMethod
+{
+    /**
+     * XoopsCaptchaRecaptcha_2::isActive()
+     *
+     * @return bool
+     */
+    public function isActive()
+    {
+        return true;
+    }
+
+    /**
+     * XoopsCaptchaRecaptcha_2::render()
+     *
+     * @return string
+     */
+    public function render()
+    {
+        $form = "<script src='https://www.google.com/recaptcha/api.js'></script>";
+        $form .= "<div class=\"form-group\">
+                  <div class=\"g-recaptcha\" data-sitekey=\"" . $this->config['website_key'] . "\"></div>
+                  </div>";
+        return $form;
+    }
+
+    /**
+     * XoopsCaptchaRecaptcha_2::verify()
+     *
+     * @param mixed|null $sessionName
+     *
+     * @return bool
+     */
+    public function verify($sessionName = NULL)
+    {
+        $is_valid = false;
+        XoopsLoad::load('XoopsRequest');
+        $recaptcha_response = XoopsRequest::getString('g-recaptcha-response', '');
+        if ($recaptcha_response == '') {
+            $is_valid = false;
+        } else {
+            $recaptcha_check = file_get_contents('https://www.google.com/recaptcha/api/siteverify?secret=' . $this->config['secret_key'] . '&response=' .  $recaptcha_response . '&remoteip=' . getenv('REMOTE_ADDR'));
+            $recaptcha_check = json_decode($recaptcha_check , true);
+            if ($recaptcha_check['success'] == true) {
+                $is_valid = true;
+            } else {
+                foreach (array_keys($recaptcha_check['error-codes']) as $i) {
+                    echo $recaptcha_check['error-codes'][$i] . '<br>';
+                }
+            }
+        }
+        return $is_valid;
+    }
+}

--- a/htdocs/class/captcha/recaptcha_2.php
+++ b/htdocs/class/captcha/recaptcha_2.php
@@ -71,8 +71,9 @@ class XoopsCaptchaRecaptcha_2 extends XoopsCaptchaMethod
             if ($recaptcha_check['success'] == true) {
                 $is_valid = true;
             } else {
-                foreach (array_keys($recaptcha_check['error-codes']) as $i) {
-                    echo $recaptcha_check['error-codes'][$i] . '<br>';
+                $captchaInstance = XoopsCaptcha::getInstance();
+                foreach ($recaptcha_check['error-codes'] as $msg) {
+                    $captchaInstance->message[] = $msg;
                 }
             }
         }

--- a/htdocs/class/xoopsform/formcaptcha.php
+++ b/htdocs/class/xoopsform/formcaptcha.php
@@ -28,7 +28,7 @@ xoops_load('XoopsFormElement');
  *
  * For verification:
  * <code>
- *               xoops_load("captcha");
+ *               xoops_load('xoopscaptcha');
  *               $xoopsCaptcha = XoopsCaptcha::getInstance();
  *               if (! $xoopsCaptcha->verify() ) {
  *                   echo $xoopsCaptcha->getMessage();

--- a/htdocs/test_xoopscaptcha.php
+++ b/htdocs/test_xoopscaptcha.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+/**
+ * CAPTCHA tests
+ *
+ * @author      Grégory Mage
+ * @copyright   2016 XOOPS Project (http://xoops.org)
+ * @license     GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @link        http://xoops.org
+ */
+ 
+ /* IMPORTANT!!! 
+ * please modify htdocs\class\captcha\config.php like this for test:
+     return $config = array(
+        'disabled'    => false,  // Disable CAPTCHA
+        'mode'        => 'recaptcha_2',  // default mode, you can choose 'text', 'image', 'recaptcha'(requires api key)
+        'name'        => 'xoopscaptcha',  // captcha name
+        'skipmember'  => false,  // Skip CAPTCHA check for members
+        'maxattempts' => 10,  // Maximum attempts for each session
+    );
+ */
+
+include __DIR__ . '/mainfile.php';
+include_once XOOPS_ROOT_PATH.'/header.php';
+
+XoopsLoad::load('XoopsRequest');
+// Get Action type
+$op = XoopsRequest::getCmd('op', 'form');
+switch ($op) {    
+    // form
+    case 'form':
+        include_once XOOPS_ROOT_PATH . '/class/xoopsformloader.php';
+        echo '<h2>Test xoops captcha</h2>';
+        $form = new XoopsThemeForm('Test xoops captcha', 'form', $_SERVER['REQUEST_URI'], 'post', true);
+        $form->addElement(new XoopsFormText('Test text', 'text', 50, 255, ''), true);
+        $form->addElement(new XoopsFormCaptcha('Test captcha', 'captcha', false), true);
+        $form->addElement(new XoopsFormHidden('op', 'save'));
+        $form->addElement(new XoopsFormButton('', 'submit', _SUBMIT, 'submit'));
+        echo $form->render();
+    break;
+
+    // save
+    case 'save':
+        echo '<h2>Test xoops captcha answer</h2>';
+        xoops_load('xoopscaptcha');
+        $xoopsCaptcha = XoopsCaptcha::getInstance();
+        if (! $xoopsCaptcha->verify() ) {
+            echo 'Errors: ' . $xoopsCaptcha->getMessage();
+        } else {
+            echo 'Good!';
+        }
+    break;
+}
+include XOOPS_ROOT_PATH.'/footer.php';


### PR DESCRIPTION
New version of reCaptcha for Xoops.

I added a file to test the captcha. To remove before the release of the final version of XOOPS 2.5.9.

Richard, in recaptcha_2.php I have:

`echo $recaptcha_check['error-codes'][$i] . '<br>';`

I tried to do this:

`$this->message[] = $recaptcha_check['error-codes'][$i] `

but it does not work, can you help me?
