### PR TITLE
Allow comment instead of blank title

### DIFF
--- a/htdocs/class/theme_blocks.php
+++ b/htdocs/class/theme_blocks.php
@@ -171,6 +171,11 @@ class xos_logos_PageBuilder
             'weight'  => $xobject->getVar('weight'),
             'lastmod' => $xobject->getVar('last_modified'));
 
+        // title is a comment, don't show it
+        if (0 === strpos($block['title'], '// ')) {
+            $block['title'] = '';
+        }
+
         $bcachetime = (int)$xobject->getVar('bcachetime');
         if (empty($bcachetime)) {
             $template->caching = 0;


### PR DESCRIPTION
Suppress display of block titles starting with `// `.

The display of a block title can be suppressed by leaving the title field blank, but this makes it difficult to identify blocks when editing in the admin section.

This change allows "commenting" out a title by starting it with a slash-slash-space sequence. Blocks with a title starting with this sequence will be displayed as if their title was blank.