### PR TITLE
Add XoopsHttpGet, deprecate Snoopy

### DIFF
--- a/htdocs/admin.php
+++ b/htdocs/admin.php
@@ -80,7 +80,6 @@ if (!empty($_GET['xoopsorgnews'])) {
     // Multiple feeds
     $myts     = MyTextSanitizer::getInstance();
     $rssurl   = array();
-    //$rssurl[] = 'http://sourceforge.net/export/rss2_projnews.php?group_id=41586&rss_fulltext=1';
     $rssurl[] = 'https://xoops.org/modules/publisher/backend.php';
     if ($URLs = include $GLOBALS['xoops']->path('language/' . xoops_getConfigOption('language') . '/backend.php')) {
         $rssurl = array_unique(array_merge($URLs, $rssurl));
@@ -89,19 +88,26 @@ if (!empty($_GET['xoopsorgnews'])) {
     xoops_load('XoopsCache');
     $items = array();
     if (!$items = XoopsCache::read($rssfile)) {
-        require_once $GLOBALS['xoops']->path('class/snoopy.php');
-        include_once $GLOBALS['xoops']->path('class/xml/rss/xmlrss2parser.php');
+        XoopsLoad::load('xoopshttpget');
+        require_once $GLOBALS['xoops']->path('class/xml/rss/xmlrss2parser.php');
 
         xoops_load('XoopsLocal');
-        $snoopy = new Snoopy();
         $cnt    = 0;
         foreach ($rssurl as $url) {
-            if ($snoopy->fetch($url)) {
-                $rssdata    = $snoopy->results;
+            try {
+                $httpGet = new XoopsHttpGet($url);
+            } catch (\RuntimeException $e) {
+                echo $e->getMessage() . '<br>';
+                break;
+            }
+            $rssdata    = $httpGet->fetch();
+            if (false === $rssdata) {
+                echo $httpGet->getError() . '<br>';
+            } else {
                 $rss2parser = new XoopsXmlRss2Parser($rssdata);
                 if (false !== $rss2parser->parse()) {
                     $_items =& $rss2parser->getItems();
-                    $count  = count($_items);
+                    $count = count($_items);
                     for ($i = 0; $i < $count; ++$i) {
                         $_items[$i]['title'] = XoopsLocal::convert_encoding($_items[$i]['title'], _CHARSET, 'UTF-8');
                         $_items[$i]['description'] = XoopsLocal::convert_encoding($_items[$i]['description'], _CHARSET, 'UTF-8');

--- a/htdocs/class/snoopy.php
+++ b/htdocs/class/snoopy.php
@@ -28,6 +28,11 @@
  *************************************************/
 class Snoopy
 {
+    public function __construct()
+    {
+        trigger_error('Use of Snoopy in XOOPS is deprecated, and the class will be removed in future version.', E_USER_DEPRECATED);
+    }
+
     /**** Public variables ****/
 
     /* user definable vars */

--- a/htdocs/class/snoopy.php
+++ b/htdocs/class/snoopy.php
@@ -30,7 +30,7 @@ class Snoopy
 {
     public function __construct()
     {
-        trigger_error('Use of Snoopy in XOOPS is deprecated, and the class will be removed in future version.', E_USER_DEPRECATED);
+        trigger_error('Use of Snoopy in XOOPS is deprecated and has been replaced in core with XoopsHttpGet. Snoopy will be removed in future versions.', E_USER_DEPRECATED);
     }
 
     /**** Public variables ****/

--- a/htdocs/class/xoopshttpget.php
+++ b/htdocs/class/xoopshttpget.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/**
+ * XoopsHttpGet - return response to a http get request
+ *
+ * @category  HttpGet
+ * @package   Xoops
+ * @author    Richard Griffith <richard@geekwright.com>
+ * @copyright 2020 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ */
+class XoopsHttpGet
+{
+    protected $useCurl = true;
+    protected $url;
+    protected $error;
+
+    /**
+     * XoopsHttpGet constructor.
+     *
+     * @param string $url the url to process
+     *
+     * @throws \RuntimeException if neither curl extension or stream wrappers (allow_url_fopen) is available
+     */
+    public function __construct($url)
+    {
+        $this->url = $url;
+        if (!function_exists('curl_init')) {
+            $this->useCurl = false;
+            $urlFopen = (int) ini_get('allow_url_fopen');
+            if ($urlFopen === 0) {
+                throw new \RuntimeException("CURL extension or allow_url_fopen ini setting is required.");
+            }
+        }
+    }
+
+    /**
+     * Return the response from a GET to the specified URL.
+     *
+     * @return string|false response or false on error
+     */
+    public function fetch()
+    {
+        return ($this->useCurl) ? $this->fetchCurl() : $this->fetchFopen();
+    }
+
+    /**
+     * Use curl to GET the specified URL.
+     *
+     * @return string|false response or false on error
+     */
+    protected function fetchCurl()
+    {
+        $curlHandle = curl_init($this->url);
+        $options = array(
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_HEADER         => 0,
+            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_FOLLOWLOCATION => 1,
+            CURLOPT_MAXREDIRS      => 4,
+        );
+        curl_setopt_array($curlHandle, $options);
+
+        $response = curl_exec($curlHandle);
+        if (false === $response) {
+            $this->error = curl_error($curlHandle);
+        } else {
+            $httpcode = curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
+            if (200 != $httpcode) {
+                $this->error = $response;
+                $response = false;
+            }
+        }
+        curl_close($curlHandle);
+        return $response;
+    }
+
+    /**
+     * Use stream wrapper to GET the specified URL.
+     *
+     * @return string|false response or false on error
+     */
+    protected function fetchFopen()
+    {
+        $response = file_get_contents($this->url);
+        if (false === $response) {
+            $this->error = 'file_get_contents() failed.';
+        }
+        return $response;
+    }
+
+    /**
+     * Return any error set during processing of fetch()
+     *
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/htdocs/class/xoopshttpget.php
+++ b/htdocs/class/xoopshttpget.php
@@ -61,6 +61,10 @@ class XoopsHttpGet
     protected function fetchCurl()
     {
         $curlHandle = curl_init($this->url);
+        if (false === $curlHandle) {
+            $this->error = 'curl_init failed';
+            return false;
+        }
         $options = array(
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_HEADER         => 0,

--- a/htdocs/class/xoopsload.php
+++ b/htdocs/class/xoopsload.php
@@ -232,7 +232,9 @@ class XoopsLoad
             'xoopsformrendererbootstrap3'=> XOOPS_ROOT_PATH . '/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php',
             'xoopsformrendererbootstrap4'=> XOOPS_ROOT_PATH . '/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php',
             'xoopsfilterinput'           => XOOPS_ROOT_PATH . '/class/xoopsfilterinput.php',
-            'xoopsrequest'               => XOOPS_ROOT_PATH . '/class/xoopsrequest.php');
+            'xoopsrequest'               => XOOPS_ROOT_PATH . '/class/xoopsrequest.php',
+            'xoopshttpget'               => XOOPS_ROOT_PATH . '/class/xoopshttpget.php',
+        );
     }
 
     /**


### PR DESCRIPTION
**Adds class XoopsHttpGet**

This class is used to retrieve the response from an http(s) request to a URL. It is replacing "Snoopy" that has been used for fetching rss feeds in the administration area.

For proper operation, it requires the curl PHP extension, or alternately that the ini settiing 'allow_url_fopen' is enabled.

**Deprecates class Snoopy**

This class will be removed in a future version of XOOPS. Developers are encouraged to remove any dependencies on this class.

Issues with Snoopy were reported in #782