### PR TITLE
Handle no theme case in XoopsFormSelectUsers

### DIFF
--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -158,6 +158,8 @@ class XoopsFormSelectUser extends XoopsFormElementTray
 
          if (isset($GLOBALS['xoTheme']) && is_object($GLOBALS['xoTheme'])) {
              $GLOBALS['xoTheme']->addScript('', array(), $js_addusers);
+         } else {
+             echo '<script>' . $js_addusers . '</script>';
          }
         parent::__construct($caption, '', $name);
         $this->addElement($select_element);


### PR DESCRIPTION
JS to add users was not being added in pmlite as xoTheme was not set.