### PR TITLE
Fix broken license_url in core modules

### DIFF
--- a/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
@@ -503,6 +503,11 @@ class ModuleAdmin
         foreach ( $author as $k => $aName ) {
             $authorArray[$k] = ( isset( $nickname[$k] ) && ( '' != $nickname[$k] ) ) ? "{$aName} ({$nickname[$k]})" : "{$aName}";
         }
+        $license_url = $this->_obj->getInfo('license_url');
+        $license_url = preg_match('%^(https?:)?//%', $license_url) ? $license_url : 'http://' . $license_url;
+        $website = $this->_obj->getInfo('website');
+        $website = preg_match('%^(https?:)?//%', $website) ? $website : 'http://' . $website;
+
         $ret = "<table>\n<tr>\n"
              . "<td width=\"50%\">\n"
              . "<table>\n<tr>\n<td style=\"width: 100px;\">\n"
@@ -516,9 +521,9 @@ class ModuleAdmin
              . _AM_MODULEADMIN_ABOUT_BY . implode(', ', $authorArray) . "\n"
              . "</div>\n"
              . "<div style=\"line-height: 16px;\">\n"
-             . "<a href=\"http://" . $this->_obj->getInfo('license_url') . "\" target=\"_blank\" rel=\"external\">" . $this->_obj->getInfo('license') . "</a>\n"
+             . "<a href=\"$license_url\" target=\"_blank\" rel=\"external\">" . $this->_obj->getInfo('license') . "</a>\n"
              . "<br>\n"
-             . "<a href=\"http://" . $this->_obj->getInfo('website') . "\" target=\"_blank\">" . $this->_obj->getInfo('website') . "</a>\n"
+             . "<a href=\"$website\" target=\"_blank\">" . $this->_obj->getInfo('website') . "</a>\n"
              . "<br>\n"
              . "<br>\n"
              . "</div>\n"

--- a/htdocs/modules/pm/xoops_version.php
+++ b/htdocs/modules/pm/xoops_version.php
@@ -31,7 +31,7 @@ $modversion['author']         = 'Jan Pedersen, Taiwen Jiang';
 $modversion['credits']        = 'The XOOPS Project, Wanikoo';
 $modversion['help']           = 'page=help';
 $modversion['license']        = 'GNU GPL 2.0 or later';
-$modversion['license_url']    = 'www.gnu.org/licenses/gpl-2.0.html/';
+$modversion['license_url']    = 'www.gnu.org/licenses/gpl-2.0.html';
 $modversion['image']          = 'assets/images/logo.png';
 $modversion['dirname']        = 'pm';
 $modversion['dirmoduleadmin'] = '/Frameworks/moduleclasses/moduleadmin';

--- a/htdocs/modules/profile/xoops_version.php
+++ b/htdocs/modules/profile/xoops_version.php
@@ -30,7 +30,7 @@ $modversion['author']         = 'Jan Pedersen, Taiwen Jiang, alfred, Wishcraft';
 $modversion['credits']        = 'Ackbarr, mboyden, marco, mamba, trabis, etc.';
 $modversion['help']           = 'page=help';
 $modversion['license']        = 'GNU GPL 2.0 or later';
-$modversion['license_url']    = 'www.gnu.org/licenses/gpl-2.0.html/';
+$modversion['license_url']    = 'www.gnu.org/licenses/gpl-2.0.html';
 $modversion['image']          = 'assets/images/logo.png';
 $modversion['dirname']        = 'profile';
 $modversion['dirmoduleadmin'] = '/Frameworks/moduleclasses/moduleadmin';

--- a/htdocs/xoops_lib/modules/protector/xoops_version.php
+++ b/htdocs/xoops_lib/modules/protector/xoops_version.php
@@ -27,7 +27,7 @@ $modversion['credits']        = 'PEAK Corp.';
 $modversion['author']         = 'GIJ=CHECKMATE PEAK Corp.(http://www.peak.ne.jp/)';
 $modversion['help']           = 'page=help';
 $modversion['license']        = 'GNU GPL 2.0';
-$modversion['license_url']    = 'www.gnu.org/licenses/gpl-2.0.html/';
+$modversion['license_url']    = 'www.gnu.org/licenses/gpl-2.0.html';
 $modversion['official']       = 1;
 $modversion['image']          = file_exists($mydirpath . '/module_icon.png') ? 'module_icon.png' : 'module_icon.php';
 $modversion['iconbig']        = 'module_icon.php?file=iconbig';


### PR DESCRIPTION
- Modules included in core have trailing '/' in URL used in About page, leading to 404 on gnu.org
- `\ModuleAdmin::renderAbout()` always adding 'http://' to *license_url* and *website* keys, even if already present