### PR TITLE
PHP 8 issues in system maintenance

### DIFF
--- a/htdocs/modules/system/admin/maintenance/main.php
+++ b/htdocs/modules/system/admin/maintenance/main.php
@@ -62,7 +62,7 @@ switch ($op) {
         $cache->addOptionArray($cache_arr);
         $form_maintenance->addElement($cache);
 
-        $form_maintenance->addElement(new XoopsFormRadioYN(_AM_SYSTEM_MAINTENANCE_SESSION, 'session', '', _YES, _NO));
+        $form_maintenance->addElement(new XoopsFormRadioYN(_AM_SYSTEM_MAINTENANCE_SESSION, 'session', 0, _YES, _NO));
 
         $tables_tray = new XoopsFormElementTray(_AM_SYSTEM_MAINTENANCE_TABLES, '');
         $tables_tray->setDescription(_AM_SYSTEM_MAINTENANCE_TABLES_DESC);
@@ -80,7 +80,7 @@ switch ($op) {
         $tables_tray->addElement($choice, false);
         $form_maintenance->addElement($tables_tray);
 
-        $form_maintenance->addElement(new XoopsFormRadioYN(_AM_SYSTEM_MAINTENANCE_AVATAR, 'avatar', '', _YES, _NO));
+        $form_maintenance->addElement(new XoopsFormRadioYN(_AM_SYSTEM_MAINTENANCE_AVATAR, 'avatar', 0, _YES, _NO));
 
         $form_maintenance->addElement(new XoopsFormHidden('op', 'maintenance_save'));
         $form_maintenance->addElement(new XoopsFormButton('', 'maintenance_save', _SUBMIT, 'submit'));

--- a/htdocs/modules/system/templates/admin/system_maintenance.html
+++ b/htdocs/modules/system/templates/admin/system_maintenance.html
@@ -2,11 +2,11 @@
 <{includeq file="db:system_header.tpl"}>
 <!-- Display mailusers form  -->
 <br>
-<{if $form_maintenance}>
+<{if $form_maintenance|default:false}>
     <div class="spacer"><{$form_maintenance}></div>
     <br>
     <div class="spacer"><{$form_dump}></div>
-<{elseif $maintenance}>
+<{elseif $maintenance|default:false}>
     <{if $verif_cache || $verif_session || $verif_avatar}>
         <table class="outer ui-corner-all" cellspacing="1">
             <tr>
@@ -45,7 +45,7 @@
         </table>
         <br>
     <{/if}>
-    <{if $verif_maintenance}>
+    <{if $verif_maintenance|default:false}>
         <{$result_maintenance}>
     <{/if}>
 <{else}>

--- a/htdocs/modules/system/templates/admin/system_maintenance.tpl
+++ b/htdocs/modules/system/templates/admin/system_maintenance.tpl
@@ -2,11 +2,11 @@
 <{includeq file="db:system_header.tpl"}>
 <!-- Display mailusers form  -->
 <br>
-<{if $form_maintenance}>
+<{if $form_maintenance|default:false}>
     <div class="spacer"><{$form_maintenance}></div>
     <br>
     <div class="spacer"><{$form_dump}></div>
-<{elseif $maintenance}>
+<{elseif $maintenance|default:false}>
     <{if $verif_cache || $verif_session || $verif_avatar}>
         <table class="outer ui-corner-all" cellspacing="1">
             <tr>
@@ -45,7 +45,7 @@
         </table>
         <br>
     <{/if}>
-    <{if $verif_maintenance}>
+    <{if $verif_maintenance|default:false}>
         <{$result_maintenance}>
     <{/if}>
 <{else}>


### PR DESCRIPTION
- **Changed behavior** in XoopsFormRadioYN value (value of empty string is not considered NO) - change to 0
- provide default value for possibly undefined variable in template