### PR TITLE
Change hard coded http: to use XOOPS_PROT for URLs

### DIFF
--- a/htdocs/class/model/write.php
+++ b/htdocs/class/model/write.php
@@ -179,7 +179,7 @@ class XoopsModelWrite extends XoopsModelAbstract
                         continue 2;
                     }
                     if ($cleanv != '' && !preg_match("/^http[s]*:\/\//i", $cleanv)) {
-                        $cleanv = 'http://' . $cleanv;
+                        $cleanv = XOOPS_PROT . $cleanv;
                     }
                     if (!$v['not_gpc']) {
                         $cleanv = $ts->stripSlashesGPC($cleanv);
@@ -193,7 +193,7 @@ class XoopsModelWrite extends XoopsModelAbstract
                         continue 2;
                     }
                     if ($cleanv != '' && !preg_match("/^http[s]*:\/\//i", $cleanv)) {
-                        $cleanv = 'http://' . $cleanv;
+                        $cleanv = XOOPS_PROT . $cleanv;
                     }
                     if (!$v['not_gpc']) {
                         $cleanv = $ts->stripSlashesGPC($cleanv);


### PR DESCRIPTION
In the current internet environment it seems that using the installed protocol as the 'default' would be better than using http:  this allows links to URLs on the same site to maintain SSL.