### PR TITLE
Error from protector in PHP 7.1

### DIFF
--- a/htdocs/kernel/module.php
+++ b/htdocs/kernel/module.php
@@ -75,7 +75,7 @@ class XoopsModule extends XoopsObject
             $this->loadInfo($dirname, $verbose);
         }
         $this->setVar('name', $this->modinfo['name'], true);
-        $this->setVar('version', (int)(100 * ($this->modinfo['version'] + 0.001)), true);
+        $this->setVar('version', (int)(100 * ((float) $this->modinfo['version'] + 0.001)), true);
         $this->setVar('dirname', $this->modinfo['dirname'], true);
         $hasmain     = (isset($this->modinfo['hasMain']) && $this->modinfo['hasMain'] == 1) ? 1 : 0;
         $hasadmin    = (isset($this->modinfo['hasAdmin']) && $this->modinfo['hasAdmin'] == 1) ? 1 : 0;

--- a/htdocs/xoops_lib/modules/protector/include/precheck.inc.php
+++ b/htdocs/xoops_lib/modules/protector/include/precheck.inc.php
@@ -9,7 +9,7 @@ if (class_exists('Database')) {
 }
 
 define('PROTECTOR_PRECHECK_INCLUDED', 1);
-define('PROTECTOR_VERSION', file_get_contents(__DIR__ . '/version.txt'));
+define('PROTECTOR_VERSION', (float) file_get_contents(__DIR__ . '/version.txt'));
 
 // set $_SERVER['REQUEST_URI'] for IIS
 if (empty($_SERVER['REQUEST_URI'])) {         // Not defined by IIS

--- a/htdocs/xoops_lib/modules/protector/xoops_version.php
+++ b/htdocs/xoops_lib/modules/protector/xoops_version.php
@@ -24,7 +24,7 @@ $modversion['name']           = constant($constpref . '_NAME');
 $modversion['description']    = constant($constpref . '_DESC');
 $modversion['version']        = (float) file_get_contents(__DIR__ . '/include/version.txt');
 $modversion['credits']        = 'PEAK Corp.';
-$modversion['author']         = 'GIJ=CHECKMATE<br>PEAK Corp.(http://www.peak.ne.jp/)';
+$modversion['author']         = 'GIJ=CHECKMATE PEAK Corp.(http://www.peak.ne.jp/)';
 $modversion['help']           = 'page=help';
 $modversion['license']        = 'GNU GPL 2.0';
 $modversion['license_url']    = 'www.gnu.org/licenses/gpl-2.0.html/';

--- a/htdocs/xoops_lib/modules/protector/xoops_version.php
+++ b/htdocs/xoops_lib/modules/protector/xoops_version.php
@@ -22,7 +22,7 @@ $constpref = '_MI_' . strtoupper($mydirname);
 
 $modversion['name']           = constant($constpref . '_NAME');
 $modversion['description']    = constant($constpref . '_DESC');
-$modversion['version']        = file_get_contents(__DIR__ . '/include/version.txt');
+$modversion['version']        = (float) file_get_contents(__DIR__ . '/include/version.txt');
 $modversion['credits']        = 'PEAK Corp.';
 $modversion['author']         = 'GIJ=CHECKMATE<br>PEAK Corp.(http://www.peak.ne.jp/)';
 $modversion['help']           = 'page=help';


### PR DESCRIPTION
Under PHP 7.1 there is an error:

> Notice: A non well formed numeric value encountered in file /kernel/module.php line 78

This appears to come from protector's use of a version.txt file it reads to obtain the actual version number. That file has a line feed at the end, and the entire contents of the file, including the line ending, is assigned to the $modversion['version'] key in xoops_version.php. That can result in the notice when a XoopsModule object for protector is accessed.

Change to both protector and XoopsModule to cast the version as float, which silently swallows the offending whitespace.