### PR TITLE
Change in Shareaholic support

### DIFF
--- a/htdocs/themes/xbootstrap/README.md
+++ b/htdocs/themes/xbootstrap/README.md
@@ -12,7 +12,7 @@ follow these steps:
 
 - Visit https://shareaholic.com to create an account and register your site
 - Take note of the Site Id code Shareaholic assigns to your site
-- Open the temlate file tpl/shareaholic-script.tpl in your editor
+- Open the template file tpl/shareaholic-script.tpl in your editor
 - Replace the *n/a* in this line `<{assign var='siteId' value='n/a'}>` with the *Site Id* Shareaholic assigned to you, andd save the file
 
 You can customize how Shareaholic interacts with your site in the Site Tools

--- a/htdocs/themes/xbootstrap/README.md
+++ b/htdocs/themes/xbootstrap/README.md
@@ -4,3 +4,19 @@ xBootstrap
 xBootstrap is a theme for XOOPS (www.xoops.org) developed with Bootstrap.
 
 Online demo: http://themes.angelorocha.com.br
+
+###Shareaholic support
+Previously, social sharing links through Shareaholic were automatically enabled.
+These are now optional and disabled by default. To enable Shareaholic support
+follow these steps:
+
+- Visit https://shareaholic.com to create an account and register your site
+- Take note of the Site Id code Shareaholic assigns to your site
+- Open the temlate file tpl/shareaholic-script.tpl in your editor
+- Replace the *n/a* in this line `<{assign var='siteId' value='n/a'}>` with the *Site Id* Shareaholic assigned to you, andd save the file
+
+You can customize how Shareaholic interacts with your site in the Site Tools
+Dashboard on shareaholic.com. You may want to create an Inline App Location
+on that page to customize the Share Buttons. These buttons will be shown in
+templates such as modules/publisher/publisher_item.tpl with this line:
+`<div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>`

--- a/htdocs/themes/xbootstrap/modules/extgallery/extgallery_public-photo.tpl
+++ b/htdocs/themes/xbootstrap/modules/extgallery/extgallery_public-photo.tpl
@@ -90,7 +90,7 @@
 
         <!-- Start social network and bookmarks -->
         <div class="col-md-12 aligncenter">
-            <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='482507'></div>
+            <div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>
         </div>
     </div><!-- .gallery-image-details -->
 

--- a/htdocs/themes/xbootstrap/modules/news/news_article.tpl
+++ b/htdocs/themes/xbootstrap/modules/news/news_article.tpl
@@ -65,7 +65,7 @@
 <{/if}>
 
 <{if $share == true}>
-    <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='482507'></div>
+    <div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>
 <{/if}>
 
 <div class="comments-nav">

--- a/htdocs/themes/xbootstrap/modules/publisher/publisher_item.tpl
+++ b/htdocs/themes/xbootstrap/modules/publisher/publisher_item.tpl
@@ -74,7 +74,7 @@
     <div>
         <{$item.maintext}>
 
-        <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='482507'></div>
+        <div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>
     </div>
 
 </div>

--- a/htdocs/themes/xbootstrap/modules/tdmdownloads/tdmdownloads_singlefile.tpl
+++ b/htdocs/themes/xbootstrap/modules/tdmdownloads/tdmdownloads_singlefile.tpl
@@ -96,7 +96,7 @@
     <{/if}>
 
     <{if $show_social}>
-        <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='482507'></div>
+        <div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>
     <{/if}>
 </div><!-- .tdmdownloads -->
 

--- a/htdocs/themes/xbootstrap/modules/xoopstube/xoopstube_singlevideo.tpl
+++ b/htdocs/themes/xbootstrap/modules/xoopstube/xoopstube_singlevideo.tpl
@@ -100,7 +100,7 @@
 
         <div class="col-md-12">
             <{if $video.showsbookmarx > 0}>
-                <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='482507'></div>
+                <div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>
             <{/if}>
         </div>
     </div><!-- .xoopstube-data -->

