### PR TITLE
Normalize paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ htdocs/xoops_data/caches/xoops_cache/*
 htdocs/xoops_data/caches/xoops_cache/*/
 htdocs/xoops_data/configs/*
 htdocs/xoops_data/data/secure.php
+htdocs/xoops_data/data/license.php
 htdocs/xoops_data/data/*key*

--- a/htdocs/class/theme.php
+++ b/htdocs/class/theme.php
@@ -274,7 +274,9 @@ class xos_opal_Theme
         $this->template               = new XoopsTpl();
         $this->template->currentTheme = $this;
         $this->template->assign_by_ref('xoTheme', $this);
-        $xoops_page = str_replace(realpath(XOOPS_ROOT_PATH) . '/', '', realpath($_SERVER['SCRIPT_FILENAME']));
+        $tempPath = str_replace('\\', '/', realpath(XOOPS_ROOT_PATH) . '/');
+        $tempName = str_replace('\\', '/',  realpath($_SERVER['SCRIPT_FILENAME']));
+        $xoops_page = str_replace($tempPath, '', $tempName);
         if (strpos($xoops_page, 'modules') !== false) {
             $xoops_page = str_replace('modules/', '', $xoops_page);
         }


### PR DESCRIPTION
Issue with paths on Windows affecting $xoops_page theme variable. This cause the xBootstrap slider to fail, among other less obvious things.

Fixes #415