### PR TITLE
Debug option for fine uploader

### DIFF
--- a/htdocs/imagemanager.php
+++ b/htdocs/imagemanager.php
@@ -188,6 +188,14 @@ switch ($op) {
         );
         $jwt = \Xmf\Jwt\TokenFactory::build('fineuploader', $payload, 60*30); // token good for 30 minutes
         $xoopsTpl->assign('jwt', $jwt);
+        $fineup_debug = 'false';
+        if (($xoopsUser instanceof \XoopsUser ? $xoopsUser->isAdmin() : false)
+            && isset($_REQUEST['FINEUPLOADER_DEBUG']))
+        {
+            $fineup_debug = 'true';
+        }
+        $xoopsTpl->assign('fineup_debug', $fineup_debug);
+
         $xoopsTpl->display('db:system_imagemanager2.tpl');
         exit();
         break;

--- a/htdocs/modules/system/templates/system_imagemanager2.tpl
+++ b/htdocs/modules/system/templates/system_imagemanager2.tpl
@@ -184,7 +184,12 @@
             sizeLimit: <{$imgcat_maxsize}>
         },
         autoUpload: false,
-        debug: true
+        callbacks: {
+            onError: function(id, name, errorReason, xhrOrXdr) {
+                console.log(qq.format("Error uploading {}.  Reason: {}", name, errorReason));
+            }
+        },
+        debug: <{$fineup_debug}>
     });
 
     qq(document.getElementById("trigger-upload")).attach("click", function() {


### PR DESCRIPTION
A FINEUPLOADER_DEBUG key in $_REQUEST will turn on debugging output from Image Manager.

Example:
`/imagemanager.php?target=message&op=upload&imgcat_id=1&FINEUPLOADER_DEBUG`

Also, add js console logging of error messages from handlers.