### PR TITLE
Add bootstrap compatible template

### DIFF
--- a/htdocs/themes/xbootstrap/modules/system/blocks/system_block_siteinfo.tpl
+++ b/htdocs/themes/xbootstrap/modules/system/blocks/system_block_siteinfo.tpl
@@ -1,0 +1,35 @@
+<table class="outer">
+
+    <{if $block.showgroups == true}>
+
+        <!-- start group loop -->
+        <{foreach item=group from=$block.groups}>
+            <tr>
+                <th colspan="2"><{$group.name}></th>
+            </tr>
+            <!-- start group member loop -->
+            <{foreach item=user from=$group.users}>
+                <tr>
+                    <td class="even txtcenter alignmiddle">
+                        <img style="width:48px;" src="<{$user.avatar}>" alt="<{$user.name}>"/><br>
+                        <a href="<{$xoops_url}>/userinfo.php?uid=<{$user.id}>" title="<{$user.name}>"><{$user.name}></a>
+                    </td>
+                    <td class="odd width20 txtright alignmiddle">
+                        <a href="javascript:openWithSelfMain('<{$xoops_url}>/pmlite.php?send2=1&to_userid=<{$user.id}>','pmlite',565,500);">
+                        <span class="fa fa-envelope fa-lg" aria-hidden="true"></span>
+                        </a>
+                    </td>
+                </tr>
+            <{/foreach}>
+            <!-- end group member loop -->
+
+        <{/foreach}>
+        <!-- end group loop -->
+    <{/if}>
+</table>
+
+<br>
+
+<div>
+    <img src="<{$block.logourl}>" alt=""/><br><{$block.recommendlink}>
+</div>


### PR DESCRIPTION
Override system_block_siteinfo.tpl template to avoid legacy conflicts. Fixes #308 

Main issue is the css class "collapse" used on the table. This has a much different meaning in ANY bootstrap based theme.

The intended definition comes from /xoops.css
```
.collapse {
    border-collapse: collapse;
}
```

Changing the base template could break layout in non-bootstrap themes, so a new theme override template is added. Other bootstrap themes may want to adopt a similar solution.