### PR TITLE
Match jGrowl to theme in xswatch

### DIFF
--- a/htdocs/themes/xswatch/css-dark/xoops.css
+++ b/htdocs/themes/xswatch/css-dark/xoops.css
@@ -125,8 +125,8 @@ div.center div.jGrowl-notification, div.center div.jGrowl-closer {
 }
 
 div.jGrowl div.jGrowl-notification, div.jGrowl div.jGrowl-closer {
-    background-color: #EBFBFE;
-    color: #000080;
+    background-color: #42b142;
+    color: #f0f0f0;
     width: 100%;
     padding: .5em;
     margin-top: .5em;
@@ -134,7 +134,7 @@ div.jGrowl div.jGrowl-notification, div.jGrowl div.jGrowl-closer {
     font-family: Tahoma, Geneva, sans-serif;
     font-size: 1.2em;
     text-align: center;
-    border: 1px solid #6699FF;
+    border: 1px solid #296a29;
     display: none;
     border-radius: 5px;
     -moz-border-radius: 5px;
@@ -156,6 +156,11 @@ div.jGrowl div.jGrowl-notification button.jGrowl-close {
     font-weight: bold;
     font-size: 12px;
     cursor: pointer;
+}
+
+div.jGrowl button {
+    padding: 2px 4px;
+    background-color: #a9b3b7;
 }
 
 div.jGrowl div.jGrowl-closer {

--- a/htdocs/themes/xswatch/css-light/xoops.css
+++ b/htdocs/themes/xswatch/css-light/xoops.css
@@ -125,8 +125,8 @@ div.center div.jGrowl-notification, div.center div.jGrowl-closer {
 }
 
 div.jGrowl div.jGrowl-notification, div.jGrowl div.jGrowl-closer {
-    background-color: #EBFBFE;
-    color: #000080;
+    background-color: #d6efff;
+    color: #022a50;
     width: 100%;
     padding: .5em;
     margin-top: .5em;
@@ -134,7 +134,7 @@ div.jGrowl div.jGrowl-notification, div.jGrowl div.jGrowl-closer {
     font-family: Tahoma, Geneva, sans-serif;
     font-size: 1.2em;
     text-align: center;
-    border: 1px solid #6699FF;
+    border: 1px solid #022a50;
     display: none;
     border-radius: 5px;
     -moz-border-radius: 5px;

--- a/htdocs/themes/xswatch/css/xoops.css
+++ b/htdocs/themes/xswatch/css/xoops.css
@@ -125,8 +125,8 @@ div.center div.jGrowl-notification, div.center div.jGrowl-closer {
 }
 
 div.jGrowl div.jGrowl-notification, div.jGrowl div.jGrowl-closer {
-    background-color: #EBFBFE;
-    color: #000080;
+    background-color: #d6efff;
+    color: #022a50;
     width: 100%;
     padding: .5em;
     margin-top: .5em;
@@ -134,7 +134,7 @@ div.jGrowl div.jGrowl-notification, div.jGrowl div.jGrowl-closer {
     font-family: Tahoma, Geneva, sans-serif;
     font-size: 1.2em;
     text-align: center;
-    border: 1px solid #6699FF;
+    border: 1px solid #022a50;
     display: none;
     border-radius: 5px;
     -moz-border-radius: 5px;


### PR DESCRIPTION
Re: #399

The system jGrowl styles can now be overridden by the theme's css, so this change tweaks it a bit for xswatch.