### PR TITLE
Refresh inbox count cache when using pm programs

### DIFF
--- a/htdocs/class/smarty/xoops_plugins/function.xoInboxCount.php
+++ b/htdocs/class/smarty/xoops_plugins/function.xoInboxCount.php
@@ -20,6 +20,18 @@ function smarty_function_xoInboxCount($params, &$smarty)
     if (!isset($xoopsUser) || !is_object($xoopsUser)) {
         return null;
     }
+
+    // unset cache in pm programs so stale cache won't show inconsistencies
+    $freshRead = isset($GLOBALS['xoInboxCountFresh']);
+    $pmScripts = array('pmlite', 'readpmsg', 'viewpmsg');
+    if (in_array(basename($_SERVER['SCRIPT_FILENAME'], '.php'), $pmScripts)) {
+        trigger_error(sprintf('$freshRead = %d', (int) $freshRead));
+        if (!$freshRead) {
+            unset($_SESSION['xoops_inbox_count'], $_SESSION['xoops_inbox_total'], $_SESSION['xoops_inbox_count_expire']);
+            $GLOBALS['xoInboxCountFresh'] = true;
+        }
+    }
+
     $time = time();
     if (isset($_SESSION['xoops_inbox_count']) && @$_SESSION['xoops_inbox_count_expire'] > $time) {
         $totals['assign'] = (int)$_SESSION['xoops_inbox_count'];


### PR DESCRIPTION
When working with pm's, the counts provided by the xoInboxCount Smarty plugin will always be current. Otherwise, the cache will be updated every 60 seconds. This should provide a less confusing user experience when reading messages.

Re: #738