### PR TITLE
Error in class management

### DIFF
--- a/htdocs/class/xml/saxparser.php
+++ b/htdocs/class/xml/saxparser.php
@@ -167,12 +167,6 @@ class SaxParser
     public function free()
     {
         xml_parser_free($this->parser);
-
-        if (!method_exists($this, '__destruct')) {
-            unset($this);
-        } else {
-            $this->__destruct();
-        }
     }
 
     /****************************************************************************


### PR DESCRIPTION
Let PHP handle freeing resources.

- unset($this) is a fatal error in PHP 7.1 (never was a good idea)
- __destruct() is called automatically by PHP when appropriate