### PR TITLE
Freshen Links

### DIFF
--- a/htdocs/modules/system/themes/default/xotpl/xo_accordion.tpl
+++ b/htdocs/modules/system/themes/default/xotpl/xo_accordion.tpl
@@ -92,11 +92,7 @@
         <table>
             <tr>
                 <td><a rel="external" href="http://xoops.org"><{$smarty.const._OXYGEN_XOOPSPROJECT}></a></td>
-                <td><a rel="external" href="http://xoops.org"><{$smarty.const._OXYGEN_WEBSITE}></a></td>
-            </tr>
-            <tr>
-                <td><a rel="external" href="http://www.xoops.org/modules/core"><{$smarty.const._OXYGEN_XOOPSCORE}></a></td>
-                <td><a rel="external" href="http://www.xoops.org/modules/mediawiki/index.php/Main_Page"><{$smarty.const._OXYGEN_XOOPSWIKI}></a></td>
+                <td><a rel="external" href="https://github.com/XOOPS/XoopsCore25/releases"><{$smarty.const._OXYGEN_XOOPSCORE}></a></td>
             </tr>
             <tr>
                 <td><a rel="external" href="http://www.xoops.org/modules/xoopspartners"><{$smarty.const._OXYGEN_LOCALSUPPORT}></a></td>

--- a/htdocs/modules/system/themes/transition/xotpl/xo_accordion.tpl
+++ b/htdocs/modules/system/themes/transition/xotpl/xo_accordion.tpl
@@ -92,11 +92,7 @@
         <table>
             <tr>
                 <td><a rel="external" href="http://xoops.org"><{$smarty.const._OXYGEN_XOOPSPROJECT}></a></td>
-                <td><a rel="external" href="http://xoops.org"><{$smarty.const._OXYGEN_WEBSITE}></a></td>
-            </tr>
-            <tr>
-                <td><a rel="external" href="http://www.xoops.org/modules/core"><{$smarty.const._OXYGEN_XOOPSCORE}></a></td>
-                <td><a rel="external" href="http://www.xoops.org/modules/mediawiki/index.php/Main_Page"><{$smarty.const._OXYGEN_XOOPSWIKI}></a></td>
+                <td><a rel="external" href="https://github.com/XOOPS/XoopsCore25/releases"><{$smarty.const._OXYGEN_XOOPSCORE}></a></td>
             </tr>
             <tr>
                 <td><a rel="external" href="http://www.xoops.org/modules/xoopspartners"><{$smarty.const._OXYGEN_LOCALSUPPORT}></a></td>

--- a/htdocs/modules/system/themes/zetadigme/xotpl/xo_accordion.tpl
+++ b/htdocs/modules/system/themes/zetadigme/xotpl/xo_accordion.tpl
@@ -142,20 +142,12 @@
                         <a class="tooltip" rel="external" href="http://xoops.org" title="<{$lang_xoops_xoopsproject}>"><{$lang_xoops_xoopsproject}></a>
                     </td>
                     <td>
+                        <a class="tooltip" rel="external" href="https://github.com/XOOPS/XoopsCore25/releases" title="<{$lang_xoops_xoopscore}>"><{$lang_xoops_xoopscore}></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <a class="tooltip" rel="external" href="http://www.xoops.org/modules/xoopspartners" title="<{$lang_xoops_localsupport}>"><{$lang_xoops_localsupport}></a>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <a class="tooltip" rel="external" href="http://www.xoops.org/modules/core" title="<{$lang_xoops_xoopscore}>"><{$lang_xoops_xoopscore}></a>
-                    </td>
-                    <td>
-                        <a class="tooltip" rel="external" href="http://www.xoops.org/modules/extgallery" title="<{$lang_xoops_xoopsthems}>"><{$lang_xoops_xoopsthems}></a>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <a class="tooltip" rel="external" href="http://www.xoops.org/modules/mediawiki/index.php/Main_Page" title="<{$lang_xoops_xoopswiki}>"><{$lang_xoops_xoopswiki}></a>
                     </td>
                     <td>
                         <a class="tooltip" rel="external" href="https://github.com/XOOPS/XoopsCore25" title="<{$lang_xoops_codesvn}>"><{$lang_xoops_codesvn}></a>


### PR DESCRIPTION
Fixes #494 

We really need to work out a plan to rebuild some missing sections and functionality on xoops.org, but this is not the forum to develop a consensus on that. These changes just makes the links relevant and contemporary.