### PR TITLE
Fix XOOPS truncate plugin

### DIFF
--- a/htdocs/class/smarty/xoops_plugins/modifier.truncate.php
+++ b/htdocs/class/smarty/xoops_plugins/modifier.truncate.php
@@ -34,7 +34,7 @@ function smarty_modifier_truncate($string, $length = 80, $etc = '…', $break_wo
     $charset = defined('_CHARSET') ? _CHARSET : 'UTF-8';
 
     if (mb_strlen($string) <= $length) {
-        return '';
+        return $string;
     }
     $length -= min($length, mb_strlen($etc));
     if (!$break_words && !$middle) {

--- a/htdocs/include/comment_view.php
+++ b/htdocs/include/comment_view.php
@@ -196,9 +196,11 @@ if (XOOPS_COMMENT_APPROVENONE != $xoopsModuleConfig['com_rule']) {
             }
         }
 
-        // <input type="button" onclick="self.location.href=\'' . $postcomment_link . '' . $link_extra . '\'" class="formButton" value="' . _CM_POSTCOMMENT . '" />';
-        $commentPostButton = new XoopsFormButton('', 'com_post', _CM_POSTCOMMENT, 'button');
-        $commentPostButton->setExtra(' onclick="self.location.href=\'' . $postcomment_link . $link_extra . '\'"');
+        $commentPostButton = false;
+        if (!empty($xoopsModuleConfig['com_anonpost']) || is_object($xoopsUser)) {
+            $commentPostButton = new XoopsFormButton('', 'com_post', _CM_POSTCOMMENT, 'button');
+            $commentPostButton->setExtra(' onclick="self.location.href=\'' . $postcomment_link . $link_extra . '\'"');
+        }
         $commentTpl->assign('commentPostButton', $commentPostButton);
         $commentTpl->assign('commentPostHidden', $commentBarHidden);
 


### PR DESCRIPTION
Returning empty string instead of un-truncated short strings.