### PR TITLE
Move xswatch4 css directory selection to a separate file

### DIFF
--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -237,6 +237,7 @@ function xoops_header($closehead = true)
     $headTpl->assign(array(
         'closeHead'      => (bool) $closehead,
         'themeUrl'       => $themeUrl,
+        'themePath'      => $themePath,
         'xoops_langcode' => _LANGCODE,
         'xoops_charset'  => _CHARSET,
         'xoops_sitename' => $xoopsConfig['sitename'],
@@ -369,13 +370,13 @@ function xoops_result($msg, $title = '')
 function xoops_confirm($hiddens, $action, $msg, $submit = '', $addtoken = true)
 {
 	if (!isset($GLOBALS['xoTheme']) || !is_object($GLOBALS['xoTheme'])) {
-		include_once $GLOBALS['xoops']->path('/class/theme.php'); 
-		$GLOBALS['xoTheme'] = new \xos_opal_Theme(); 
+		include_once $GLOBALS['xoops']->path('/class/theme.php');
+		$GLOBALS['xoTheme'] = new \xos_opal_Theme();
 	}
 	require_once $GLOBALS['xoops']->path('/class/template.php');
-	$confirmTpl = new \XoopsTpl(); 
-	$confirmTpl->assign('msg', $msg); 
-	$confirmTpl->assign('action', $action); 
+	$confirmTpl = new \XoopsTpl();
+	$confirmTpl->assign('msg', $msg);
+	$confirmTpl->assign('action', $action);
 	$tempHiddens = '';
     foreach ($hiddens as $name => $value) {
         if (is_array($value)) {
@@ -387,14 +388,14 @@ function xoops_confirm($hiddens, $action, $msg, $submit = '', $addtoken = true)
             $tempHiddens .= '<input type="hidden" name="' . $name . '" value="' . htmlspecialchars($value) . '" />';
         }
     }
-	$confirmTpl->assign('hiddens', $tempHiddens); 
-	$confirmTpl->assign('addtoken', $addtoken); 
-	if ($addtoken != false) { 
-		$confirmTpl->assign('token', $GLOBALS['xoopsSecurity']->getTokenHTML()); 
-	} 
+	$confirmTpl->assign('hiddens', $tempHiddens);
+	$confirmTpl->assign('addtoken', $addtoken);
+	if ($addtoken != false) {
+		$confirmTpl->assign('token', $GLOBALS['xoopsSecurity']->getTokenHTML());
+	}
     $submit = ($submit != '') ? trim($submit) : _SUBMIT;
-	$confirmTpl->assign('submit', $submit); 
-	$html = $confirmTpl->fetch("db:system_confirm.tpl");	
+	$confirmTpl->assign('submit', $submit);
+	$html = $confirmTpl->fetch("db:system_confirm.tpl");
 	if (!empty($html)) {
 		echo $html;
 	} else {

--- a/htdocs/themes/xswatch4/README.md
+++ b/htdocs/themes/xswatch4/README.md
@@ -15,13 +15,10 @@ Features:
 Customize xSwatch:
 
 - 21 themes in 1 theme (Preview : [Bootswatch](https://bootswatch.com/))
-In theme.tpl file : 
-	<{* pick the css directory you want to use in the assign var="xswatchCss" value below. *}>
-	<{* Valid values are css-cerulean, css-slate, css-darkly, css-journal... *}>
-	<{assign var="xswatchCss" value="css-cerulean"}>
-	<link rel="stylesheet" type="text/css" href="<{xoImgUrl}><{$xswatchCss}>/xoops.css">
-	<link rel="stylesheet" type="text/css" href="<{xoImgUrl}><{$xswatchCss}>/bootstrap.min.css">
-	<link rel="stylesheet" type="text/css" href="<{xoImgUrl}><{$xswatchCss}>/cookieconsent.css">
+  In the file _tpl/xswatchCss.tpl_, edit the bottom line to match the Bootswatch theme of your 
+  choice. By default, the line reads **css-cerulean**. To change to a dark theme, like the one 
+  used in the original xswatch for example, change it to **css-slate**.
+  You can pick from any of the 21 variations listed in the comments in _tpl/xswatchCss.tpl_  
 - customize the Navigation Bar in tpl/nav-menu.tpl and language/*/main.php to match your system and installed modules
 - customize the Jumbotron in theme.tpl and tpl/jumbotron.tpl
 - enable a slider in theme.tpl and tpl/slider.tpl

--- a/htdocs/themes/xswatch4/modules/system/system_popup_header.tpl
+++ b/htdocs/themes/xswatch4/modules/system/system_popup_header.tpl
@@ -7,8 +7,10 @@
     <{section name=item loop=$headItems}>
     <{$headItems[item]}>
     <{/section}>
-    <link rel="stylesheet" type="text/css" href="<{$themeUrl}>css/xoops.css">
-    <link rel="stylesheet" type="text/css" href="<{$themeUrl}>css/bootstrap.min.css">
+
+    <{include file="$themePath/tpl/xswatchCss.tpl" assign="xswatchCss"}>
+    <link rel="stylesheet" type="text/css" href="<{$themeUrl}><{$xswatchCss}>/xoops.css">
+    <link rel="stylesheet" type="text/css" href="<{$themeUrl}><{$xswatchCss}>/bootstrap.min.css">
     <script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>
     <script src="<{$themeUrl}>js/bootstrap.bundle.min.js"></script>
 

--- a/htdocs/themes/xswatch4/modules/system/system_popup_header.tpl
+++ b/htdocs/themes/xswatch4/modules/system/system_popup_header.tpl
@@ -8,6 +8,8 @@
     <{$headItems[item]}>
     <{/section}>
 
+    <link href="<{$xoops_url}>/favicon.ico" rel="shortcut icon">
+
     <{include file="$themePath/tpl/xswatchCss.tpl" assign="xswatchCss"}>
     <link rel="stylesheet" type="text/css" href="<{$themeUrl}><{$xswatchCss}>/xoops.css">
     <link rel="stylesheet" type="text/css" href="<{$themeUrl}><{$xswatchCss}>/bootstrap.min.css">

--- a/htdocs/themes/xswatch4/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xswatch4/modules/system/system_siteclosed.tpl
@@ -15,7 +15,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     -->
     <link href="<{$xoops_url}>/favicon.ico" rel="shortcut icon">
-    <link rel="stylesheet" type="text/css" href="<{$xoops_imageurl}>css/bootstrap.min.css">
+    <{include file="$theme_name/tpl/xswatchCss.tpl" assign="xswatchCss"}>
+    <link rel="stylesheet" type="text/css" href="<{$xoops_imageurl}><{$xswatchCss}>/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="<{xoAppUrl media/font-awesome/css/font-awesome.min.css}>">
     <link rel="stylesheet" type="text/css" media="all" href="<{$xoops_themecss}>">
     <script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>

--- a/htdocs/themes/xswatch4/theme.tpl
+++ b/htdocs/themes/xswatch4/theme.tpl
@@ -13,14 +13,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <link href="<{$xoops_url}>/favicon.ico" rel="shortcut icon">
-	
-	<{* pick the css directory you want to use in the assign var="xswatchCss" value below. *}>
-    <{* Valid values are css-cerulean, css-slate, css-darkly, css-journal... *}>
-    <{assign var="xswatchCss" value="css-cerulean"}>
+
+	<{* Edit tpl/xswatchCss.tpl to pick the css directory you want to use *}>
+    <{include file="$theme_name/tpl/xswatchCss.tpl" assign="xswatchCss"}>
     <link rel="stylesheet" type="text/css" href="<{xoImgUrl}><{$xswatchCss}>/xoops.css">
     <link rel="stylesheet" type="text/css" href="<{xoImgUrl}><{$xswatchCss}>/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="<{xoImgUrl}><{$xswatchCss}>/cookieconsent.css">
-	
+
     <script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>
     <script src="<{xoImgUrl}>js/bootstrap.bundle.min.js"></script>
     <{include file="$theme_name/tpl/cookieConsent.tpl"}>

--- a/htdocs/themes/xswatch4/tpl/xswatchCss.tpl
+++ b/htdocs/themes/xswatch4/tpl/xswatchCss.tpl
@@ -1,0 +1,9 @@
+<{* pick the css directory you want to use by entering its name on the bottom line.
+Valid values are:
+ css-cerulean  css-cosmo     css-cyborg    css-darkly    css-flaty
+ css-journal   css-litera    css-lumen     css-lux       css-materia
+ css-minty     css-pulse     css-sandstone css-simplex   css-sketchy
+ css-slate     css-solar     css-spacelab  css-superhero css-united
+ css-yeti
+*}>
+css-slate

--- a/htdocs/themes/xswatch4/tpl/xswatchCss.tpl
+++ b/htdocs/themes/xswatch4/tpl/xswatchCss.tpl
@@ -6,4 +6,4 @@ Valid values are:
  css-slate     css-solar     css-spacelab  css-superhero css-united
  css-yeti
 *}>
-css-slate
+css-cerulean


### PR DESCRIPTION
Moving the css selection to tpl/xswatchCss.tpl allows it to be shared with the light weight pages such as those using xoops_header()

Fixes #815