### PR TITLE
Deprecate system module Cookie class

### DIFF
--- a/htdocs/modules/system/class/cookie.php
+++ b/htdocs/modules/system/class/cookie.php
@@ -14,6 +14,8 @@
  * @license             GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
  * @author              Andricq Nicolas (AKA MusS)
  * @package             system
+ *
+ * @deprecated since 2.5.9 - will be removed in future versions
  */
 class Cookie
 {

--- a/htdocs/modules/system/header.php
+++ b/htdocs/modules/system/header.php
@@ -34,7 +34,7 @@ include_once $GLOBALS['xoops']->path('/class/xoopsformloader.php');
 include_once $GLOBALS['xoops']->path('/class/xoopslists.php');
 // System Class
 include_once $GLOBALS['xoops']->path('/modules/system/class/breadcrumb.php');
-include_once $GLOBALS['xoops']->path('/modules/system/class/cookie.php');
+//include_once $GLOBALS['xoops']->path('/modules/system/class/cookie.php');
 // Load Language
 xoops_loadLanguage('admin', 'system');
 // Include System files


### PR DESCRIPTION
Class is not used and contains errors. Will remove in next XOOPS version.