### PR TITLE
Basic support for MySQL 8.0

### DIFF
--- a/htdocs/class/criteria.php
+++ b/htdocs/class/criteria.php
@@ -323,7 +323,8 @@ class Criteria extends CriteriaElement
      */
     public function render()
     {
-        $clause = (!empty($this->prefix) ? "{$this->prefix}." : '') . $this->column;
+        $backtick = (false === strpos($this->column, '.')) ? '`' : '';
+        $clause = (!empty($this->prefix) ? "{$this->prefix}." : '') . $backtick . $this->column . $backtick;
         if (!empty($this->function)) {
             $clause = sprintf($this->function, $clause);
         }

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -363,7 +363,11 @@ function xoFormFieldCollation($name, $value, $label, $help, $link, $charset)
 
     $options           = array();
     foreach ($collations as $key => $isDefault) {
-        $options[$key] = $key . (($isDefault) ? ' (Default)' : '');
+        if ($isDefault) {  // 'Yes' or ''
+            $options = array($key => $key . ' (Default)') + $options;
+        } else {
+            $options[$key] = $key;
+        }
     }
 
     return xoFormSelect($name, $value, $label, $options, $help);

--- a/htdocs/install/sql/mysql.structure.sql
+++ b/htdocs/install/sql/mysql.structure.sql
@@ -549,7 +549,7 @@ CREATE TABLE users (
   pass varchar(255) NOT NULL default '',
   posts mediumint(8) unsigned NOT NULL default '0',
   attachsig tinyint(1) unsigned NOT NULL default '0',
-  rank smallint(5) unsigned NOT NULL default '0',
+  `rank` smallint(5) unsigned NOT NULL default '0',
   level tinyint(3) unsigned NOT NULL default '1',
   theme varchar(100) NOT NULL default '',
   timezone_offset float(3,1) NOT NULL default '0.0',


### PR DESCRIPTION
The changes provide basic compatibility with MySQL 8.0 in XoopsCore25

*Please note* that there are some actions required outside of XOOPS to configure MySQL 8 to be compatible with PHP. For more information, see: 
https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html
https://mysqlserverteam.com/upgrading-to-mysql-8-0-default-authentication-plugin-considerations/
http://php.net/manual/en/ref.pdo-mysql.php

> PHP: the PDO_MySQL and ext/mysqli extensions do not support caching_sha2_password. In addition, when used with PHP versions before 7.1.16 and PHP 7.2 before 7.2.4, they fail to connect with default_authentication_plugin=caching_sha2_password even if caching_sha2_password is not used.