### PR TITLE
allow StdClass to be cast to array when compiling foreach

### DIFF
--- a/htdocs/class/smarty/Smarty_Compiler.class.php
+++ b/htdocs/class/smarty/Smarty_Compiler.class.php
@@ -1192,7 +1192,7 @@ class Smarty_Compiler extends Smarty {
         }
 
         $output = '<?php ';
-        $output .= "\$_from = $from; if (!is_array(\$_from) && !is_object(\$_from)) { settype(\$_from, 'array'); }";
+        $output .= "\$_from = $from; if ((\$_from instanceof StdClass) || (!is_array(\$_from) && !is_object(\$_from))) { settype(\$_from, 'array'); }";
         if (isset($name)) {
             $foreach_props = "\$this->_foreach[$name]";
             $output .= "{$foreach_props} = array('total' => count(\$_from), 'iteration' => 0);\n";


### PR DESCRIPTION
see: https://github.com/smarty-php/smarty/pull/544