### PR TITLE
Update admin.php

### DIFF
--- a/htdocs/admin.php
+++ b/htdocs/admin.php
@@ -81,7 +81,7 @@ if (!empty($_GET['xoopsorgnews'])) {
     $myts     = MyTextSanitizer::getInstance();
     $rssurl   = array();
     //$rssurl[] = 'http://sourceforge.net/export/rss2_projnews.php?group_id=41586&rss_fulltext=1';
-    $rssurl[] = 'http://www.xoops.org/backend.php';
+    $rssurl[] = 'http://www.xoops.org/modules/publisher/backend.php';
     if ($URLs = include $GLOBALS['xoops']->path('language/' . xoops_getConfigOption('language') . '/backend.php')) {
         $rssurl = array_unique(array_merge($rssurl, $URLs));
     }


### PR DESCRIPTION
Hi, I'm not sure if i'm doing this right. Never done this before.

This updates the rssurl for xoops.org to the publisher-module. The old url gives news from 1 januari 2017 and older. Since every new xoops-er can check in the adminpanel the Xoops news (first menu-item Configuration - Xoops News) and will only see old news I thought lets correct this. Could be that the xoops.org/backend.php is faulty. Then this request is wrong.

Let me know if i'm doing something wrong, regards,
Robert