### PR TITLE
Add options text editing to profile field edit

### DIFF
--- a/htdocs/modules/profile/admin/field.php
+++ b/htdocs/modules/profile/admin/field.php
@@ -118,6 +118,17 @@ switch ($op) {
         $form->display();
         break;
 
+    case 'edit-option-strings':
+        $obj = $profilefield_handler->get($_REQUEST['id']);
+        $fieldOptions = $obj->getVar('field_options');
+        if (empty($fieldOptions)) { //If no option strings exist
+            redirect_header('field.php', 2, _PROFILE_AM_FIELDNOTCONFIGURABLE);
+        }
+        include_once dirname(__DIR__) . '/include/forms.php';
+        $form = profile_getFieldOptionForm($obj);
+        $form->display();
+        break;
+
     case 'reorder':
         if (!$GLOBALS['xoopsSecurity']->check()) {
             redirect_header('field.php', 3, implode(',', $GLOBALS['xoopsSecurity']->getErrors()));
@@ -289,6 +300,22 @@ switch ($op) {
         echo $obj->getHtmlErrors();
         $form = profile_getFieldForm($obj);
         $form->display();
+        break;
+
+    case 'save-option-strings':
+        if (!$GLOBALS['xoopsSecurity']->check()) {
+            redirect_header('field.php', 3, implode(',', $GLOBALS['xoopsSecurity']->getErrors()));
+        }
+        $obj = $profilefield_handler->get($_REQUEST['id']);
+        $fieldOptions = \Xmf\Request::getArray('field_options');
+        if (empty($fieldOptions)) { //If no option strings exist
+            redirect_header('field.php', 2, _PROFILE_AM_FIELDNOTCONFIGURABLE);
+        }
+        $obj->setVar('field_options', $fieldOptions);
+        if ($profilefield_handler->insert($obj)) {
+            redirect_header('field.php', 2, sprintf(_PROFILE_AM_SAVEDSUCCESS, _PROFILE_AM_FIELD));
+        }
+        redirect_header('field.php', 2, implode(',', $obj->getErrors()));
         break;
 
     case 'delete':

--- a/htdocs/modules/profile/include/forms.php
+++ b/htdocs/modules/profile/include/forms.php
@@ -265,6 +265,36 @@ function profile_getFieldForm(ProfileField $field, $action = false)
     $form->addElement(new XoopsFormHidden('op', 'save'));
     $form->addElement(new XoopsFormButton('', 'submit', _SUBMIT, 'submit'));
 
+    $options = $field->getVar('field_options');
+    if (count($options) > 0) {
+        $linkText = defined('_PROFILE_AM_EDIT_OPTION_STRINGS') ? _PROFILE_AM_EDIT_OPTION_STRINGS : 'Edit Option Strings';
+        $editOptionsButton = new XoopsFormLabel('','<a href="'.$action.'&op=edit-option-strings"><i class="fa fa-fw fa-2x fa-language" aria-hidden="true"></i> ' . $linkText . '</a>');
+        $form->addElement($editOptionsButton);
+    }
+
+    return $form;
+}
+
+function profile_getFieldOptionForm(ProfileField $field, $action = false)
+{
+    if ($action === false) {
+        $action = ''; // $_SERVER['REQUEST_URI'];
+    }
+    $title = sprintf(_PROFILE_AM_EDIT, _PROFILE_AM_FIELD);
+
+    include_once $GLOBALS['xoops']->path('class/xoopsformloader.php');
+    $form = new XoopsThemeForm($title, 'form', $action, 'post', true);
+
+    $form->addElement(new XoopsFormLabel(_PROFILE_AM_TITLE, $field->getVar('field_title', 'e')));
+
+    $options = $field->getVar('field_options');
+    foreach($options as $name=>$value) {
+        $form->addElement(new XoopsFormText($name, "field_options[$name]", 80, 255, $value));
+    }
+
+    $form->addElement(new XoopsFormHidden('op', 'save-option-strings'));
+    $form->addElement(new XoopsFormButton('', 'submit', _SUBMIT, 'submit'));
+
     return $form;
 }
 

--- a/htdocs/modules/profile/language/english/admin.php
+++ b/htdocs/modules/profile/language/english/admin.php
@@ -1,5 +1,5 @@
 <?php
-// 
+//
 // _LANGCODE: en
 // _CHARSET : UTF-8
 // Translator: XOOPS Translation Team
@@ -103,4 +103,5 @@ define('_PROFILE_AM_SAVESTEP_TOGGLE_SUCCESS', 'Successfully Changed Save After S
 define('_PROFILE_AM_SAVESTEP_TOGGLE_FAILED', "Changing 'Save After Step' Failed");
 //XOOPS 2.5.9
 define('_PROFILE_AM_CANNOTDEACTIVATEWEBMASTERS', 'You cannot deactivate Webmaster account');
-
+//XOOPS 2.5.11
+define('_PROFILE_AM_EDIT_OPTION_STRINGS', 'Edit option strings');

--- a/htdocs/modules/profile/xoops_version.php
+++ b/htdocs/modules/profile/xoops_version.php
@@ -24,7 +24,7 @@
  */
 $modversion                   = array();
 $modversion['name']           = _PROFILE_MI_NAME;
-$modversion['version']        = 1.90;
+$modversion['version']        = 1.91;
 $modversion['description']    = _PROFILE_MI_DESC;
 $modversion['author']         = 'Jan Pedersen, Taiwen Jiang, alfred, Wishcraft';
 $modversion['credits']        = 'Ackbarr, mboyden, marco, mamba, trabis, etc.';


### PR DESCRIPTION
Options taken from language files cannot be changed after installing the profile module.

This change adds an edit link to the form for any field that has options such as a select field. The edit screen presented allows updating the option text only, not the values.

Initial report here:
https://xoops.org/modules/newbb/viewtopic.php?topic_id=78808