### PR TITLE
Remove redundant script tags

### DIFF
--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -117,7 +117,7 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         }
 
         xoops_loadLanguage('findusers');
-        $js_addusers = "<script type='text/javascript'>
+        $js_addusers = "
             function addusers(opts)
             {
                 var num = opts.substring(0, opts.indexOf(':'));
@@ -145,8 +145,7 @@ class XoopsFormSelectUser extends XoopsFormElementTray
                 }
 
                 return true;
-            }
-            </script>";
+            }";
         $token       = $GLOBALS['xoopsSecurity']->createToken();
         $action_tray = new XoopsFormElementTray('', '');
         $removeUsers = new XoopsFormButton('', 'rmvusr_' . $name, _MA_USER_REMOVE, 'button');


### PR DESCRIPTION
Script added via addScript() which also adds script tags. This can result in in the CDATA closing sequence "//]]>" being introduced in the display.

This was what the rendered page contained:
```
<script type="text/javascript">
//<![CDATA[
<script type='text/javascript'>
            function addusers(opts)
            {
                // ...
            }
            </script>
//]]></script>
```

Example of the visual defect shown in Profile module admin User page (using Chrome 56.0.2924.87)
![formselectuser](https://cloud.githubusercontent.com/assets/3181636/23706304/3b513588-03d3-11e7-8f6b-222e92f33ffe.png)