--- a/htdocs/themes/xbootstrap/tpl/shareaholic-script.tpl
+++ b/htdocs/themes/xbootstrap/tpl/shareaholic-script.tpl
@@ -1,22 +1,11 @@
-<script type="text/javascript">
-    //<![CDATA[
-    (function () {
-        var shr = document.createElement('script');
-        shr.setAttribute('data-cfasync', 'false');
-        shr.src = '//dsms0mj1bbhn4.cloudfront.net/assets/pub/shareaholic.js';
-        shr.type = 'text/javascript';
-        shr.async = 'true';
-        shr.onload = shr.onreadystatechange = function () {
-            var rs = this.readyState;
-            if (rs && rs != 'complete' && rs != 'loaded') return;
-            var apikey = '4b44261173043ae4c20b8aef56d4521d';
-            try {
-                Shareaholic.init(apikey);
-            } catch (e) {
-            }
-        };
-        var s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(shr, s);
-    })();
-    //]]>
-</script>
+<{* To enable Shareaholic, create an account and register your site at https://shareaholic.com/
+    Then copy the Site ID that shareaholic assigned to your site in place of the n/a in the next line. *}>
+<{assign var='siteId' value='n/a'}>
+<{if $siteId != 'n/a'}>
+    <script type='text/javascript'
+            data-cfasync='false'
+            src='//dsms0mj1bbhn4.cloudfront.net/assets/pub/shareaholic.js'
+            data-shr-siteid='<{$siteId}>'
+            async='async'>
+    </script>
+<{/if}>

--- a/htdocs/themes/xswatch/modules/extgallery/extgallery_public-photo.tpl
+++ b/htdocs/themes/xswatch/modules/extgallery/extgallery_public-photo.tpl
@@ -90,7 +90,7 @@
 
         <!-- Start social network and bookmarks -->
         <div class="col-md-12 aligncenter">
-            <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='482507'></div>
+            <div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>
         </div>
     </div><!-- .gallery-image-details -->
 

--- a/htdocs/themes/xswatch/modules/news/news_article.tpl
+++ b/htdocs/themes/xswatch/modules/news/news_article.tpl
@@ -65,7 +65,7 @@
 <{/if}>
 
 <{if $share == true}>
-    <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='482507'></div>
+    <div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>
 <{/if}>
 
 <div class="comments-nav">

--- a/htdocs/themes/xswatch/modules/publisher/publisher_item.tpl
+++ b/htdocs/themes/xswatch/modules/publisher/publisher_item.tpl
@@ -74,7 +74,7 @@
     <div>
         <{$item.maintext}>
 
-        <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='482507'></div>
+        <div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>
     </div>
 
 </div>

--- a/htdocs/themes/xswatch/modules/tdmdownloads/tdmdownloads_singlefile.tpl
+++ b/htdocs/themes/xswatch/modules/tdmdownloads/tdmdownloads_singlefile.tpl
@@ -96,7 +96,7 @@
     <{/if}>
 
     <{if $show_social}>
-        <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='482507'></div>
+        <div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>
     <{/if}>
 </div><!-- .tdmdownloads -->
 


### PR DESCRIPTION
Re #433 

Previously, social sharing links through Shareaholic were automatically enabled. These are now optional and disabled by default. To enable Shareaholic support follow these steps:

- Visit https://shareaholic.com to create an account and register your site
- Take note of the *Site Id* code Shareaholic assigns to your site
- Open the template file *themes/xbootstrap/tpl/shareaholic-script.tpl* in your editor
- Replace the *n/a* in this line `<{assign var='siteId' value='n/a'}>` with the *Site Id* Shareaholic assigned to you, andd save the file

You can customize how Shareaholic interacts with your site in the Site Tools Dashboard on Shareaholic.com. You may want to create an Inline App Location on that page to customize the Share Buttons. These will show in templates such as *themes/xbootstrap/modules/publisher/publisher_item.tpl* with this line:
`<div class='shareaholic-canvas' data-app='share_buttons' data-app-id=''></div>`
