### PR TITLE
Protector vs. FineUploader Round 2

### DIFF
--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -57,6 +57,9 @@ use Xmf\Jwt\TokenReader;
  * SOFTWARE.
  */
 
+if(isset($_POST['Authorization'])) {
+    define('PROTECTOR_SKIP_DOS_CHECK', 1);
+}
 include __DIR__ . '/mainfile.php';
 $xoopsLogger->activated = false;
 

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -1159,13 +1159,6 @@ class Protector
         }
         $uri     = @$_SERVER['REQUEST_URI'];
 
-        // skip ajax fine uploader traffic
-        $parts = parse_url($uri);
-        $basename = empty($parts['path']) ? '' : basename($parts['path']);
-        if (('ajaxfineupload.php' === $basename) && ('' !== \Xmf\Request::getHeader('Authorization', ''))) {
-            return true;
-        }
-
         $ip4sql  = $xoopsDB->quote($ip->asReadable());
         $uri4sql = $xoopsDB->quote($uri);
 

--- a/htdocs/xoops_lib/modules/protector/include/postcheck_functions.php
+++ b/htdocs/xoops_lib/modules/protector/include/postcheck_functions.php
@@ -113,7 +113,7 @@ function protector_postcommon()
         }
     }
 
-    // module can controll DoS skipping
+    // module can control DoS skipping
     if (defined('PROTECTOR_SKIP_DOS_CHECK')) {
         $dos_skipping = true;
     }


### PR DESCRIPTION
Changes in #584 reintroduced issues with Protector's DOS/F5 triggering on multiple and/or large file uploads. These changes remove the original fix in Protector, and move it into the uploader code, where it should have been.