### PR TITLE
Use semver rules to check min_xoops

### DIFF
--- a/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
@@ -374,7 +374,7 @@ class ModuleAdmin
 
             // xoops version
             if ($this->_obj->getInfo('min_xoops')) {
-                $currentXoopsVersion = strtolower(str_replace(array('XOOPS ', '-'), '', XOOPS_VERSION));
+                $currentXoopsVersion = strtolower(str_replace('XOOPS ', '', XOOPS_VERSION));
                 if (version_compare($currentXoopsVersion, $this->_obj->getInfo('min_xoops'), '<')) {
                     $ret .= "<span style='color : red; font-weight : bold;'><img src='" . $path . "0.png' >" . sprintf(_AM_MODULEADMIN_CONFIG_XOOPS, $this->_obj->getInfo('min_xoops'), substr(XOOPS_VERSION, 6, strlen(XOOPS_VERSION) - 6)) . "</span>\n";
                 } else {

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
@@ -374,10 +374,11 @@ class ModuleAdmin
 
             // xoops version
             if ($this->_obj->getInfo('min_xoops')) {
-                if (substr(XOOPS_VERSION, 6, strlen(XOOPS_VERSION) - 6) < $this->_obj->getInfo('min_xoops')) {
+                $currentXoopsVersion = strtolower(str_replace(array('XOOPS ', '-'), '', XOOPS_VERSION));
+                if (version_compare($currentXoopsVersion, $this->_obj->getInfo('min_xoops'), '<')) {
                     $ret .= "<span style='color : red; font-weight : bold;'><img src='" . $path . "0.png' >" . sprintf(_AM_MODULEADMIN_CONFIG_XOOPS, $this->_obj->getInfo('min_xoops'), substr(XOOPS_VERSION, 6, strlen(XOOPS_VERSION) - 6)) . "</span>\n";
                 } else {
-                    $ret .= "<span style='color : green;'><img src='" . $path . "1.png' >" . sprintf(_AM_MODULEADMIN_CONFIG_XOOPS, $this->_obj->getInfo('min_xoops'), substr(XOOPS_VERSION, 6, strlen(XOOPS_VERSION) - 6)) . "</span>\n";
+                    $ret .= "<span style='color : green;'><img src='" . $path . "1.png' >" . sprintf(_AM_MODULEADMIN_CONFIG_XOOPS, $this->_obj->getInfo('min_xoops'), substr(XOOPS_VERSION, 6)) . "</span>\n";
                 }
                 $ret .= '<br>';
             }


### PR DESCRIPTION
The introduction of version 2.5.10 broke the moduleadmin class version checking for "min_xoops."

This change uses PHP's version_compare() to test the XOOPS version.
