### PR TITLE
Correct issues in dhtmltextarea

### DIFF
--- a/docs/lang_diff.txt
+++ b/docs/lang_diff.txt
@@ -7,6 +7,10 @@ Below are language differences from a version to next version.
 2020/02/14: Version 2.5.11-Beta1
 ================================
 CHANGED FILES:
+htdocs/language/english/global.php
+- changed define('_SIZE', 'Size'); // font size
+- changed define('_FONT', 'Font'); // font family
+- changed define('_COLOR', 'Color'); // font color
 htdocs/install/language/english/welcome.php
 - changed recommended PHP & MySQL versions, links changed to "https:"
 htdocs/modules/system/language/english/help/blocksadmin.html

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
@@ -361,7 +361,7 @@ class XoopsFormRendererBootstrap4 implements XoopsFormRendererInterface
             . '<ul class="dropdown-menu">';
             //. _SIZE . '&nbsp;&nbsp;<span class="caret"></span></button><ul class="dropdown-menu">';
         foreach ($GLOBALS['formtextdhtml_sizes'] as $value => $name) {
-            $fontStr .= '<li><a href="javascript:xoopsSetElementAttribute(\'size\', \'' . $value . '\', \''
+            $fontStr .= '<li class="dropdown-item"><a href="javascript:xoopsSetElementAttribute(\'size\', \'' . $value . '\', \''
                 . $textarea_id . '\', \'' . $hiddentext . '\');">' . $name . '</a></li>';
         }
         $fontStr .= '</ul></div>';
@@ -373,7 +373,7 @@ class XoopsFormRendererBootstrap4 implements XoopsFormRendererInterface
             . '<ul class="dropdown-menu">';
             //. _FONT . '&nbsp;&nbsp;<span class="caret"></span></button><ul class="dropdown-menu">';
         foreach ($fontarray as $font) {
-            $fontStr .= '<li><a href="javascript:xoopsSetElementAttribute(\'font\', \'' . $font . '\', \''
+            $fontStr .= '<li class="dropdown-item"><a href="javascript:xoopsSetElementAttribute(\'font\', \'' . $font . '\', \''
                 . $textarea_id . '\', \'' . $hiddentext . '\');">' . $font . '</a></li>';
         }
         $fontStr .= '</ul></div>';
@@ -385,7 +385,7 @@ class XoopsFormRendererBootstrap4 implements XoopsFormRendererInterface
             . '<ul class="dropdown-menu">';
             //. _COLOR . '&nbsp;&nbsp;<span class="caret"></span></button><ul class="dropdown-menu">';
         foreach ($colorArray as $color => $hex) {
-            $fontStr .= '<li><a href="javascript:xoopsSetElementAttribute(\'color\', \'' . $hex . '\', \''
+            $fontStr .= '<li class="dropdown-item"><a href="javascript:xoopsSetElementAttribute(\'color\', \'' . $hex . '\', \''
                 . $textarea_id . '\', \'' . $hiddentext . '\');">'
                 . '<span style="color:#' . $hex . ';">' . $color .'</span></a></li>';
         }

--- a/htdocs/language/english/global.php
+++ b/htdocs/language/english/global.php
@@ -1,5 +1,5 @@
 <?php
-// 
+//
 // _LANGCODE: en
 // _CHARSET : UTF-8
 // Translator: XOOPS Translation Team
@@ -162,9 +162,9 @@ define('_REQUIRED', 'Required');
 // %%%%%%    File Name commentform.php     %%%%%
 define('_REGISTER', 'Register');
 // %%%%%%    File Name xoopscodes.php     %%%%%
-define('_SIZE', 'SIZE'); // font size
-define('_FONT', 'FONT'); // font family
-define('_COLOR', 'COLOR'); // font color
+define('_SIZE', 'Size'); // font size
+define('_FONT', 'Font'); // font family
+define('_COLOR', 'Color'); // font color
 define('_EXAMPLE', 'SAMPLE');
 define('_ENTERURL', 'Enter the URL of the link you want to add:');
 define('_ENTERWEBTITLE', 'Enter the web site title:');


### PR DESCRIPTION
Re: #778

- add "dropdown-item" class to typography controls, adds missing padding
- change _FONT, _SIZE and _COLOR constants to mixed case

Note that _FONT, _SIZE and _COLOR constants are in htdocs/language/english/global.php,
so changes in other languages are dependent on updated language files.


