### PR TITLE
Add warning for old PHP versions

### DIFF
--- a/docs/lang_diff.txt
+++ b/docs/lang_diff.txt
@@ -24,6 +24,8 @@ htdocs/language/english/uploader.php
 htdocs/install/english/welcome.php
 - changed recommended PHP version
 
+htdocs/language/english/admin.php
+- added define('_AD_WARNING_OLD_PHP', 'WARNING: Consider upgrading to a newer version of PHP. Version %s or newer is recommended and will be required in future XOOPS versions.');
 
 NEW FILES:
 

--- a/htdocs/admin.php
+++ b/htdocs/admin.php
@@ -33,6 +33,14 @@ xoops_cp_header();
  * Error warning messages
  */
 if (!isset($xoopsConfig['admin_warnings_enable']) || $xoopsConfig['admin_warnings_enable']) {
+    // recommend lowest security supported version at time of XOOPS release
+    // see: http://php.net/supported-versions.php
+    $minRecommendedPHP = '7.1.0';
+    if (version_compare(PHP_VERSION, $minRecommendedPHP) < 0) {
+        xoops_error(sprintf(_AD_WARNING_OLD_PHP, $minRecommendedPHP));
+        echo '<br>';
+    }
+
     if (is_dir(XOOPS_ROOT_PATH . '/install/')) {
         xoops_error(sprintf(_AD_WARNINGINSTALL, XOOPS_ROOT_PATH . '/install/'));
         echo '<br>';

--- a/htdocs/language/english/admin.php
+++ b/htdocs/language/english/admin.php
@@ -1,5 +1,5 @@
 <?php
-// 
+//
 // _LANGCODE: en
 // _CHARSET : UTF-8
 // Translator: XOOPS Translation Team
@@ -19,3 +19,4 @@ define('_AD_WARNINGINSTALL', 'WARNING: Directory %s exists on your server. <br>P
 define('_AD_WARNINGWRITEABLE', 'WARNING: File %s is writeable by the server. <br>Please change the permission of this file for security reasons.<br> in Unix (444), in Win32 (read-only)');
 define('_AD_WARNINGNOTWRITEABLE', 'WARNING: Folder %s is not writeable by the server. <br>Please change the permission of this folder.<br> in Unix (777), in Win32 (writable)');
 define('_AD_WARNINGXOOPSLIBINSIDE', 'WARNING: Folder %s is inside DocumentRoot! <br>For security considerations it is highly suggested to move it out of DocumentRoot.');
+define('_AD_WARNING_OLD_PHP', 'WARNING: Consider upgrading to a newer version of PHP. Version %s or newer is recommended and will be required in future XOOPS versions.');


### PR DESCRIPTION
Add admin area security warning for PHP versions which were not supported with security updates at the time of the XOOPS release.

For XOOPS 2.5.10 this version is PHP 7.1. We continue to function correctly on older versions at this time, but using an older version is a significant security issue.