### PR TITLE
Add user issue

### DIFF
--- a/htdocs/modules/profile/admin/user.php
+++ b/htdocs/modules/profile/admin/user.php
@@ -42,7 +42,7 @@ switch ($op) {
         $button_tray->addElement(new XoopsFormButton('', 'delete', _DELETE, 'submit'));
         $form->addElement($button_tray);
         $form->display();
-        break;
+        // no break;
     case 'new':
         xoops_loadLanguage('main', $GLOBALS['xoopsModule']->getVar('dirname', 'n'));
         include_once dirname(__DIR__) . '/include/forms.php';


### PR DESCRIPTION
Restore add user form to default view on admin/user.php

This returns to the behavior which was consistent thru 2.5.6 which seems to have been inadvertently changed.

Fixes: #397
