### PR TITLE
Installer and Upgrader tweaks

### DIFF
--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -137,8 +137,13 @@ class PathStuffController
                 $this->xoopsUrl = $request['URL'];
             }
             if (isset($request['COOKIE_DOMAIN'])) {
-                $request['COOKIE_DOMAIN'] = trim($request['COOKIE_DOMAIN']);
-                $this->xoopsCookieDomain = $request['COOKIE_DOMAIN'];
+                $tempCookieDomain = trim($request['COOKIE_DOMAIN']);
+                $tempParts = parse_url($tempCookieDomain);
+                if (!empty($tempParts['host'])) {
+                    $tempCookieDomain = $tempParts['host'];
+                }
+                $request['COOKIE_DOMAIN'] = $tempCookieDomain;
+                $this->xoopsCookieDomain = $tempCookieDomain;;
             }
         }
     }

--- a/htdocs/install/include/common.inc.php
+++ b/htdocs/install/include/common.inc.php
@@ -33,6 +33,24 @@ define('INSTALL_PASSWORD', '');
 
 define('XOOPS_INSTALL', 1);
 
+function fatalPhpErrorHandler($e = null) {
+    $messageFormat = '<br><div>Fatal %s %s file: %s : %d </div>';
+    $exceptionClass = '\Exception';
+    $throwableClass = '\Throwable';
+    if ($e === null) {
+        $lastError = error_get_last();
+        if ($lastError['type'] === E_ERROR) {
+            // fatal error
+            printf($messageFormat, 'Error', $lastError['message'], $lastError['file'], $lastError['line']);
+        }
+    } elseif ($e instanceof $exceptionClass || $e instanceof $throwableClass) {
+        /** @var $e \Exception */
+        printf($messageFormat, get_class($e), $e->getMessage(), $e->getFile(), $e->getLine());
+    }
+}
+register_shutdown_function('fatalPhpErrorHandler');
+set_exception_handler('fatalPhpErrorHandler');
+
 // options for mainfile.php
 if (empty($xoopsOption['hascommon'])) {
     $xoopsOption['nocommon'] = true;
@@ -42,6 +60,7 @@ if (empty($xoopsOption['hascommon'])) {
 if (!defined('XOOPS_ROOT_PATH')) {
     define('XOOPS_ROOT_PATH', str_replace("\\", '/', realpath('../')));
 }
+
 /*
 error_reporting( 0 );
 if (isset($xoopsLogger)) {

--- a/upgrade/checkmainfile.php
+++ b/upgrade/checkmainfile.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Load mainfile.php wedge that checks for needed upgrades.
+ *
+ * This should be included instead of mainfile.php
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright 2017 XOOPS Project (www.xoops.org)
+ * @license   GNU GPL 2 (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @package   upgrader
+ * @since     2.5.9
+ * @author    Richard Griffith <richard@geekwright.com>
+ */
+
+$loadCommon = !isset($xoopsOption['nocommon']);
+$xoopsOption['nocommon'] = true;
+include_once '../mainfile.php';
+
+$mainfileKeys = array(
+    // in mainfile.php
+    'XOOPS_ROOT_PATH'     => null,
+    'XOOPS_PATH'          => null,
+    'XOOPS_VAR_PATH'      => null, // *
+    'XOOPS_TRUST_PATH'    => null,
+    'XOOPS_URL'           => null,
+    'XOOPS_COOKIE_DOMAIN' => null, // *
+    'XOOPS_PROT'          => null, // *
+    // in data/secure.php
+    'XOOPS_DB_TYPE'       => null,
+    'XOOPS_DB_CHARSET'    => null,
+    'XOOPS_DB_PREFIX'     => null,
+    'XOOPS_DB_HOST'       => null,
+    'XOOPS_DB_USER'       => null,
+    'XOOPS_DB_PASS'       => null,
+    'XOOPS_DB_NAME'       => null,
+    'XOOPS_DB_PCONNECT'   => null,
+);
+
+$needMainfileRewrite = false;
+foreach ($mainfileKeys as $key => $unused) {
+    if (defined($key)) {
+        $mainfileKeys[$key] = constant($key);
+    } else {
+        $needMainfileRewrite = true;
+    }
+}
+
+// this is a generated define in a current mainfile, so just define it if it doesn't exist
+unset ($mainfileKeys['XOOPS_PROT']);
+if (!defined('XOOPS_PROT')) {
+    $parts = parse_url(XOOPS_URL);
+    $http = (empty($parts['scheme']) ? 'http' : $parts['scheme']) . '://';
+    define('XOOPS_PROT', $http);
+    unset($parts, $http);
+}
+
+// we have what we need so continue
+if ($loadCommon) {
+    unset($xoopsOption['nocommon']);
+    include XOOPS_ROOT_PATH . '/include/common.php';
+}
+
+unset($loadCommon);

--- a/upgrade/class/control.php
+++ b/upgrade/class/control.php
@@ -16,6 +16,12 @@ class UpgradeControl
      */
     public $supportSites = array();
 
+    /** @var bool */
+    public $needMainfileRewrite = false;
+
+    /** @var string[]  */
+    public $mainfileKeys = array();
+
     /**
      * @var string language being used in the upgrade process
      */
@@ -91,7 +97,7 @@ class UpgradeControl
         if (isset($xoopsConfig['language'])) {
             $upgrade_language = $xoopsConfig['language'];
         }
-        $upgrade_language = !empty($_COOKIE['xo_upgrade_lang']) ? $_COOKIE['xo_install_lang'] : $upgrade_language;
+        $upgrade_language = !empty($_COOKIE['xo_upgrade_lang']) ? $_COOKIE['xo_upgrade_lang'] : $upgrade_language;
         $upgrade_language = Xmf\Request::getString('lang', $upgrade_language);
         $upgrade_language = (null === $xoopsConfig['language']) ? 'english' : $upgrade_language;
         setcookie('xo_upgrade_lang', $upgrade_language, null, null, null);
@@ -135,7 +141,8 @@ class UpgradeControl
 
         if ($this->needUpgrade && !empty($files)) {
             foreach ($files as $k => $file) {
-                if (is_writable("../{$file}")) {
+                $testFile = preg_match('/^([.\/\\\\:])|([a-z]:)/i', $file) ? $file : "../{$file}";
+                if (is_writable($testFile) || !file_exists($testFile)) {
                     unset($files[$k]);
                 }
             }
@@ -203,4 +210,14 @@ class UpgradeControl
 
         return $form;
     }
+
+    public function storeMainfileCheck($needMainfileRewrite, $mainfileKeys)
+    {
+        $this->needMainfileRewrite = $needMainfileRewrite;
+
+        if ($needMainfileRewrite) {
+            $this->mainfileKeys = $mainfileKeys;
+        }
+    }
+
 }

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -27,10 +27,10 @@ function fatalPhpErrorHandler($e = null) {
         if ($lastError['type'] === E_ERROR) {
             // fatal error
             printf($messageFormat, 'Error', $lastError['message'], $lastError['file'], $lastError['line']);
-        } elseif ($e instanceof $exceptionClass || $e instanceof $throwableClass) {
-            /** @var $e \Exception */
-            printf($messageFormat, get_class($e), $e->getMessage(), $e->getFile(), $e->getLine());
         }
+    } elseif ($e instanceof $exceptionClass || $e instanceof $throwableClass) {
+        /** @var $e \Exception */
+        printf($messageFormat, get_class($e), $e->getMessage(), $e->getFile(), $e->getLine());
     }
 }
 register_shutdown_function('fatalPhpErrorHandler');

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -18,18 +18,42 @@
  */
 /* @var  $xoopsUser XoopsUser */
 
-//Before xoops 2.5.8 the table 'sess_ip' was of type varchar (15). This is a problem for IPv6 addresses because it is longer. The upgrade process would change the column to VARCHAR(45) but it requires login, which is failing. If the user has an IPv6 address, it is converted to short IP during the upgrade. At the end of the upgrade IPV6 works
-//save current IP
+function fatalPhpErrorHandler($e = null) {
+    $messageFormat = '<br><div>Fatal %s %s file: %s : %d </div>';
+    $exceptionClass = '\Exception';
+    $throwableClass = '\Throwable';
+    if ($e === null) {
+        $lastError = error_get_last();
+        if ($lastError['type'] === E_ERROR) {
+            // fatal error
+            printf($messageFormat, 'Error', $lastError['message'], $lastError['file'], $lastError['line']);
+        } elseif ($e instanceof $exceptionClass || $e instanceof $throwableClass) {
+            /** @var $e \Exception */
+            printf($messageFormat, get_class($e), $e->getMessage(), $e->getFile(), $e->getLine());
+        }
+    }
+}
+register_shutdown_function('fatalPhpErrorHandler');
+set_exception_handler('fatalPhpErrorHandler');
+
+/*
+ * Before xoops 2.5.8 the table 'sess_ip' was of type varchar (15). This is a problem for IPv6
+ * addresses because it is longer. The upgrade process would change the column to VARCHAR(45)
+ * but it requires login, which is failing. If the user has an IPv6 address, it is converted to
+ * short IP during the upgrade. At the end of the upgrade IPV6 works
+ *
+ * Here we save the current IP address if needed
+ */
 $ip = $_SERVER['REMOTE_ADDR'];
 if (strlen($_SERVER['REMOTE_ADDR']) > 15) {
     //new IP for upgrade
     $_SERVER['REMOTE_ADDR'] = '::1';
 }
 
-include_once '../mainfile.php';
+include_once 'checkmainfile.php';
 defined('XOOPS_ROOT_PATH') or die('Bad installation: please add this folder to the XOOPS install you want to upgrade');
 
-$reporting = -1; // 0;
+$reporting = 0;
 if (isset($_GET['debug'])) {
     $reporting = -1;
 }
@@ -37,14 +61,16 @@ error_reporting($reporting);
 $xoopsLogger->activated = true;
 $xoopsLogger->enableRendering();
 xoops_loadLanguage('logger');
+set_exception_handler('fatalPhpErrorHandler'); // should have been changed by now, reset to ours
 
 require './class/abstract.php';
 require './class/patchstatus.php';
 require './class/control.php';
 
 $GLOBALS['error'] = false;
-$upgradeControl = new UpgradeControl();
+$GLOBALS['upgradeControl'] = new UpgradeControl();
 
+$upgradeControl->storeMainfileCheck($needMainfileRewrite, $mainfileKeys);
 $upgradeControl->determineLanguage();
 $upgradeControl->buildUpgradeQueue();
 

--- a/upgrade/language/english/upgrade.php
+++ b/upgrade/language/english/upgrade.php
@@ -36,3 +36,4 @@ define('_CONTINUE', 'Continue');
 
 define('XOOPS_ERROR_ENCOUNTERED', 'Error');
 define('XOOPS_ERROR_SEE_BELOW', 'See below for messages.');
+define('_FILE_ACCESS_ERROR', 'Could not access the file %s');


### PR DESCRIPTION
Fixes a few issues reported during in the field use.

- Intercept fatal error or unhandled exception to issue message regardless of other settings
- make sure the entered cookie domain is valid
- rewrite mainfile.php and data/secure.php as part of 2.5.9 upgrade
- attempt to disable obsolete and problematic "legacy" admin theme
