### PR TITLE
Fix issue #410 for profile module: select fields not showing.

### DIFF
--- a/htdocs/modules/profile/class/field.php
+++ b/htdocs/modules/profile/class/field.php
@@ -254,6 +254,7 @@ class ProfileField extends XoopsObject
             case 'select':
             case 'radio':
                 $options = $this->getVar('field_options');
+                $value = $value[0];
                 if (isset($options[$value])) {
                     $value = htmlspecialchars(defined($options[$value]) ? constant($options[$value]) : $options[$value]);
                 } else {


### PR DESCRIPTION
It seems there was a change introduced in Xoops 2.5.2 that changed the getVar behavior for arrays on XoopsObject.

I was able to reproduce the bug and this change fixed it for me. I also tested radio buttons and changing datatype from array to integer and had no problems.