### PR TITLE
Error in email forward

### DIFF
--- a/htdocs/modules/pm/class/message.php
+++ b/htdocs/modules/pm/class/message.php
@@ -154,7 +154,7 @@ class PmMessageHandler extends XoopsPersistableObjectHandler
      * @param  XoopsUser $user
      * @return bool
      **/
-    public function sendEmail(XoopsPrivmessage $pm, XoopsUser $user)
+    public function sendEmail(PmMessage $pm, XoopsUser $user)
     {
         global $xoopsConfig;
 

--- a/htdocs/modules/pm/class/message.php
+++ b/htdocs/modules/pm/class/message.php
@@ -150,8 +150,8 @@ class PmMessageHandler extends XoopsPersistableObjectHandler
 
     /**
      * Send a message to user's email
-     * @param  XoopsPrivmessage $pm {@link XoopsPrivmessage} object
-     * @param  XoopsUser $user
+     * @param  PmMessage $pm   message object
+     * @param  XoopsUser $user user object
      * @return bool
      **/
     public function sendEmail(PmMessage $pm, XoopsUser $user)


### PR DESCRIPTION
Error: TypeError: Argument 1 passed to PmMessageHandler::sendEmail() must be an instance of XoopsPrivmessage, instance of PmMessage given, called in /modules/pm/readpmsg.php on line 45 in file /modules/pm/class/message.php line 157