### PR TITLE
Escape Tooltip Text

### DIFF
--- a/htdocs/modules/system/themes/default/js/tooltip.js
+++ b/htdocs/modules/system/themes/default/js/tooltip.js
@@ -8,7 +8,22 @@
  *
  */
 
+var entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;'
+};
 
+function escapeHtml (string) {
+    return String(string).replace(/[&<>"'`=\/]/g, function (s) {
+        return entityMap[s];
+    });
+}
 
 this.tooltip = function(){
     /* CONFIG */
@@ -22,7 +37,7 @@ this.tooltip = function(){
         //Removing alt atribute for IE
         $("a.tooltip img").each(function() { $(this).attr("title", ""); $(this).attr("alt", ""); });
 
-        $("body").append("<p id='tooltip'>"+ this.t +"</p>");
+        $("body").append("<p id='tooltip'>"+ escapeHtml(this.t) +"</p>");
 
         $("#tooltip")
             .css("top",(e.pageY + yOffset) + "px")

--- a/htdocs/modules/system/themes/default/js/tooltip.js
+++ b/htdocs/modules/system/themes/default/js/tooltip.js
@@ -8,6 +8,19 @@
  *
  */
 
+/**
+ * This section originates from https://github.com/janl/mustache.js under The MIT License
+ *
+ * Copyright (c) 2009 Chris Wanstrath (Ruby)
+ * Copyright (c) 2010-2014 Jan Lehnardt (JavaScript)
+ * Copyright (c) 2010-2015 The mustache.js community
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 var entityMap = {
     '&': '&amp;',
     '<': '&lt;',
@@ -24,6 +37,7 @@ function escapeHtml (string) {
         return entityMap[s];
     });
 }
+/* End of mustache.js code */
 
 this.tooltip = function(){
     /* CONFIG */

--- a/htdocs/modules/system/themes/transition/js/tooltip.js
+++ b/htdocs/modules/system/themes/transition/js/tooltip.js
@@ -8,7 +8,22 @@
  *
  */
 
+var entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;'
+};
 
+function escapeHtml (string) {
+    return String(string).replace(/[&<>"'`=\/]/g, function (s) {
+        return entityMap[s];
+    });
+}
 
 this.tooltip = function(){
     /* CONFIG */
@@ -22,7 +37,7 @@ this.tooltip = function(){
         //Removing alt atribute for IE
         $("a.tooltip img").each(function() { $(this).attr("title", ""); $(this).attr("alt", ""); });
 
-        $("body").append("<p id='tooltip'>"+ this.t +"</p>");
+        $("body").append("<p id='tooltip'>"+ escapeHtml(this.t) +"</p>");
 
         $("#tooltip")
             .css("top",(e.pageY + yOffset) + "px")

--- a/htdocs/modules/system/themes/transition/js/tooltip.js
+++ b/htdocs/modules/system/themes/transition/js/tooltip.js
@@ -8,6 +8,19 @@
  *
  */
 
+/**
+ * This section originates from https://github.com/janl/mustache.js under The MIT License
+ *
+ * Copyright (c) 2009 Chris Wanstrath (Ruby)
+ * Copyright (c) 2010-2014 Jan Lehnardt (JavaScript)
+ * Copyright (c) 2010-2015 The mustache.js community
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 var entityMap = {
     '&': '&amp;',
     '<': '&lt;',
@@ -24,6 +37,7 @@ function escapeHtml (string) {
         return entityMap[s];
     });
 }
+/* End of mustache.js code */
 
 this.tooltip = function(){
     /* CONFIG */

--- a/htdocs/modules/system/themes/zetadigme/js/tooltip.js
+++ b/htdocs/modules/system/themes/zetadigme/js/tooltip.js
@@ -8,7 +8,22 @@
  *
  */
 
+var entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;'
+};
 
+function escapeHtml (string) {
+    return String(string).replace(/[&<>"'`=\/]/g, function (s) {
+        return entityMap[s];
+    });
+}
 
 this.tooltip = function(){
     /* CONFIG */
@@ -22,7 +37,7 @@ this.tooltip = function(){
         //Removing alt atribute for IE
         $("a.tooltip img").each(function() { $(this).attr("title", ""); $(this).attr("alt", ""); });
 
-        $("body").append("<p id='tooltip'>"+ this.t +"</p>");
+        $("body").append("<p id='tooltip'>"+ escapeHtml(this.t) +"</p>");
 
         $("#tooltip")
             .css("top",(e.pageY + yOffset) + "px")

--- a/htdocs/modules/system/themes/zetadigme/js/tooltip.js
+++ b/htdocs/modules/system/themes/zetadigme/js/tooltip.js
@@ -8,6 +8,19 @@
  *
  */
 
+/**
+ * This section originates from https://github.com/janl/mustache.js under The MIT License
+ *
+ * Copyright (c) 2009 Chris Wanstrath (Ruby)
+ * Copyright (c) 2010-2014 Jan Lehnardt (JavaScript)
+ * Copyright (c) 2010-2015 The mustache.js community
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 var entityMap = {
     '&': '&amp;',
     '<': '&lt;',
@@ -24,6 +37,7 @@ function escapeHtml (string) {
         return entityMap[s];
     });
 }
+/* End of mustache.js code */
 
 this.tooltip = function(){
     /* CONFIG */

--- a/htdocs/modules/system/themes/zetadigme/xotpl/xo_toolsbar.tpl
+++ b/htdocs/modules/system/themes/zetadigme/xotpl/xo_toolsbar.tpl
@@ -4,7 +4,7 @@
             <img src='<{"$theme_icons/help.png"}>' alt='<{$smarty.const._AM_SYSTEM_HELP}>'/>
         </a>
         <{foreach item=op from=$mod_options}>
-            <a class="tooltip" href="<{$op.link}>" title="<strong class='italic'><{$op.title}></strong>: <{$op.desc}>">
+            <a class="tooltip" href="<{$op.link}>" title="<{$op.title}>: <{$op.desc}>">
                 <img src='<{$op.icon|default:"$theme_icons/icon_options_small.png"}>' alt="<{$op.title}>"/>
             </a>
         <{/foreach}>


### PR DESCRIPTION
Escape tooltip text in admin themes. Also, remove HTML styling in zetadigme admin theme.