### PR TITLE
Supress zero post users

### DIFF
--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -400,6 +400,7 @@ function b_system_topposters_show($options)
 {
     $block    = array();
     $criteria = new CriteriaCompo(new Criteria('level', 0, '>'));
+    $criteria->add(new Criteria('posts', 0, '>'));
     $limit    = (!empty($options[0])) ? $options[0] : 10;
     $size     = count($options);
     for ($i = 2; $i < $size; ++$i) {


### PR DESCRIPTION
Fixes #309 - an edge case where top posters block is used on an unused site.