### PR TITLE
added missing tooltip.js

### DIFF
--- a/htdocs/modules/system/themes/transition/transition.php
+++ b/htdocs/modules/system/themes/transition/transition.php
@@ -89,7 +89,7 @@ class XoopsGuiTransition extends XoopsSystemGui
         $xoTheme->addScript(XOOPS_ADMINTHEME_URL . '/transition/js/styleswitch.js');
         $xoTheme->addScript(XOOPS_ADMINTHEME_URL . '/transition/js/formenu.js');
         $xoTheme->addScript(XOOPS_ADMINTHEME_URL . '/transition/js/menu.js');
-        //$xoTheme->addScript(XOOPS_ADMINTHEME_URL . '/transition/js/tooltip.js');
+        $xoTheme->addScript(XOOPS_ADMINTHEME_URL . '/transition/js/tooltip.js');
 //        $xoTheme->addScript(XOOPS_ADMINTHEME_URL . '/transition/js/tabs.jquery.tools.min.js');
         $xoTheme->addScript(XOOPS_ADMINTHEME_URL . '/transition/js/tabs.js');
         $xoTheme->addScript(XOOPS_ADMINTHEME_URL . '/transition/js/tabs.slideshow.js');


### PR DESCRIPTION
Added missing tooltip.js used in 'transition' Control Panel GUI.

XOOPS_URL/admin.php
![image](https://user-images.githubusercontent.com/5456660/27778654-86466fa0-5f71-11e7-9053-c027e9767d84.png)
