### PR TITLE
Remove locale specific date format for calendar.js

### DIFF
--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php
@@ -600,7 +600,7 @@ class XoopsFormRendererBootstrap3 implements XoopsFormRendererInterface
             $display_value = date(_SHORTDATESTRING, $ele_value);
         }
 
-        $jstime = formatTimestamp($ele_value, _SHORTDATESTRING);
+        $jstime = formatTimestamp($ele_value, 'm/d/Y');
         if (isset($GLOBALS['xoTheme']) && is_object($GLOBALS['xoTheme'])) {
             $GLOBALS['xoTheme']->addScript('include/calendar.js');
             $GLOBALS['xoTheme']->addStylesheet('include/calendar-blue.css');

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php
@@ -14,9 +14,8 @@
  * @category  XoopsForm
  * @package   XoopsFormRendererBootstrap3
  * @author    Richard Griffith <richard@geekwright.com>
- * @copyright 2017 XOOPS Project (http://xoops.org)
- * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
- * @link      http://xoops.org
+ * @copyright 2017-2020 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  */
 class XoopsFormRendererBootstrap3 implements XoopsFormRendererInterface
 {

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
@@ -14,9 +14,8 @@
  * @category  XoopsForm
  * @package   XoopsFormRendererBootstrap4
  * @author    Richard Griffith <richard@geekwright.com>
- * @copyright 2018 XOOPS Project (http://xoops.org)
- * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
- * @link      http://xoops.org
+ * @copyright 2018-2020 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  */
 class XoopsFormRendererBootstrap4 implements XoopsFormRendererInterface
 {

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
@@ -609,7 +609,7 @@ class XoopsFormRendererBootstrap4 implements XoopsFormRendererInterface
             $display_value = date(_SHORTDATESTRING, $ele_value);
         }
 
-        $jstime = formatTimestamp($ele_value, _SHORTDATESTRING);
+        $jstime = formatTimestamp($ele_value, 'm/d/Y');
         if (isset($GLOBALS['xoTheme']) && is_object($GLOBALS['xoTheme'])) {
             $GLOBALS['xoTheme']->addScript('include/calendar.js');
             $GLOBALS['xoTheme']->addStylesheet('include/calendar-blue.css');

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererLegacy.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererLegacy.php
@@ -14,9 +14,8 @@
  * @category  XoopsForm
  * @package   XoopsFormRendererLegacy
  * @author    Richard Griffith <richard@geekwright.com>
- * @copyright 2017 XOOPS Project (http://xoops.org)
- * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
- * @link      http://xoops.org
+ * @copyright 2017-2020 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  */
 class XoopsFormRendererLegacy implements XoopsFormRendererInterface
 {

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererLegacy.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererLegacy.php
@@ -497,7 +497,7 @@ class XoopsFormRendererLegacy implements XoopsFormRendererInterface
             $display_value = date(_SHORTDATESTRING, $ele_value);
         }
 
-        $jstime = formatTimestamp($ele_value, _SHORTDATESTRING);
+        $jstime = formatTimestamp($ele_value, 'm/d/Y');
         if (isset($GLOBALS['xoTheme']) && is_object($GLOBALS['xoTheme'])) {
             $GLOBALS['xoTheme']->addScript('include/calendar.js');
             $GLOBALS['xoTheme']->addStylesheet('include/calendar-blue.css');


### PR DESCRIPTION
Fixes #764 

Several issues found:

- The localized format date is directly used to instantiate a js Date object, and those localized formats are not supported in that context.

- There seems to be a bug that effects the preferred ISO format, causing calendar.js to be off by one day back(?)  The generally supported mm/dd/yyyy seems to work correctly.

Helpful reference: https://www.w3schools.com/js/js_date_formats.asp