### PR TITLE
Fix purgeCookies()

### DIFF
--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -240,22 +240,12 @@ class Protector
     public function purgeCookies()
     {
         if (!headers_sent()) {
-            // clear typical session id of PHP
-            setcookie('PHPSESSID', '', time() - 3600, '/', '', 0);
-            if (isset($_COOKIE[session_name()])) {
-                setcookie(session_name(), '', time() - 3600, '/', '', 0);
+            $domain =  defined(XOOPS_COOKIE_DOMAIN) ? XOOPS_COOKIE_DOMAIN : '';
+            $past = time() - 3600;
+            foreach ($_COOKIE as $key => $value) {
+                setcookie($key, '', $past, '', $domain);
+                setcookie($key, '', $past, '/', $domain);
             }
-
-            // clear autologin cookies
-            $xoops_cookie_path = defined('XOOPS_COOKIE_PATH') ? XOOPS_COOKIE_PATH : preg_replace('?http[s]{0,1}://[^/]+(/.*)$?', "$1", XOOPS_URL);
-            if ($xoops_cookie_path == XOOPS_URL) {
-                $xoops_cookie_path = '/';
-            }
-            setcookie($GLOBALS['xoopsConfig']['usercookie'], null, time() - 3600, '/', XOOPS_COOKIE_DOMAIN, 0);
-            setcookie($GLOBALS['xoopsConfig']['usercookie'], null, time() - 3600, '/');
-
-            setcookie('autologin_uname', '', time() - 3600, $xoops_cookie_path, '', 0);
-            setcookie('autologin_pass', '', time() - 3600, $xoops_cookie_path, '', 0);
         }
     }
 


### PR DESCRIPTION
Protector::purgeCookies() assumed global $xoopsConfig is available, but it can be invoked in response to core.include.common.start event.

Secondary issue, many of the hard coded names were no longer correct, and new ones have been added.

This change attempts to delete *all* cookies sent to the page.

Re: #551