### PR TITLE
Add rendered form to XoopsForm::assign()

### DIFF
--- a/docs/changelog.250.txt
+++ b/docs/changelog.250.txt
@@ -54,6 +54,7 @@ XOOPS 2.5.x Changelog (Language changes: see: /docs/lang_diff.txt)
 - PHP 7.1 compatibility fixes (mamba, geekwright)
 - set XOOPS_COOKIE_DOMAIN during install and set in mainfile.php
 - recommend Intl extension
+- add 'rendered' key to XoopsForm::assign(), allows template to choose rendered or by element
 
 Updated libraries and assets:
  - jQuery 3.1.1 (mamba)

--- a/htdocs/class/xoopsform/form.php
+++ b/htdocs/class/xoopsform/form.php
@@ -629,6 +629,8 @@ class XoopsForm
             'method'     => $this->getMethod(),
             'extra'      => 'onsubmit="return xoopsFormValidate_' . $this->getName() . '();"' . $this->getExtra(),
             'javascript' => $js,
-            'elements'   => $elements));
+            'elements'   => $elements,
+            'rendered'   => $this->render(),
+        ));
     }
 }

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -816,7 +816,7 @@ function xoops_getcss($theme = '')
  *
  * @return \XoopsMailer|\XoopsMailerLocal
  */
-function &xoops_getMailer()
+function xoops_getMailer()
 {
     static $mailer;
     global $xoopsConfig;


### PR DESCRIPTION
Add a fully rendered version of the form to the template assignments when the XoopsForm::assign() method is used. The form rendering is added to the 'rendered' key of the assignments.

This change allows the theme templates to choose the full system rendered form or process the individual elements as appropriate.