### PR TITLE
Add macro substitutions for {X_SITEURL} and {X_YEAR}

### DIFF
--- a/htdocs/class/theme.php
+++ b/htdocs/class/theme.php
@@ -9,8 +9,8 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * @copyright       (c) 2000-2016 XOOPS Project (www.xoops.org)
- * @license             GNU GPL 2 (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @copyright       (c) 2000-2020 XOOPS Project (https://xoops.org)
+ * @license             GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
  * @author              Skalpa Keo <skalpa@xoops.org>
  * @author              Taiwen Jiang <phppp@users.sourceforge.net>
  * @since               2.3.0
@@ -359,8 +359,13 @@ class xos_opal_Theme
         $criteria->add(new Criteria('conf_catid', XOOPS_CONF_METAFOOTER));
         $config = $configHandler->getConfigs($criteria, true);
         foreach (array_keys($config) as $i) {
-            $name  = $config[$i]->getVar('conf_name', 'n');
+            $name = $config[$i]->getVar('conf_name', 'n');
             $value = $config[$i]->getVar('conf_value', 'n');
+            // limited substitutions for {X_SITEURL} and {X_YEAR}
+            if ($name === 'footer' || $name === 'meta_copyright') {
+                $value = str_replace('{X_SITEURL}', XOOPS_URL . '/', $value);
+                $value = str_replace('{X_YEAR}', date('Y', time()), $value);
+            }
             if (substr($name, 0, 5) === 'meta_') {
                 $this->addMeta('meta', substr($name, 5), $value);
             } else {

--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -205,7 +205,7 @@ function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $
     $dbm->insert('config', " VALUES (36, 0, 2, 'maxuname', '_MD_AM_MAXUNAME', '10', '_MD_AM_MAXUNAMEDSC', 'textbox', 'int', 3)");
     $dbm->insert('config', " VALUES (37, 0, 1, 'bad_ips', '_MD_AM_BADIPS', '" . addslashes(serialize(array('127.0.0.1'))) . "', '_MD_AM_BADIPSDSC', 'textarea', 'array', 42)");
     $dbm->insert('config', " VALUES (38, 0, 3, 'meta_keywords', '_MD_AM_METAKEY', 'xoops, web application framework, cms, content management system', '_MD_AM_METAKEYDSC', 'textarea', 'text', 0)");
-    $dbm->insert('config', " VALUES (39, 0, 3, 'footer', '_MD_AM_FOOTER', 'Powered by XOOPS &#169; 2001-" . date('Y', time()) . " <a href=\"http://xoops.org\" rel=\"external\" title=\"The XOOPS Project\">The XOOPS Project</a>', '_MD_AM_FOOTERDSC', 'textarea', 'text', 20)");
+    $dbm->insert('config', " VALUES (39, 0, 3, 'footer', '_MD_AM_FOOTER', 'Powered by XOOPS &#169; 2001-{X_YEAR} <a href=\"https://xoops.org\" rel=\"external\" title=\"The XOOPS Project\">The XOOPS Project</a>', '_MD_AM_FOOTERDSC', 'textarea', 'text', 20)");
     $dbm->insert('config', " VALUES (40, 0, 4, 'censor_enable', '_MD_AM_DOCENSOR', '0', '_MD_AM_DOCENSORDSC', 'yesno', 'int', 0)");
     $dbm->insert('config', " VALUES (41, 0, 4, 'censor_words', '_MD_AM_CENSORWRD', '" . addslashes(serialize(array(
                                                                                                                  'fuck',
@@ -218,7 +218,7 @@ function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $
     $dbm->insert('config', " VALUES (47, 0, 1, 'enable_badips', '_MD_AM_DOBADIPS', '0', '_MD_AM_DOBADIPSDSC', 'yesno', 'int', 40)");
     $dbm->insert('config', " VALUES (48, 0, 3, 'meta_rating', '_MD_AM_METARATING', 'general', '_MD_AM_METARATINGDSC', 'select', 'text', 4)");
     $dbm->insert('config', " VALUES (49, 0, 3, 'meta_author', '_MD_AM_METAAUTHOR', 'XOOPS', '_MD_AM_METAAUTHORDSC', 'textbox', 'text', 6)");
-    $dbm->insert('config', " VALUES (50, 0, 3, 'meta_copyright', '_MD_AM_METACOPYR', 'Copyright &#169; 2001-" . date('Y', time()) . "', '_MD_AM_METACOPYRDSC', 'textbox', 'text', 8)");
+    $dbm->insert('config', " VALUES (50, 0, 3, 'meta_copyright', '_MD_AM_METACOPYR', 'Copyright &#169; 2001-{X_YEAR}', '_MD_AM_METACOPYRDSC', 'textbox', 'text', 8)");
     $dbm->insert('config', " VALUES (51, 0, 3, 'meta_description', '_MD_AM_METADESC', 'XOOPS is a dynamic Object Oriented based open source portal script written in PHP.', '_MD_AM_METADESCDSC', 'textarea', 'text', 1)");
     $dbm->insert('config', " VALUES (52, 0, 2, 'allow_chgmail', '_MD_AM_ALLWCHGMAIL', '0', '_MD_AM_ALLWCHGMAILDSC', 'yesno', 'int', 3)");
     $dbm->insert('config', " VALUES (53, 0, 1, 'use_mysession', '_MD_AM_USEMYSESS', '1', '_MD_AM_USEMYSESSDSC', 'yesno', 'int', 19)");

--- a/htdocs/install/language/english/finish.php
+++ b/htdocs/install/language/english/finish.php
@@ -7,9 +7,9 @@
 $content .= "<h3>Your site</h3>
 <p>You can now access the <a href='../index.php'>home page of your site</a>.</p>
 <h3>Support</h3>
-<p>Visit <a href='http://xoops.org/' rel='external'>The XOOPS Project</a></p>
+<p>Visit <a href='https://xoops.org/' rel='external'>The XOOPS Project</a></p>
 <p><strong>ATTENTION :</strong> Your site currently contains the minimum functionality. 
-Please visit <a href='http://xoops.org/' rel='external' title='XOOPS Web Application System'>xoops.org</a> 
+Please visit <a href='https://xoops.org/' rel='external' title='XOOPS Web Application System'>xoops.org</a> 
 to learn more about extending XOOPS to present text pages, photo galleries, forums, and more, 
 with <em>modules</em> as well as customizing the look of your XOOPS with <em>themes</em>.</p>
 ";

--- a/htdocs/modules/system/language/english/help/preferences.html
+++ b/htdocs/modules/system/language/english/help/preferences.html
@@ -24,6 +24,9 @@
 
         Try to be accurate and honest in providing meta information. Don’t try to ‘<em>manipulate</em>’ search engines to gain a better ranking – they may recognise this behaviour and your site may be downgraded or blacklisted from their index.
 
+        <br><br>The <strong>Meta Copyright</strong> and <strong>Footer</strong> fields both support two substitution tags to simplify maintenance.
+        <br>&nbsp;- <strong>{X_SITEURL}</strong> will be replaced by the full URL to your site's main page.
+        <br>&nbsp;- <strong>{X_YEAR}</strong> will be replaced by the current four digit year. It eliminates the need to update the upper copyright date each year.
     </p>
 
     <h4 class="odd">Word Censoring Options</h4>

--- a/htdocs/themes/xbootstrap/theme.tpl
+++ b/htdocs/themes/xbootstrap/theme.tpl
@@ -8,6 +8,7 @@
     <meta name="robots" content="<{$xoops_meta_robots}>">
     <meta name="rating" content="<{$xoops_meta_rating}>">
     <meta name="author" content="<{$xoops_meta_author}>">
+    <meta name="copyright" content="<{$xoops_meta_copyright}>">
     <meta name="generator" content="XOOPS">
     <!--[if IE]>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->

--- a/htdocs/themes/xswatch/theme.tpl
+++ b/htdocs/themes/xswatch/theme.tpl
@@ -8,6 +8,7 @@
     <meta name="robots" content="<{$xoops_meta_robots}>">
     <meta name="rating" content="<{$xoops_meta_rating}>">
     <meta name="author" content="<{$xoops_meta_author}>">
+    <meta name="copyright" content="<{$xoops_meta_copyright}>">
     <meta name="generator" content="XOOPS">
     <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/htdocs/themes/xswatch4/theme.tpl
+++ b/htdocs/themes/xswatch4/theme.tpl
@@ -8,6 +8,7 @@
     <meta name="robots" content="<{$xoops_meta_robots}>">
     <meta name="rating" content="<{$xoops_meta_rating}>">
     <meta name="author" content="<{$xoops_meta_author}>">
+    <meta name="copyright" content="<{$xoops_meta_copyright}>">
     <meta name="generator" content="XOOPS">
     <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
Re: #846 - Adds macro substitutions for {X_SITEURL} and {X_YEAR}

In *Preferences -> Meta Tags and Footer* process substitutions for {X_SITEURL} and {X_YEAR} only in 'footer' and 'meta_copyright' fields.

- {X_SITEURL} is replaced by the site URL
- {X_YEAR} is replaced by the current year