### PR TITLE
Add indication on cloned blocks

### DIFF
--- a/htdocs/modules/system/templates/admin/system_blocks_item.tpl
+++ b/htdocs/modules/system/templates/admin/system_blocks_item.tpl
@@ -7,7 +7,7 @@
             <img class="xo-imgmini" src="<{xoAdminIcons block.png}>" alt="<{$smarty.const._AM_SYSTEM_BLOCKS_DRAG}>"
                  title="<{$smarty.const._AM_SYSTEM_BLOCKS_DRAG}>"/>
         </span>
-                <{$item.title}>
+<{$item.title}><{if $item.block_type == 'D'}> (<{$item.bid}>)<{/if}>
             </div>
             <div class="xo-blockaction xo-actions"><img id="loading_img<{$item.bid}>" src="./images/mimetypes/spinner.gif" style="display:none;"
                                                         title="<{$smarty.const._AM_SYSTEM_LOADING}>" alt="<{$smarty.const._AM_SYSTEM_LOADING}>"/><img


### PR DESCRIPTION
Show block number after cloned blocks in blocks administration. This is to help identify blocks if the name was not changed when cloned.

Fixes #275