### PR TITLE
Wrong template on user block after upgrade

### DIFF
--- a/htdocs/modules/system/xoops_version.php
+++ b/htdocs/modules/system/xoops_version.php
@@ -109,7 +109,7 @@ $modversion['templates'][] = array('file' => 'system_maintenance.tpl', 'descript
 $modversion['templates'][] = array('file' => 'system_help.tpl', 'description' => '', 'type' => 'admin');
 
 // Blocks
-$modversion['blocks'][] = array(
+$modversion['blocks'][1] = array(
     'file'        => 'system_blocks.php',
     'name'        => _MI_SYSTEM_BNAME2,
     'description' => 'Shows user block',


### PR DESCRIPTION
The shift in array index causes the func_num on the newblocks table not to match on update. The old definition was not updated, and still referenced the .html template. This interfered with the expected template overrides using .tpl template names.

Probably should address this in the block update code eventually, but this fixes the problem for now.