### PR TITLE
Move protector data to xoops_data

### DIFF
--- a/htdocs/xoops_data/protector/index.html
+++ b/htdocs/xoops_data/protector/index.html
@@ -1,0 +1,1 @@
+<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -364,7 +364,7 @@ class Protector
      */
     public static function get_filepath4bwlimit()
     {
-        return XOOPS_TRUST_PATH . '/modules/protector/configs/bwlimit' . substr(md5(XOOPS_ROOT_PATH . XOOPS_DB_USER . XOOPS_DB_PREFIX), 0, 6);
+        return XOOPS_VAR_PATH . '/protector/bwlimit' . substr(md5(XOOPS_ROOT_PATH . XOOPS_DB_USER . XOOPS_DB_PREFIX), 0, 6);
     }
 
     /**
@@ -445,7 +445,7 @@ class Protector
      */
     public static function get_filepath4badips()
     {
-        return XOOPS_TRUST_PATH . '/modules/protector/configs/badips' . substr(md5(XOOPS_ROOT_PATH . XOOPS_DB_USER . XOOPS_DB_PREFIX), 0, 6);
+        return XOOPS_VAR_PATH . '/protector/badips' . substr(md5(XOOPS_ROOT_PATH . XOOPS_DB_USER . XOOPS_DB_PREFIX), 0, 6);
     }
 
     /**
@@ -473,7 +473,7 @@ class Protector
      */
     public static function get_filepath4group1ips()
     {
-        return XOOPS_TRUST_PATH . '/modules/protector/configs/group1ips' . substr(md5(XOOPS_ROOT_PATH . XOOPS_DB_USER . XOOPS_DB_PREFIX), 0, 6);
+        return XOOPS_VAR_PATH . '/protector/group1ips' . substr(md5(XOOPS_ROOT_PATH . XOOPS_DB_USER . XOOPS_DB_PREFIX), 0, 6);
     }
 
     /**
@@ -481,7 +481,7 @@ class Protector
      */
     public function get_filepath4confighcache()
     {
-        return XOOPS_TRUST_PATH . '/modules/protector/configs/configcache' . substr(md5(XOOPS_ROOT_PATH . XOOPS_DB_USER . XOOPS_DB_PREFIX), 0, 6);
+        return XOOPS_VAR_PATH . '/protector/configcache' . substr(md5(XOOPS_ROOT_PATH . XOOPS_DB_USER . XOOPS_DB_PREFIX), 0, 6);
     }
 
     /**


### PR DESCRIPTION
Protector requires write access to xoops_lib/modules/protector.

XOOPS_VAR_PATH is always intended to be writable so it is better suited to be used for files like those that protector uses.

This changes protector's configs to xoops_data/protector.

Note: existing protector configs are not moved in this change. The file names remain the same, so if needed (i.e. IP ban lists) the files can be moved manually.