### PR TITLE
Replace XoopsMySQL with XoopsMysql  for naming consistency

### DIFF
--- a/htdocs/Frameworks/art/object.php
+++ b/htdocs/Frameworks/art/object.php
@@ -61,14 +61,14 @@ class ArtObjectHandler extends XoopsPersistableObjectHandler
     /**
      * Constructor
      *
-     * @param XoopsMySQLDatabase $db reference to the {@link XoopsDatabase} object
+     * @param XoopsMysqlDatabase $db reference to the {@link XoopsDatabase} object
      * @param string             $table
      * @param string             $className
      * @param string             $keyName
      * @param string             $identifierName
      */
 
-    public function __construct(XoopsMySQLDatabase $db, $table = '', $className = '', $keyName = '', $identifierName = '')
+    public function __construct(XoopsMysqlDatabase $db, $table = '', $className = '', $keyName = '', $identifierName = '')
     {
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
         trigger_error("ArtObjectHandler is deprecated, instantiated from {$trace[0]['file']} line {$trace[0]['line']},");

--- a/htdocs/class/database/mysqldatabase.php
+++ b/htdocs/class/database/mysqldatabase.php
@@ -30,7 +30,7 @@ include_once XOOPS_ROOT_PATH . '/class/database/database.php';
  * @package             class
  * @subpackage          database
  */
-class XoopsMySQLDatabase extends XoopsDatabase
+class XoopsMysqlDatabase extends XoopsDatabase
 {
     /**
      * Database connection
@@ -135,7 +135,7 @@ class XoopsMySQLDatabase extends XoopsDatabase
     }
 
     /**
-     * XoopsMySQLiDatabase::fetchObjected()
+     * XoopsMysqliDatabase::fetchObjected()
      *
      * @param mixed $result
      * @return stdClass|false false on end of data
@@ -472,7 +472,7 @@ class XoopsMySQLDatabase extends XoopsDatabase
  * @package             kernel
  * @subpackage          database
  */
-class XoopsMySQLDatabaseSafe extends XoopsMySQLDatabase
+class XoopsMysqlDatabaseSafe extends XoopsMysqlDatabase
 {
     /**
      * perform a query on the database
@@ -500,7 +500,7 @@ class XoopsMySQLDatabaseSafe extends XoopsMySQLDatabase
  * @package             class
  * @subpackage          database
  */
-class XoopsMySQLDatabaseProxy extends XoopsMySQLDatabase
+class XoopsMysqlDatabaseProxy extends XoopsMysqlDatabase
 {
     /**
      * perform a query on the database

--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -246,7 +246,7 @@ class MyTextSanitizer
     public function getSmileys($isAll = true)
     {
         if (count($this->smileys) == 0) {
-            /* @var XoopsMySQLDatabase $xoopsDB */
+            /* @var XoopsMysqlDatabase $xoopsDB */
             $xoopsDB = XoopsDatabaseFactory::getDatabaseConnection();
             if ($getsmiles = $xoopsDB->query('SELECT * FROM ' . $xoopsDB->prefix('smiles'))) {
                 while (false !== ($smiles = $xoopsDB->fetchArray($getsmiles))) {

--- a/htdocs/class/xoopsmailer.php
+++ b/htdocs/class/xoopsmailer.php
@@ -560,7 +560,8 @@ class XoopsMailer
             if (strtolower(get_class($group)) === 'xoopsgroup') {
                 /* @var XoopsMemberHandler $member_handler */
                 $member_handler = xoops_getHandler('member');
-                $this->setToUsers($member_handler->getUsersByGroup($group->getVar('groupid'), true));
+				$users = $member_handler->getUsersByGroup($group->getVar('groupid'), true);
+                $this->setToUsers($users);										  
             }
         } else {
             foreach ($group as $g) {

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -99,7 +99,7 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !$xoopsSecurity->checkReferer(XOOPS
  * Requires XoopsLogger, XOOPS_DB_PROXY;
  */
 include_once $xoops->path('class/database/databasefactory.php');
-/* @var XoopsMySQLDatabase $xoopsDB */
+/* @var XoopsMysqlDatabase $xoopsDB */
 $xoopsDB = XoopsDatabaseFactory::getDatabaseConnection();
 
 /**

--- a/htdocs/kernel/member.php
+++ b/htdocs/kernel/member.php
@@ -369,7 +369,7 @@ class XoopsMemberHandler
      */
     public function getColumnCharacterLength($table, $column)
     {
-        /** @var XoopsMySQLDatabase $db */
+        /** @var XoopsMysqlDatabase $db */
         $db = XoopsDatabaseFactory::getDatabaseConnection();
 
         $dbname = constant('XOOPS_DB_NAME');

--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -1078,7 +1078,7 @@ class XoopsObjectHandler
      */
     public function __construct(XoopsDatabase $db)
     {
-        /* @var XoopsMySQLDatabase $db */
+        /* @var XoopsMysqlDatabase $db */
         $this->db = $db;
     }
 

--- a/htdocs/modules/system/class/block.php
+++ b/htdocs/modules/system/class/block.php
@@ -397,7 +397,7 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
      */
     public function getAllBlocksByGroup($groupid, $asobject = true, $side = null, $visible = null, $orderby = 'b.weight,b.bid', $isactive = 1)
     {
-        /* @var XoopsMySQLDatabase $db */
+        /* @var XoopsMysqlDatabase $db */
         $db  = XoopsDatabaseFactory::getDatabaseConnection();
         $ret = array();
         $sql = 'SELECT b.* ';
@@ -625,7 +625,7 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
             // invalid query
             return 0;
         }
-        /* @var XoopsMySQLDatabase $db */
+        /* @var XoopsMysqlDatabase $db */
         $db = XoopsDatabaseFactory::getDatabaseConnection();
         if (isset($showFunc)) {
             // showFunc is set for more strict comparison

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -33,7 +33,7 @@ class SystemMaintenance
      */
     public function __construct()
     {
-        /* @var XoopsMySQLDatabase $db */
+        /* @var XoopsMysqlDatabase $db */
         $db           = XoopsDatabaseFactory::getDatabaseConnection();
         $this->db     = $db;
         $this->prefix = $this->db->prefix . '_';

--- a/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
+++ b/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
@@ -11,7 +11,7 @@ require_once XOOPS_ROOT_PATH . '/class/database/database.php';
 /**
  * Class ProtectorMySQLDatabase
  */
-class ProtectorMySQLDatabase extends XoopsMySQLDatabaseProxy
+class ProtectorMySQLDatabase extends XoopsMysqlDatabaseProxy
 {
     public $doubtful_requests = array();
     public $doubtful_needles  = array(

--- a/upgrade/upd-2.5.7-to-2.5.8/index.php
+++ b/upgrade/upd-2.5.7-to-2.5.8/index.php
@@ -44,7 +44,7 @@ class Upgrade_258 extends XoopsUpgrade
      */
     private function getColumnLength($table, $column)
     {
-        /** @var XoopsMySQLDatabase $db */
+        /** @var XoopsMysqlDatabase $db */
         $db = XoopsDatabaseFactory::getDatabaseConnection();
 
         $dbname = constant('XOOPS_DB_NAME');

--- a/upgrade/upd-2.5.8-to-2.5.9/index.php
+++ b/upgrade/upd-2.5.8-to-2.5.9/index.php
@@ -40,7 +40,7 @@ class Upgrade_259 extends XoopsUpgrade
      */
     private function getColumnLength($table, $column)
     {
-        /* @var XoopsMySQLDatabase $db */
+        /* @var XoopsMysqlDatabase $db */
         $db = XoopsDatabaseFactory::getDatabaseConnection();
 
         $dbname = constant('XOOPS_DB_NAME');

--- a/upgrade/upd-2.5.9-to-2.5.10/index.php
+++ b/upgrade/upd-2.5.9-to-2.5.10/index.php
@@ -33,7 +33,7 @@ class Upgrade_2510 extends XoopsUpgrade
      */
     public function check_metarobots()
     {
-        /* @var XoopsMySQLDatabase $db */
+        /* @var XoopsMysqlDatabase $db */
         $db = XoopsDatabaseFactory::getDatabaseConnection();
 
         $table = $db->prefix('config');


### PR DESCRIPTION
because in class XoopsDatabaseFactory, method getDatabaseConnection there could be some problems when istanciate class