### PR TITLE
Mail Tweaks

### DIFF
--- a/htdocs/class/mail/xoopsmultimailer.php
+++ b/htdocs/class/mail/xoopsmultimailer.php
@@ -142,6 +142,7 @@ class XoopsMultiMailer extends PHPMailer
      */
     public function __construct()
     {
+        parent::__construct();
         /* @var XoopsConfigHandler $config_handler */
         $config_handler    = xoops_getHandler('config');
         $xoopsMailerConfig = $config_handler->getConfigsByCat(XOOPS_CONF_MAILER);

--- a/htdocs/install/sql/mysql.data.sql
+++ b/htdocs/install/sql/mysql.data.sql
@@ -81,6 +81,8 @@ INSERT INTO configoption VALUES (32, '_MD_AM_WELCOMETYPE_EMAIL', '1', 95);
 INSERT INTO configoption VALUES (33, '_MD_AM_WELCOMETYPE_PM', '2', 95);
 INSERT INTO configoption VALUES (34, '_MD_AM_WELCOMETYPE_BOTH', '3', 95);
 
+# addition to email
+INSERT INTO configoption VALUES (35,'qmail','qmail',64);
 
 #
 # Dumping data for table `image`

--- a/upgrade/upd-2.5.9-to-2.5.10/index.php
+++ b/upgrade/upd-2.5.9-to-2.5.10/index.php
@@ -3,15 +3,15 @@
 use Xmf\Database\Tables;
 
 /**
- * Upgrade from 2.5.8 to 2.5.9
+ * Upgrade from 2.5.9 to 2.5.10
  *
  * See the enclosed file license.txt for licensing information.
- * If you did not receive this file, get it at http://www.gnu.org/licenses/gpl-2.0.html
+ * If you did not receive this file, get it at https://www.gnu.org/licenses/gpl-2.0.html
  *
- * @copyright    (c) 2000-2016 XOOPS Project (www.xoops.org)
- * @license          GNU GPL 2 (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @copyright    (c) 2000-2019 XOOPS Project (https://xoops.org)
+ * @license          GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
  * @package          Upgrade
- * @since            2.5.9
+ * @since            2.5.10
  * @author           XOOPS Team
  */
 class Upgrade_2510 extends XoopsUpgrade

--- a/upgrade/upd_2.5.10-to-2.5.11/index.php
+++ b/upgrade/upd_2.5.10-to-2.5.11/index.php
@@ -1,0 +1,78 @@
+<?php
+
+use Xmf\Database\Tables;
+
+/**
+ * Upgrade from 2.5.10 to 2.5.11
+ *
+ * See the enclosed file license.txt for licensing information.
+ * If you did not receive this file, get it at https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @copyright    (c) 2000-2019 XOOPS Project (https://xoops.org)
+ * @license          GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @package          Upgrade
+ * @since            2.5.11
+ * @author           XOOPS Team
+ */
+class Upgrade_2511 extends XoopsUpgrade
+{
+    /**
+     * __construct
+     */
+    public function __construct()
+    {
+        parent::__construct(basename(__DIR__));
+        $this->tasks = array('qmail');
+        $this->usedFiles = array();
+    }
+
+    /**
+     * Add qmail as valid mailmethod
+     *
+     * @return bool
+     */
+    public function check_qmail()
+    {
+        /* @var XoopsMySQLDatabase $db */
+        $db = XoopsDatabaseFactory::getDatabaseConnection();
+
+        $table = $db->prefix('configoption');
+
+        $sql = sprintf(
+            'SELECT count(*) FROM `%s` '
+            . "WHERE `conf_id` = 64 AND `confop_name` = 'qmail'",
+            $db->escape($table)
+        );
+
+        /** @var mysqli_result $result */
+        $result = $db->query($sql);
+        if ($result) {
+            $row = $db->fetchRow($result);
+            if ($row) {
+                $count = $row[0];
+                return (0 === (int) $count) ? false : true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Add qmail as valid mailmethod
+     *
+     * phpMailer has qmail support, similar to but slightly different than sendmail
+     * This will allow webmasters to utilize qmail if it is provisioned on server.
+     *
+     * @return bool
+     */
+    public function apply_qmail()
+    {
+        $migrate = new Tables();
+        $migrate->useTable('configoption');
+        $migrate->insert('configoption',
+            array('confop_name' => 'qmail', 'confop_value' => 'qmail', 'conf_id' => 64));
+        return $migrate->executeQueue(true);
+    }
+}
+
+$upg = new Upgrade_2511();
+return $upg;


### PR DESCRIPTION
Correct issues identified while researching a user issue.
- XoopsMultiMailer extends phpMailer, but does not call parent::__construct()
- phpMailer has qmail support, but XOOPS configuration option is missing