### PR TITLE
add .csv mimetypes

### DIFF
--- a/htdocs/include/mimetypes.inc.php
+++ b/htdocs/include/mimetypes.inc.php
@@ -104,6 +104,7 @@ return array(
     'xpm'   => 'image/x-xpixmap',
     'ics'   => 'text/calendar',
     'ifb'   => 'text/calendar',
+    'csv'   => 'text/csv',
     'css'   => 'text/css',
     'html'  => 'text/html',
     'htm'   => 'text/html',


### PR DESCRIPTION
The .csv extension is missing! The current system is not very practical to add a mimetype. For xoops 2.6 you have to change that.