### PR TITLE
Removing graphic images with english text

### DIFF
--- a/htdocs/modules/system/templates/system_comment.tpl
+++ b/htdocs/modules/system/templates/system_comment.tpl
@@ -36,23 +36,18 @@
 
     <{if $xoops_iscommentadmin == true}>
         <td class="even txtright">
-            <a href="<{$editcomment_link}>&amp;com_id=<{$comment.id}>" title="<{$lang_edit}>"><img src="<{$xoops_url}>/images/icons/edit.gif"
-                                                                                                   alt="<{$lang_edit}>"/></a>
-            <a href="<{$deletecomment_link}>&amp;com_id=<{$comment.id}>" title="<{$lang_delete}>"><img src="<{$xoops_url}>/images/icons/delete.gif"
-                                                                                                       alt="<{$lang_delete}>"/></a>
-            <a href="<{$replycomment_link}>&amp;com_id=<{$comment.id}>" title="<{$lang_reply}>"><img src="<{$xoops_url}>/images/icons/reply.gif"
-                                                                                                     alt="<{$lang_reply}>"/></a>
+            <button type="button" class="btn btn-default" onclick="window.location.href = '<{$editcomment_link}>&amp;com_id=<{$comment.id}>'" title="<{$lang_edit}>"><span class="fa fa-pencil-square-o fa-fw"></span></button>
+            <button type="button" class="btn btn-default" onclick="window.location.href = '<{$deletecomment_link}>&amp;com_id=<{$comment.id}>'" title="<{$lang_delete}>"><span class="fa fa-remove fa-fw"></span></button>
+            <button type="button" class="btn btn-default" onclick="window.location.href = '<{$replycomment_link}>&amp;com_id=<{$comment.id}>'" title="<{$lang_reply}>"><span class="fa fa-reply fa-fw"></span></button>
         </td>
     <{elseif $xoops_isuser == true && $xoops_userid == $comment.poster.id}>
         <td class="even txtright">
-            <a href="<{$editcomment_link}>&amp;com_id=<{$comment.id}>" title="<{$lang_edit}>"><img src="<{$xoops_url}>/images/icons/edit.gif"
-                                                                                                   alt="<{$lang_edit}>"/></a>
-            <a href="<{$replycomment_link}>&amp;com_id=<{$comment.id}>" title="<{$lang_reply}>"><img src="<{$xoops_url}>/images/icons/reply.gif"
-                                                                                                     alt="<{$lang_reply}>"/></a>
+            <button type="button" class="btn btn-default" onclick="window.location.href = '<{$editcomment_link}>&amp;com_id=<{$comment.id}>'" title="<{$lang_edit}>"><span class="fa fa-pencil-square-o fa-fw"></span></button>
+            <button type="button" class="btn btn-default" onclick="window.location.href = '<{$replycomment_link}>&amp;com_id=<{$comment.id}>'" title="<{$lang_reply}>"><span class="fa fa-reply fa-fw"></span></button>
         </td>
     <{elseif $xoops_isuser == true || $anon_canpost == true}>
         <td class="even txtright">
-            <a href="<{$replycomment_link}>&amp;com_id=<{$comment.id}>"><img src="<{$xoops_url}>/images/icons/reply.gif" alt="<{$lang_reply}>"/></a>
+            <button type="button" class="btn btn-default" onclick="window.location.href = '<{$replycomment_link}>&amp;com_id=<{$comment.id}>'" title="<{$lang_reply}>"><span class="fa fa-reply fa-fw"></span></button>
         </td>
     <{else}>
         <td class="even"></td>

--- a/htdocs/readpmsg.php
+++ b/htdocs/readpmsg.php
@@ -88,12 +88,12 @@ if (!is_object($xoopsUser)) {
         echo $pm_arr[0]->getVar('msg_text') . "<br><br></td></tr><tr class='foot'><td class='width20 txtleft' colspan='2'>";
         // we don't want to reply to a deleted user!
         if ($poster != false) {
-            echo "<a href='#' onclick='javascript:openWithSelfMain(\"" . XOOPS_URL . '/pmlite.php?reply=1&amp;msg_id=' . $pm_arr[0]->getVar('msg_id') . "\",\"pmlite\",565,500);'><img src='" . XOOPS_URL . "/images/icons/reply.gif' alt='" . _PM_REPLY . "' /></a>\n";
+            echo "<button type='button' class='btn btn-default' onclick='openWithSelfMain(\"" . XOOPS_URL . '/pmlite.php?reply=1&amp;msg_id=' . $pm_arr[0]->getVar('msg_id') . "\",\"pmlite\",565,500);' title='" . _PM_REPLY . "'><span class='fa fa-fw fa-reply'></span></button>\n";
         }
         echo "<input type='hidden' name='delete' value='1' />";
         echo $GLOBALS['xoopsSecurity']->getTokenHTML();
         echo "<input type='hidden' name='msg_id' value='" . $pm_arr[0]->getVar('msg_id') . "' />";
-        echo "<a href='#" . $pm_arr[0]->getVar('msg_id') . "' onclick='javascript:document.delete" . $pm_arr[0]->getVar('msg_id') . ".submit();'><img src='" . XOOPS_URL . "/images/icons/delete.gif' alt='" . _PM_DELETE . "' /></a>";
+        echo "<button type='button' class='btn btn-default' onclick='javascript:document.delete" . $pm_arr[0]->getVar('msg_id') . ".submit();' title='" . _PM_DELETE . "'><span class='fa fa-fw fa-remove'></span></button>";
         echo "</td></tr><tr><td class='txtright' colspan='2'>";
         $previous = $start - 1;
         $next     = $start + 1;


### PR DESCRIPTION
Images, such as images/icons/reply.gif and delete.gif, are hardcoded with english text. They appear quite dated and impede localization. With this change, these are no longer referenced in active core.