### PR TITLE
Add cookie domain to install

### DIFF
--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -38,6 +38,7 @@ class PathStuffController
         'lib'  => 'PATH');
 
     public $xoopsUrl = '';
+    public $xoopsCookieDomain = '';
 
     public $validPath = array(
         'root' => 0,
@@ -90,6 +91,11 @@ class PathStuffController
             $path           = $GLOBALS['wizard']->baseLocation();
             $this->xoopsUrl = substr($path, 0, strrpos($path, '/'));
         }
+        if (isset($_SESSION['settings']['COOKIE_DOMAIN'])) {
+            $this->xoopsCookieDomain = $_SESSION['settings']['COOKIE_DOMAIN'];
+        } else {
+            $this->xoopsCookieDomain = xoops_getBaseDomain($this->xoopsUrl);
+        }
     }
 
     public function execute()
@@ -101,6 +107,7 @@ class PathStuffController
                 $_SESSION['settings'][$sess] = $this->xoopsPath[$req];
             }
             $_SESSION['settings']['URL'] = $this->xoopsUrl;
+            $_SESSION['settings']['COOKIE_DOMAIN'] = $this->xoopsCookieDomain;
             if ($valid) {
                 $GLOBALS['wizard']->redirectToPage('+1');
             } else {
@@ -128,6 +135,10 @@ class PathStuffController
                     $request['URL'] = substr($request['URL'], 0, -1);
                 }
                 $this->xoopsUrl = $request['URL'];
+            }
+            if (isset($request['COOKIE_DOMAIN'])) {
+                $request['COOKIE_DOMAIN'] = trim($request['COOKIE_DOMAIN']);
+                $this->xoopsCookieDomain = $request['COOKIE_DOMAIN'];
             }
         }
     }

--- a/htdocs/install/language/english/install.php
+++ b/htdocs/install/language/english/install.php
@@ -185,3 +185,5 @@ define('CHMOD_CHGRP_IGNORE', 'Use Anyway');
 define('CHMOD_CHGRP_ERROR', 'Installer may not be able to write the configuration file %1$s.<p>PHP is writing files under user %2$s and group %3$s.<p>The directory %4$s/ has user %5$s and group %6$s');
 //2.5.9
 define("CURL_HTTP", "Client URL Library (cURL)");
+define('XOOPS_COOKIE_DOMAIN_LABEL', 'Cookie Domain for the Website');
+define('XOOPS_COOKIE_DOMAIN_HELP', 'Domain to set cookies. May be blank, the full host from the URL (www.example.com), or the registered domain without subdomains (example.com) to share across subdomains (www.example.com and blog.example.com.)');

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -29,6 +29,7 @@ require_once './include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 include_once './class/pathcontroller.php';
+include_once '../include/functions.php';
 
 $pageHasForm = true;
 $pageHasHelp = true;
@@ -132,6 +133,11 @@ ob_start();
 
         <div class="xoform-help"><?php echo XOOPS_URL_HELP; ?></div>
         <input type="text" name="URL" id="url" value="<?php echo $ctrl->xoopsUrl; ?>" onchange="removeTrailing('url', this.value)"/>
+
+        <label class="xolabel" for="cookie_domain"><?php echo XOOPS_COOKIE_DOMAIN_LABEL; ?></label>
+
+        <div class="xoform-help"><?php echo XOOPS_COOKIE_DOMAIN_HELP; ?></div>
+        <input type="text" name="COOKIE_DOMAIN" id="cookie_domain" value="<?php echo $ctrl->xoopsCookieDomain; ?>" onchange="removeTrailing('url', this.value)"/>
     </fieldset>
 
 <?php

--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -41,6 +41,11 @@ if (!defined('XOOPS_MAINFILE_INCLUDED')) {
     // Example: define("XOOPS_URL", "http://url_to_xoops_directory");
     define('XOOPS_URL', 'http://');
 
+    // XOOPS Cookie Domain to specify when creating cookies. May be blank (i.e. for IP address host),
+    // full host from XOOPS_URL (i.e. www.example.com) or just the registered domain (i.e. example.com)
+    // to share cookies across multiple subdomains (i.e. www.example.com and blog.example.com)
+    define('XOOPS_COOKIE_DOMAIN', '');
+
     // Shall be handled later, don't forget!
     define('XOOPS_CHECK_PATH', 0);
     // Protect against external scripts execution if safe mode is not enabled


### PR DESCRIPTION
The domain of a cookie effects which subdomains the cookie will be sent to.

Historically, the XOOPS_COOKIE_DOMAIN constant has been determined by an algorithm, which in some cases produced invalid results. Changing it required digging into code. The constant will now be explicitly defined in mainfile.php and exposed as a configurable option during the install.