### PR TITLE
Pass JWT for ajaxfineupload in post, not header

### DIFF
--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -77,7 +77,7 @@ $assert = array(
     'aud' => basename(__FILE__),
     'uid' => $xoopsUser instanceof \XoopsUser ? $xoopsUser->id() : 0,
 );
-$claims = TokenReader::fromHeader('fineuploader', $assert);
+$claims = TokenReader::fromRequest('fineuploader', 'Authorization', $assert);
 
 if ($claims === false) {
     echo json_encode(array('error' => "Invalid request token"));
@@ -149,7 +149,7 @@ function get_request_method()
     global $HTTP_RAW_POST_DATA;
 
     if(isset($HTTP_RAW_POST_DATA)) {
-    	parse_str($HTTP_RAW_POST_DATA, $_POST);
+        parse_str($HTTP_RAW_POST_DATA, $_POST);
     }
     */
 

--- a/htdocs/modules/system/templates/admin/system_avatars.html
+++ b/htdocs/modules/system/templates/admin/system_avatars.html
@@ -16,7 +16,7 @@
                 </button>
             </div>
         </div>
-    </div>   
+    </div>
 <{/if}>
 <{if $view_cat}>
     <!-- Display Avatar header for switch between system & custom category -->
@@ -115,8 +115,8 @@
             template: 'qq-template-manual-trigger',
             request: {
                 endpoint: '<{$xoops_url}>/ajaxfineupload.php',
-                customHeaders: {
-                    "Authorization": "Basic <{$jwt}>"
+                params: {
+                    "Authorization": "<{$jwt}>"
                 }
             },
             text: {

--- a/htdocs/modules/system/templates/admin/system_avatars.tpl
+++ b/htdocs/modules/system/templates/admin/system_avatars.tpl
@@ -16,7 +16,7 @@
                 </button>
             </div>
         </div>
-    </div>   
+    </div>
 <{/if}>
 <{if $view_cat}>
     <!-- Display Avatar header for switch between system & custom category -->
@@ -115,8 +115,8 @@
             template: 'qq-template-manual-trigger',
             request: {
                 endpoint: '<{$xoops_url}>/ajaxfineupload.php',
-                customHeaders: {
-                    "Authorization": "Basic <{$jwt}>"
+                params: {
+                    "Authorization": "<{$jwt}>"
                 }
             },
             text: {

--- a/htdocs/modules/system/templates/admin/system_images.html
+++ b/htdocs/modules/system/templates/admin/system_images.html
@@ -215,8 +215,8 @@
             template: 'qq-template-manual-trigger',
             request: {
                 endpoint: '<{$xoops_url}>/ajaxfineupload.php',
-                customHeaders: {
-                    "Authorization": "Basic <{$jwt}>"
+                params: {
+                    "Authorization": "<{$jwt}>"
                 }
             },
             text: {

--- a/htdocs/modules/system/templates/admin/system_images.tpl
+++ b/htdocs/modules/system/templates/admin/system_images.tpl
@@ -215,8 +215,8 @@
             template: 'qq-template-manual-trigger',
             request: {
                 endpoint: '<{$xoops_url}>/ajaxfineupload.php',
-                customHeaders: {
-                    "Authorization": "Basic <{$jwt}>"
+                params: {
+                    "Authorization": "<{$jwt}>"
                 }
             },
             text: {

--- a/htdocs/modules/system/templates/system_imagemanager2.html
+++ b/htdocs/modules/system/templates/system_imagemanager2.html
@@ -54,8 +54,8 @@
         template: 'qq-template-manual-trigger',
         request: {
             endpoint: '<{$xoops_url}>/ajaxfineupload.php',
-            customHeaders: {
-                "Authorization": "Basic <{$jwt}>"
+            params: {
+                "Authorization": "<{$jwt}>"
             }
         },
         text: {

--- a/htdocs/modules/system/templates/system_imagemanager2.tpl
+++ b/htdocs/modules/system/templates/system_imagemanager2.tpl
@@ -54,8 +54,8 @@
         template: 'qq-template-manual-trigger',
         request: {
             endpoint: '<{$xoops_url}>/ajaxfineupload.php',
-            customHeaders: {
-                "Authorization": "Basic <{$jwt}>"
+            params: {
+                "Authorization": "<{$jwt}>"
             }
         },
         text: {


### PR DESCRIPTION
JWT is now passed as a body parameter named 'Authorization' rather than as a HTTP header. The headers are scrubbed in some hosting situations causing uploads to fail.

Callers are adjusted to replace:
```
customHeaders: {
    "Authorization": "Basic <{$jwt}>"
}
```

with:
```
params: {
    "Authorization": "<{$jwt}>"
}
```