### PR TITLE
Another hard coded http: to use XOOPS_PROT for URLs

### DIFF
--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -777,7 +777,7 @@ class XoopsObject
                             continue 2;
                         }
                         if ($cleanv != '' && !preg_match("/^http[s]*:\/\//i", $cleanv)) {
-                            $cleanv = 'http://' . $cleanv;
+                            $cleanv = XOOPS_PROT . $cleanv;
                         }
                         if (!$v['not_gpc']) {
                             $cleanv =& $ts->stripSlashesGPC($cleanv);
@@ -852,7 +852,7 @@ class XoopsObject
                             continue 2;
                         }
                         if ($cleanv != '' && !preg_match("/^http[s]*:\/\//i", $cleanv)) {
-                            $cleanv = 'http://' . $cleanv;
+                            $cleanv = XOOPS_PROT . $cleanv;
                         }
                         $cleanv = xoops_convert_encode($cleanv);
                         if (!$v['not_gpc']) {


### PR DESCRIPTION
Similar to #568 - change the installed protocol to be the 'default' would be better than forcing http: to allow links to URLs on the same site to maintain SSL.