### PR TITLE
Fineuploader Review

### DIFF
--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -108,7 +108,7 @@ if (false === strpos($handler, '\\')) {
     XoopsLoad::load($handler, $moddir);
     $className = $moddir . $handler;
 }
-/* $uploader SystemFineUploadHandler */
+/* @var SystemFineUploadHandler $uploader */
 $uploader = new $className($claims);
 
 $method = get_request_method();

--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -57,7 +57,7 @@ use Xmf\Jwt\TokenReader;
  * SOFTWARE.
  */
 
-if(isset($_POST['Authorization'])) {
+if (isset($_POST['Authorization'])) {
     define('PROTECTOR_SKIP_DOS_CHECK', 1);
 }
 include __DIR__ . '/mainfile.php';
@@ -108,7 +108,7 @@ if (false === strpos($handler, '\\')) {
     XoopsLoad::load($handler, $moddir);
     $className = $moddir . $handler;
 }
-/* $uploader XoopsFineUploadHandler */
+/* $uploader SystemFineUploadHandler */
 $uploader = new $className($claims);
 
 $method = get_request_method();

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -36,11 +36,11 @@
  * SOFTWARE.
  */
 
-class SystemFineUploadHandler
+abstract class SystemFineUploadHandler
 {
 
     public $allowedExtensions = array();
-    public $allowedMimeTypes = array();
+    public $allowedMimeTypes = array('(none)'); // must specify!
     public $sizeLimit = null;
     public $inputName = 'qqfile';
     public $chunksFolder = 'chunks';


### PR DESCRIPTION
Reviewing fineuploader support for security and operational issues resulted in the following changes:

- allow fully qualified namespaced autoloading handler name
- require handler to be specified (removed default)
- require allowedMimeTypes property to be set in handlers
- disallow direct use of system fineuploadhandler class (now abstract)
- removed arbitrary handler property setting in ajaxfineupload endpoint