### PR TITLE
Use standard xoopsUser check

### DIFF
--- a/htdocs/modules/profile/index.php
+++ b/htdocs/modules/profile/index.php
@@ -29,7 +29,7 @@ if (isset($_POST['op'])) {
 }
 
 if ($op === 'main') {
-    if (!$GLOBALS['xoopsUser']) {
+    if (!is_object($GLOBALS['xoopsUser'])) {
         $GLOBALS['xoopsOption']['template_main'] = 'system_userform.tpl';
         include $GLOBALS['xoops']->path('header.php');
         $GLOBALS['xoopsTpl']->assign('lang_login', _LOGIN);


### PR DESCRIPTION
Reports indicate on some circumstances, the system_userform.tpl is not properly displayed. This check is suspect, and could cause issues under the right circumstance.

Re: #559