### PR TITLE
Replace index.html with index.php

### DIFF
--- a/htdocs/Frameworks/art/index.html
+++ b/htdocs/Frameworks/art/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/art/index.php
+++ b/htdocs/Frameworks/art/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/compat/include/index.html
+++ b/htdocs/Frameworks/compat/include/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/compat/include/index.php
+++ b/htdocs/Frameworks/compat/include/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/compat/index.html
+++ b/htdocs/Frameworks/compat/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/compat/index.php
+++ b/htdocs/Frameworks/compat/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/index.html
+++ b/htdocs/Frameworks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/index.php
+++ b/htdocs/Frameworks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/icons/16/index.html
+++ b/htdocs/Frameworks/moduleclasses/icons/16/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/icons/16/index.php
+++ b/htdocs/Frameworks/moduleclasses/icons/16/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/icons/32/index.html
+++ b/htdocs/Frameworks/moduleclasses/icons/32/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/icons/32/index.php
+++ b/htdocs/Frameworks/moduleclasses/icons/32/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/icons/bookmarks/index.html
+++ b/htdocs/Frameworks/moduleclasses/icons/bookmarks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/icons/bookmarks/index.php
+++ b/htdocs/Frameworks/moduleclasses/icons/bookmarks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/icons/index.html
+++ b/htdocs/Frameworks/moduleclasses/icons/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/icons/index.php
+++ b/htdocs/Frameworks/moduleclasses/icons/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/index.html
+++ b/htdocs/Frameworks/moduleclasses/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/index.php
+++ b/htdocs/Frameworks/moduleclasses/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/css/index.html
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/css/index.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/doc/index.html
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/doc/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/doc/index.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/doc/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/images/index.html
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/images/index.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/index.html
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/index.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/language/english/index.html
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/language/english/index.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/language/index.html
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/language/index.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/Frameworks/textsanitizer/index.html
+++ b/htdocs/Frameworks/textsanitizer/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/Frameworks/textsanitizer/index.php
+++ b/htdocs/Frameworks/textsanitizer/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/cache/index.html
+++ b/htdocs/cache/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/cache/index.php
+++ b/htdocs/cache/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/auth/index.html
+++ b/htdocs/class/auth/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/auth/index.php
+++ b/htdocs/class/auth/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/cache/index.html
+++ b/htdocs/class/cache/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/cache/index.php
+++ b/htdocs/class/cache/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/captcha/image/backgrounds/index.html
+++ b/htdocs/class/captcha/image/backgrounds/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/captcha/image/backgrounds/index.php
+++ b/htdocs/class/captcha/image/backgrounds/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/captcha/image/fonts/index.html
+++ b/htdocs/class/captcha/image/fonts/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/captcha/image/fonts/index.php
+++ b/htdocs/class/captcha/image/fonts/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/captcha/image/index.html
+++ b/htdocs/class/captcha/image/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/captcha/image/index.php
+++ b/htdocs/class/captcha/image/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/captcha/image/scripts/index.html
+++ b/htdocs/class/captcha/image/scripts/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/captcha/image/scripts/index.php
+++ b/htdocs/class/captcha/image/scripts/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/captcha/index.html
+++ b/htdocs/class/captcha/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/captcha/index.php
+++ b/htdocs/class/captcha/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/database/index.html
+++ b/htdocs/class/database/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/database/index.php
+++ b/htdocs/class/database/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/file/index.html
+++ b/htdocs/class/file/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/file/index.php
+++ b/htdocs/class/file/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/index.html
+++ b/htdocs/class/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/index.php
+++ b/htdocs/class/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/libraries/local/index.html
+++ b/htdocs/class/libraries/local/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/libraries/local/index.php
+++ b/htdocs/class/libraries/local/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/libraries/vendor/xoops/xmf/index.html
+++ b/htdocs/class/libraries/vendor/xoops/xmf/index.html
@@ -1,1 +1,0 @@
- <script>history.go(-1);</script>

--- a/htdocs/class/libraries/vendor/xoops/xmf/index.php
+++ b/htdocs/class/libraries/vendor/xoops/xmf/index.php
@@ -1,0 +1,2 @@
+ <?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/libraries/vendor/xoops/xmf/src/Database/index.html
+++ b/htdocs/class/libraries/vendor/xoops/xmf/src/Database/index.html
@@ -1,1 +1,0 @@
- <script>history.go(-1);</script>

--- a/htdocs/class/libraries/vendor/xoops/xmf/src/Database/index.php
+++ b/htdocs/class/libraries/vendor/xoops/xmf/src/Database/index.php
@@ -1,0 +1,2 @@
+ <?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/libraries/vendor/xoops/xmf/src/Module/index.html
+++ b/htdocs/class/libraries/vendor/xoops/xmf/src/Module/index.html
@@ -1,1 +1,0 @@
- <script>history.go(-1);</script>

--- a/htdocs/class/libraries/vendor/xoops/xmf/src/Module/index.php
+++ b/htdocs/class/libraries/vendor/xoops/xmf/src/Module/index.php
@@ -1,0 +1,2 @@
+ <?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/libraries/vendor/xoops/xmf/src/index.html
+++ b/htdocs/class/libraries/vendor/xoops/xmf/src/index.html
@@ -1,1 +1,0 @@
- <script>history.go(-1);</script>

--- a/htdocs/class/libraries/vendor/xoops/xmf/src/index.php
+++ b/htdocs/class/libraries/vendor/xoops/xmf/src/index.php
@@ -1,0 +1,2 @@
+ <?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/logger/index.html
+++ b/htdocs/class/logger/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/logger/index.php
+++ b/htdocs/class/logger/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/mail/index.html
+++ b/htdocs/class/mail/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/mail/index.php
+++ b/htdocs/class/mail/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/mail/phpmailer/index.html
+++ b/htdocs/class/mail/phpmailer/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/mail/phpmailer/index.php
+++ b/htdocs/class/mail/phpmailer/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/mail/phpmailer/language/index.html
+++ b/htdocs/class/mail/phpmailer/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/mail/phpmailer/language/index.php
+++ b/htdocs/class/mail/phpmailer/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/model/index.html
+++ b/htdocs/class/model/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/model/index.php
+++ b/htdocs/class/model/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/preload.php
+++ b/htdocs/class/preload.php
@@ -30,8 +30,8 @@ XoopsLoad::load('XoopsCache');
 /**
  * Class for handling events
  *
- * @copyright       (c) 2000-2016 XOOPS Project (www.xoops.org)
- * @license             GNU GPL 2 (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @copyright       (c) 2000-2020 XOOPS Project (https://xoops.org)
+ * @license             GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
  * @package             kernel
  * @subpackage          class
  * @author              trabis <lusopoemas@gmail.com>
@@ -88,10 +88,12 @@ class XoopsPreload
                     $file_list = XoopsLists::getFileListAsArray($dir);
                     foreach ($file_list as $file) {
                         if (preg_match('/(\.php)$/i', $file)) {
-                            $file                          = substr($file, 0, -4);
-                            $this->_preloads[$i]['module'] = $module;
-                            $this->_preloads[$i]['file']   = $file;
-                            ++$i;
+                            $file = substr($file, 0, -4);
+                            if ('index' !== $file) {
+                                $this->_preloads[$i]['module'] = $module;
+                                $this->_preloads[$i]['file'] = $file;
+                                ++$i;
+                            }
                         }
                     }
                 }

--- a/htdocs/class/smarty/configs/index.html
+++ b/htdocs/class/smarty/configs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/smarty/configs/index.php
+++ b/htdocs/class/smarty/configs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/smarty/index.html
+++ b/htdocs/class/smarty/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/smarty/index.php
+++ b/htdocs/class/smarty/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/smarty/internals/index.html
+++ b/htdocs/class/smarty/internals/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/smarty/internals/index.php
+++ b/htdocs/class/smarty/internals/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/smarty/plugins/index.html
+++ b/htdocs/class/smarty/plugins/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/smarty/plugins/index.php
+++ b/htdocs/class/smarty/plugins/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/smarty/xoops_plugins/index.html
+++ b/htdocs/class/smarty/xoops_plugins/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/smarty/xoops_plugins/index.php
+++ b/htdocs/class/smarty/xoops_plugins/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/censor/index.html
+++ b/htdocs/class/textsanitizer/censor/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/censor/index.php
+++ b/htdocs/class/textsanitizer/censor/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/flash/index.html
+++ b/htdocs/class/textsanitizer/flash/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/flash/index.php
+++ b/htdocs/class/textsanitizer/flash/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/iframe/index.html
+++ b/htdocs/class/textsanitizer/iframe/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/iframe/index.php
+++ b/htdocs/class/textsanitizer/iframe/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/image/index.html
+++ b/htdocs/class/textsanitizer/image/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/image/index.php
+++ b/htdocs/class/textsanitizer/image/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/index.html
+++ b/htdocs/class/textsanitizer/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/index.php
+++ b/htdocs/class/textsanitizer/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/li/index.html
+++ b/htdocs/class/textsanitizer/li/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/li/index.php
+++ b/htdocs/class/textsanitizer/li/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/mms/index.html
+++ b/htdocs/class/textsanitizer/mms/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/mms/index.php
+++ b/htdocs/class/textsanitizer/mms/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/mp3/index.html
+++ b/htdocs/class/textsanitizer/mp3/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/mp3/index.php
+++ b/htdocs/class/textsanitizer/mp3/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/rtsp/index.html
+++ b/htdocs/class/textsanitizer/rtsp/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/rtsp/index.php
+++ b/htdocs/class/textsanitizer/rtsp/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/soundcloud/index.html
+++ b/htdocs/class/textsanitizer/soundcloud/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/soundcloud/index.php
+++ b/htdocs/class/textsanitizer/soundcloud/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/syntaxhighlight/index.html
+++ b/htdocs/class/textsanitizer/syntaxhighlight/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/syntaxhighlight/index.php
+++ b/htdocs/class/textsanitizer/syntaxhighlight/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/textfilter/index.html
+++ b/htdocs/class/textsanitizer/textfilter/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/textfilter/index.php
+++ b/htdocs/class/textsanitizer/textfilter/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/ul/index.html
+++ b/htdocs/class/textsanitizer/ul/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/ul/index.php
+++ b/htdocs/class/textsanitizer/ul/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/wiki/index.html
+++ b/htdocs/class/textsanitizer/wiki/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/wiki/index.php
+++ b/htdocs/class/textsanitizer/wiki/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/wmp/index.html
+++ b/htdocs/class/textsanitizer/wmp/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/wmp/index.php
+++ b/htdocs/class/textsanitizer/wmp/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/textsanitizer/youtube/index.html
+++ b/htdocs/class/textsanitizer/youtube/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/textsanitizer/youtube/index.php
+++ b/htdocs/class/textsanitizer/youtube/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/utility/index.html
+++ b/htdocs/class/utility/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/utility/index.php
+++ b/htdocs/class/utility/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xml/index.html
+++ b/htdocs/class/xml/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xml/index.php
+++ b/htdocs/class/xml/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xml/rpc/index.html
+++ b/htdocs/class/xml/rpc/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xml/rpc/index.php
+++ b/htdocs/class/xml/rpc/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xml/rss/index.html
+++ b/htdocs/class/xml/rss/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xml/rss/index.php
+++ b/htdocs/class/xml/rss/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/dhtmltextarea/index.html
+++ b/htdocs/class/xoopseditor/dhtmltextarea/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/dhtmltextarea/index.php
+++ b/htdocs/class/xoopseditor/dhtmltextarea/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/dhtmltextarea/language/index.html
+++ b/htdocs/class/xoopseditor/dhtmltextarea/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/dhtmltextarea/language/index.php
+++ b/htdocs/class/xoopseditor/dhtmltextarea/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/index.html
+++ b/htdocs/class/xoopseditor/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/index.php
+++ b/htdocs/class/xoopseditor/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/textarea/index.html
+++ b/htdocs/class/xoopseditor/textarea/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/textarea/index.php
+++ b/htdocs/class/xoopseditor/textarea/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/textarea/language/index.html
+++ b/htdocs/class/xoopseditor/textarea/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/textarea/language/index.php
+++ b/htdocs/class/xoopseditor/textarea/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/include/index.html
+++ b/htdocs/class/xoopseditor/tinymce/include/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/include/index.php
+++ b/htdocs/class/xoopseditor/tinymce/include/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/index.html
+++ b/htdocs/class/xoopseditor/tinymce/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/index.php
+++ b/htdocs/class/xoopseditor/tinymce/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/language/index.html
+++ b/htdocs/class/xoopseditor/tinymce/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/language/index.php
+++ b/htdocs/class/xoopseditor/tinymce/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advhr/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advimage/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlink/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlist/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlist/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlist/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/advlist/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autolink/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autolink/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autolink/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autolink/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autoresize/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autoresize/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autoresize/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autoresize/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autosave/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autosave/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autosave/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/autosave/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/bbcode/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/bbcode/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/bbcode/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/bbcode/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/contextmenu/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/contextmenu/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/contextmenu/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/contextmenu/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/directionality/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/directionality/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/directionality/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/directionality/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/emotions/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example_dependency/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example_dependency/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example_dependency/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/example_dependency/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullpage/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullscreen/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullscreen/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullscreen/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/fullscreen/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/iespell/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/iespell/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/iespell/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/iespell/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/clearlooks2/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/clearlooks2/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/clearlooks2/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/clearlooks2/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/clearlooks2/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/clearlooks2/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/clearlooks2/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/clearlooks2/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/inlinepopups/skins/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/insertdatetime/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/insertdatetime/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/insertdatetime/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/insertdatetime/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/layer/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/layer/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/layer/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/layer/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/legacyoutput/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/legacyoutput/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/legacyoutput/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/legacyoutput/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/lists/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/lists/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/lists/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/lists/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/media/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/nonbreaking/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/nonbreaking/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/nonbreaking/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/nonbreaking/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/noneditable/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/noneditable/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/noneditable/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/noneditable/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/pagebreak/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/pagebreak/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/pagebreak/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/pagebreak/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/paste/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/preview/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/preview/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/preview/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/preview/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/preview/jscripts/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/preview/jscripts/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/preview/jscripts/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/preview/jscripts/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/print/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/print/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/print/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/print/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/save/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/save/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/save/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/save/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/searchreplace/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/spellchecker/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/style/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/tabfocus/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/tabfocus/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/tabfocus/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/tabfocus/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/table/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/template/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualblocks/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualblocks/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualblocks/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualblocks/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualblocks/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualblocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualblocks/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualblocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualchars/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualchars/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualchars/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/visualchars/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/wordcount/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/wordcount/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/wordcount/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/wordcount/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xhtmlxtras/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopscode/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsemotions/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsimagemanager/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/css/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/css/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsmlcontent/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/plugins/xoopsquote/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/js/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/js/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/default/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/default/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/default/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/default/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/default/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/default/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/default/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/default/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/highcontrast/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/highcontrast/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/highcontrast/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/highcontrast/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/o2k7/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/o2k7/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/o2k7/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/o2k7/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/o2k7/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/o2k7/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/o2k7/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/advanced/skins/o2k7/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/langs/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/langs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/langs/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/langs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/default/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/default/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/default/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/default/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/o2k7/img/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/o2k7/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/o2k7/img/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/o2k7/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/o2k7/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/o2k7/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/o2k7/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/themes/simple/skins/o2k7/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/utils/index.html
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/utils/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/utils/index.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce/jscripts/tiny_mce/utils/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/class/xoopsform/index.html
+++ b/htdocs/class/xoopsform/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/class/xoopsform/index.php
+++ b/htdocs/class/xoopsform/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/images/banners/index.html
+++ b/htdocs/images/banners/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/images/banners/index.php
+++ b/htdocs/images/banners/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/images/form/index.html
+++ b/htdocs/images/form/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/images/form/index.php
+++ b/htdocs/images/form/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/images/index.html
+++ b/htdocs/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/images/index.php
+++ b/htdocs/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/images/subject/index.html
+++ b/htdocs/images/subject/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/images/subject/index.php
+++ b/htdocs/images/subject/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/include/index.html
+++ b/htdocs/include/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/include/index.php
+++ b/htdocs/include/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/assets/css/index.html
+++ b/htdocs/install/assets/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/assets/css/index.php
+++ b/htdocs/install/assets/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/assets/fonts/index.html
+++ b/htdocs/install/assets/fonts/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/assets/fonts/index.php
+++ b/htdocs/install/assets/fonts/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/assets/img/index.html
+++ b/htdocs/install/assets/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/assets/img/index.php
+++ b/htdocs/install/assets/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/assets/index.html
+++ b/htdocs/install/assets/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/assets/index.php
+++ b/htdocs/install/assets/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/assets/js/index.html
+++ b/htdocs/install/assets/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/assets/js/index.php
+++ b/htdocs/install/assets/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/class/index.html
+++ b/htdocs/install/class/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/class/index.php
+++ b/htdocs/install/class/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/include/index.html
+++ b/htdocs/install/include/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/include/index.php
+++ b/htdocs/install/include/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/language/english/index.html
+++ b/htdocs/install/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/language/english/index.php
+++ b/htdocs/install/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/language/index.html
+++ b/htdocs/install/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/language/index.php
+++ b/htdocs/install/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/install/sql/index.html
+++ b/htdocs/install/sql/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/install/sql/index.php
+++ b/htdocs/install/sql/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/kernel/index.html
+++ b/htdocs/kernel/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/kernel/index.php
+++ b/htdocs/kernel/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/language/english/index.html
+++ b/htdocs/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/language/english/index.php
+++ b/htdocs/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/language/english/mail_template/index.html
+++ b/htdocs/language/english/mail_template/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/language/english/mail_template/index.php
+++ b/htdocs/language/english/mail_template/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/language/index.html
+++ b/htdocs/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/language/index.php
+++ b/htdocs/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/media/fine-uploader/index.html
+++ b/htdocs/media/fine-uploader/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/media/fine-uploader/index.php
+++ b/htdocs/media/fine-uploader/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/index.html
+++ b/htdocs/modules/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/index.php
+++ b/htdocs/modules/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/assets/css/index.html
+++ b/htdocs/modules/pm/assets/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/assets/css/index.php
+++ b/htdocs/modules/pm/assets/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/assets/images/index.html
+++ b/htdocs/modules/pm/assets/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/assets/images/index.php
+++ b/htdocs/modules/pm/assets/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/assets/index.html
+++ b/htdocs/modules/pm/assets/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/assets/index.php
+++ b/htdocs/modules/pm/assets/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/assets/js/index.html
+++ b/htdocs/modules/pm/assets/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/assets/js/index.php
+++ b/htdocs/modules/pm/assets/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/class/index.html
+++ b/htdocs/modules/pm/class/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/class/index.php
+++ b/htdocs/modules/pm/class/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/docs/index.html
+++ b/htdocs/modules/pm/docs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/docs/index.php
+++ b/htdocs/modules/pm/docs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/include/index.html
+++ b/htdocs/modules/pm/include/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/include/index.php
+++ b/htdocs/modules/pm/include/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/language/english/help/index.html
+++ b/htdocs/modules/pm/language/english/help/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/language/english/help/index.php
+++ b/htdocs/modules/pm/language/english/help/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/language/english/index.html
+++ b/htdocs/modules/pm/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/language/english/index.php
+++ b/htdocs/modules/pm/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/language/index.html
+++ b/htdocs/modules/pm/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/language/index.php
+++ b/htdocs/modules/pm/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/preloads/index.html
+++ b/htdocs/modules/pm/preloads/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/preloads/index.php
+++ b/htdocs/modules/pm/preloads/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/sql/index.html
+++ b/htdocs/modules/pm/sql/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/sql/index.php
+++ b/htdocs/modules/pm/sql/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/pm/templates/index.html
+++ b/htdocs/modules/pm/templates/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/pm/templates/index.php
+++ b/htdocs/modules/pm/templates/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/assets/css/index.html
+++ b/htdocs/modules/profile/assets/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/assets/css/index.php
+++ b/htdocs/modules/profile/assets/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/assets/images/actions/index.html
+++ b/htdocs/modules/profile/assets/images/actions/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/assets/images/actions/index.php
+++ b/htdocs/modules/profile/assets/images/actions/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/assets/images/index.html
+++ b/htdocs/modules/profile/assets/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/assets/images/index.php
+++ b/htdocs/modules/profile/assets/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/assets/index.html
+++ b/htdocs/modules/profile/assets/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/assets/index.php
+++ b/htdocs/modules/profile/assets/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/assets/js/index.html
+++ b/htdocs/modules/profile/assets/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/assets/js/index.php
+++ b/htdocs/modules/profile/assets/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/class/index.html
+++ b/htdocs/modules/profile/class/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/class/index.php
+++ b/htdocs/modules/profile/class/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/docs/index.html
+++ b/htdocs/modules/profile/docs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/docs/index.php
+++ b/htdocs/modules/profile/docs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/include/index.html
+++ b/htdocs/modules/profile/include/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/include/index.php
+++ b/htdocs/modules/profile/include/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/language/english/help/index.html
+++ b/htdocs/modules/profile/language/english/help/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/language/english/help/index.php
+++ b/htdocs/modules/profile/language/english/help/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/language/english/index.html
+++ b/htdocs/modules/profile/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/language/english/index.php
+++ b/htdocs/modules/profile/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/language/english/mail_template/index.html
+++ b/htdocs/modules/profile/language/english/mail_template/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/language/english/mail_template/index.php
+++ b/htdocs/modules/profile/language/english/mail_template/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/language/index.html
+++ b/htdocs/modules/profile/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/language/index.php
+++ b/htdocs/modules/profile/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/preloads/index.html
+++ b/htdocs/modules/profile/preloads/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/preloads/index.php
+++ b/htdocs/modules/profile/preloads/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/sql/index.html
+++ b/htdocs/modules/profile/sql/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/sql/index.php
+++ b/htdocs/modules/profile/sql/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/profile/templates/index.html
+++ b/htdocs/modules/profile/templates/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/profile/templates/index.php
+++ b/htdocs/modules/profile/templates/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/protector/blocks/index.html
+++ b/htdocs/modules/protector/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/protector/blocks/index.php
+++ b/htdocs/modules/protector/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/protector/docs/index.html
+++ b/htdocs/modules/protector/docs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/protector/docs/index.php
+++ b/htdocs/modules/protector/docs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/protector/images/index.html
+++ b/htdocs/modules/protector/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/protector/images/index.php
+++ b/htdocs/modules/protector/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/protector/language/english/help/index.html
+++ b/htdocs/modules/protector/language/english/help/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/protector/language/english/help/index.php
+++ b/htdocs/modules/protector/language/english/help/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/protector/language/english/index.html
+++ b/htdocs/modules/protector/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/protector/language/english/index.php
+++ b/htdocs/modules/protector/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/protector/language/index.html
+++ b/htdocs/modules/protector/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/protector/language/index.php
+++ b/htdocs/modules/protector/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/protector/preload/index.html
+++ b/htdocs/modules/protector/preload/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/protector/preload/index.php
+++ b/htdocs/modules/protector/preload/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/protector/preloads/index.html
+++ b/htdocs/modules/protector/preloads/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/protector/preloads/index.php
+++ b/htdocs/modules/protector/preloads/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/avatars/index.html
+++ b/htdocs/modules/system/admin/avatars/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/avatars/index.php
+++ b/htdocs/modules/system/admin/avatars/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/banners/index.html
+++ b/htdocs/modules/system/admin/banners/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/banners/index.php
+++ b/htdocs/modules/system/admin/banners/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/blocksadmin/index.html
+++ b/htdocs/modules/system/admin/blocksadmin/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/blocksadmin/index.php
+++ b/htdocs/modules/system/admin/blocksadmin/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/comments/index.html
+++ b/htdocs/modules/system/admin/comments/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/comments/index.php
+++ b/htdocs/modules/system/admin/comments/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/groups/index.html
+++ b/htdocs/modules/system/admin/groups/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/groups/index.php
+++ b/htdocs/modules/system/admin/groups/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/images/index.html
+++ b/htdocs/modules/system/admin/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/images/index.php
+++ b/htdocs/modules/system/admin/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/index.html
+++ b/htdocs/modules/system/admin/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/index.php
+++ b/htdocs/modules/system/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/mailusers/index.html
+++ b/htdocs/modules/system/admin/mailusers/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/mailusers/index.php
+++ b/htdocs/modules/system/admin/mailusers/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/maintenance/dump/index.html
+++ b/htdocs/modules/system/admin/maintenance/dump/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/maintenance/dump/index.php
+++ b/htdocs/modules/system/admin/maintenance/dump/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/maintenance/index.html
+++ b/htdocs/modules/system/admin/maintenance/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/maintenance/index.php
+++ b/htdocs/modules/system/admin/maintenance/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/modulesadmin/index.html
+++ b/htdocs/modules/system/admin/modulesadmin/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/modulesadmin/index.php
+++ b/htdocs/modules/system/admin/modulesadmin/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/preferences/index.html
+++ b/htdocs/modules/system/admin/preferences/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/preferences/index.php
+++ b/htdocs/modules/system/admin/preferences/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/smilies/index.html
+++ b/htdocs/modules/system/admin/smilies/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/smilies/index.php
+++ b/htdocs/modules/system/admin/smilies/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/tplsets/index.html
+++ b/htdocs/modules/system/admin/tplsets/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/tplsets/index.php
+++ b/htdocs/modules/system/admin/tplsets/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/userrank/index.html
+++ b/htdocs/modules/system/admin/userrank/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/userrank/index.php
+++ b/htdocs/modules/system/admin/userrank/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/admin/users/index.html
+++ b/htdocs/modules/system/admin/users/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/admin/users/index.php
+++ b/htdocs/modules/system/admin/users/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/blocks/index.html
+++ b/htdocs/modules/system/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/blocks/index.php
+++ b/htdocs/modules/system/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/class/index.html
+++ b/htdocs/modules/system/class/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/class/index.php
+++ b/htdocs/modules/system/class/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/class/thumbs/fonts/index.html
+++ b/htdocs/modules/system/class/thumbs/fonts/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/class/thumbs/fonts/index.php
+++ b/htdocs/modules/system/class/thumbs/fonts/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/class/thumbs/index.html
+++ b/htdocs/modules/system/class/thumbs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/class/thumbs/index.php
+++ b/htdocs/modules/system/class/thumbs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/code_mirror/index.html
+++ b/htdocs/modules/system/css/code_mirror/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/code_mirror/index.php
+++ b/htdocs/modules/system/css/code_mirror/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/index.html
+++ b/htdocs/modules/system/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/index.php
+++ b/htdocs/modules/system/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/base/images/index.html
+++ b/htdocs/modules/system/css/ui/base/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/base/images/index.php
+++ b/htdocs/modules/system/css/ui/base/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/base/index.html
+++ b/htdocs/modules/system/css/ui/base/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/base/index.php
+++ b/htdocs/modules/system/css/ui/base/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/base/minified/images/index.html
+++ b/htdocs/modules/system/css/ui/base/minified/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/base/minified/images/index.php
+++ b/htdocs/modules/system/css/ui/base/minified/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/base/minified/index.html
+++ b/htdocs/modules/system/css/ui/base/minified/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/base/minified/index.php
+++ b/htdocs/modules/system/css/ui/base/minified/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/cupertino/images/index.html
+++ b/htdocs/modules/system/css/ui/cupertino/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/cupertino/images/index.php
+++ b/htdocs/modules/system/css/ui/cupertino/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/cupertino/index.html
+++ b/htdocs/modules/system/css/ui/cupertino/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/cupertino/index.php
+++ b/htdocs/modules/system/css/ui/cupertino/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/index.html
+++ b/htdocs/modules/system/css/ui/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/index.php
+++ b/htdocs/modules/system/css/ui/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/redmond/images/index.html
+++ b/htdocs/modules/system/css/ui/redmond/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/redmond/images/index.php
+++ b/htdocs/modules/system/css/ui/redmond/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/redmond/index.html
+++ b/htdocs/modules/system/css/ui/redmond/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/redmond/index.php
+++ b/htdocs/modules/system/css/ui/redmond/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/smoothness/images/index.html
+++ b/htdocs/modules/system/css/ui/smoothness/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/smoothness/images/index.php
+++ b/htdocs/modules/system/css/ui/smoothness/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/smoothness/index.html
+++ b/htdocs/modules/system/css/ui/smoothness/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/smoothness/index.php
+++ b/htdocs/modules/system/css/ui/smoothness/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/south-street/images/index.html
+++ b/htdocs/modules/system/css/ui/south-street/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/south-street/images/index.php
+++ b/htdocs/modules/system/css/ui/south-street/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/south-street/index.html
+++ b/htdocs/modules/system/css/ui/south-street/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/south-street/index.php
+++ b/htdocs/modules/system/css/ui/south-street/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/ui-darkness/images/index.html
+++ b/htdocs/modules/system/css/ui/ui-darkness/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/ui-darkness/images/index.php
+++ b/htdocs/modules/system/css/ui/ui-darkness/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/ui-darkness/index.html
+++ b/htdocs/modules/system/css/ui/ui-darkness/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/ui-darkness/index.php
+++ b/htdocs/modules/system/css/ui/ui-darkness/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/ui-lightness/images/index.html
+++ b/htdocs/modules/system/css/ui/ui-lightness/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/ui-lightness/images/index.php
+++ b/htdocs/modules/system/css/ui/ui-lightness/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/css/ui/ui-lightness/index.html
+++ b/htdocs/modules/system/css/ui/ui-lightness/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/css/ui/ui-lightness/index.php
+++ b/htdocs/modules/system/css/ui/ui-lightness/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/breadcrumb/default/index.html
+++ b/htdocs/modules/system/images/breadcrumb/default/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/breadcrumb/default/index.php
+++ b/htdocs/modules/system/images/breadcrumb/default/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/breadcrumb/index.html
+++ b/htdocs/modules/system/images/breadcrumb/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/breadcrumb/index.php
+++ b/htdocs/modules/system/images/breadcrumb/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/icons/default/index.html
+++ b/htdocs/modules/system/images/icons/default/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/icons/default/index.php
+++ b/htdocs/modules/system/images/icons/default/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/icons/default/xoops/index.html
+++ b/htdocs/modules/system/images/icons/default/xoops/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/icons/default/xoops/index.php
+++ b/htdocs/modules/system/images/icons/default/xoops/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/icons/index.html
+++ b/htdocs/modules/system/images/icons/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/icons/index.php
+++ b/htdocs/modules/system/images/icons/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/icons/transition/index.html
+++ b/htdocs/modules/system/images/icons/transition/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/icons/transition/index.php
+++ b/htdocs/modules/system/images/icons/transition/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/icons/transition/xoops/index.html
+++ b/htdocs/modules/system/images/icons/transition/xoops/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/icons/transition/xoops/index.php
+++ b/htdocs/modules/system/images/icons/transition/xoops/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/index.html
+++ b/htdocs/modules/system/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/index.php
+++ b/htdocs/modules/system/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/menu/index.html
+++ b/htdocs/modules/system/images/menu/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/menu/index.php
+++ b/htdocs/modules/system/images/menu/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/images/mimetypes/index.html
+++ b/htdocs/modules/system/images/mimetypes/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/images/mimetypes/index.php
+++ b/htdocs/modules/system/images/mimetypes/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/include/index.html
+++ b/htdocs/modules/system/include/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/include/index.php
+++ b/htdocs/modules/system/include/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/index.html
+++ b/htdocs/modules/system/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/index.php
+++ b/htdocs/modules/system/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/js/code_mirror/index.html
+++ b/htdocs/modules/system/js/code_mirror/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/js/code_mirror/index.php
+++ b/htdocs/modules/system/js/code_mirror/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/js/index.html
+++ b/htdocs/modules/system/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/js/index.php
+++ b/htdocs/modules/system/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/language/english/admin/index.html
+++ b/htdocs/modules/system/language/english/admin/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/language/english/admin/index.php
+++ b/htdocs/modules/system/language/english/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/language/english/help/index.html
+++ b/htdocs/modules/system/language/english/help/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/language/english/help/index.php
+++ b/htdocs/modules/system/language/english/help/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/language/english/images/index.html
+++ b/htdocs/modules/system/language/english/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/language/english/images/index.php
+++ b/htdocs/modules/system/language/english/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/language/english/index.html
+++ b/htdocs/modules/system/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/language/english/index.php
+++ b/htdocs/modules/system/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/language/index.html
+++ b/htdocs/modules/system/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/language/index.php
+++ b/htdocs/modules/system/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/preloads/index.html
+++ b/htdocs/modules/system/preloads/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/preloads/index.php
+++ b/htdocs/modules/system/preloads/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/templates/admin/index.html
+++ b/htdocs/modules/system/templates/admin/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/templates/admin/index.php
+++ b/htdocs/modules/system/templates/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/templates/blocks/index.html
+++ b/htdocs/modules/system/templates/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/templates/blocks/index.php
+++ b/htdocs/modules/system/templates/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/templates/index.html
+++ b/htdocs/modules/system/templates/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/templates/index.php
+++ b/htdocs/modules/system/templates/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/css/index.html
+++ b/htdocs/modules/system/themes/default/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/css/index.php
+++ b/htdocs/modules/system/themes/default/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/icons/index.html
+++ b/htdocs/modules/system/themes/default/icons/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/icons/index.php
+++ b/htdocs/modules/system/themes/default/icons/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/img/dark/index.html
+++ b/htdocs/modules/system/themes/default/img/dark/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/img/dark/index.php
+++ b/htdocs/modules/system/themes/default/img/dark/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/img/index.html
+++ b/htdocs/modules/system/themes/default/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/img/index.php
+++ b/htdocs/modules/system/themes/default/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/img/orange/index.html
+++ b/htdocs/modules/system/themes/default/img/orange/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/img/orange/index.php
+++ b/htdocs/modules/system/themes/default/img/orange/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/img/silver/index.html
+++ b/htdocs/modules/system/themes/default/img/silver/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/img/silver/index.php
+++ b/htdocs/modules/system/themes/default/img/silver/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/index.html
+++ b/htdocs/modules/system/themes/default/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/index.php
+++ b/htdocs/modules/system/themes/default/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/js/index.html
+++ b/htdocs/modules/system/themes/default/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/js/index.php
+++ b/htdocs/modules/system/themes/default/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/language/english/index.html
+++ b/htdocs/modules/system/themes/default/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/language/english/index.php
+++ b/htdocs/modules/system/themes/default/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/language/index.html
+++ b/htdocs/modules/system/themes/default/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/language/index.php
+++ b/htdocs/modules/system/themes/default/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/default/xotpl/index.html
+++ b/htdocs/modules/system/themes/default/xotpl/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/default/xotpl/index.php
+++ b/htdocs/modules/system/themes/default/xotpl/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/index.html
+++ b/htdocs/modules/system/themes/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/index.php
+++ b/htdocs/modules/system/themes/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/thadmin/index.html
+++ b/htdocs/modules/system/themes/thadmin/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/thadmin/index.php
+++ b/htdocs/modules/system/themes/thadmin/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/transition/LESS/index.html
+++ b/htdocs/modules/system/themes/transition/LESS/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/transition/LESS/index.php
+++ b/htdocs/modules/system/themes/transition/LESS/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/transition/css/index.html
+++ b/htdocs/modules/system/themes/transition/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/transition/css/index.php
+++ b/htdocs/modules/system/themes/transition/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/transition/images/index.html
+++ b/htdocs/modules/system/themes/transition/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/transition/images/index.php
+++ b/htdocs/modules/system/themes/transition/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/transition/index.html
+++ b/htdocs/modules/system/themes/transition/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/transition/index.php
+++ b/htdocs/modules/system/themes/transition/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/transition/js/index.html
+++ b/htdocs/modules/system/themes/transition/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/transition/js/index.php
+++ b/htdocs/modules/system/themes/transition/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/transition/language/english/index.html
+++ b/htdocs/modules/system/themes/transition/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/transition/language/english/index.php
+++ b/htdocs/modules/system/themes/transition/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/transition/language/index.html
+++ b/htdocs/modules/system/themes/transition/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/transition/language/index.php
+++ b/htdocs/modules/system/themes/transition/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/transition/xotpl/index.html
+++ b/htdocs/modules/system/themes/transition/xotpl/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/transition/xotpl/index.php
+++ b/htdocs/modules/system/themes/transition/xotpl/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/modules/system/themes/transition/xotpl/info/index.html
+++ b/htdocs/modules/system/themes/transition/xotpl/info/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/modules/system/themes/transition/xotpl/info/index.php
+++ b/htdocs/modules/system/themes/transition/xotpl/info/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/templates_c/index.html
+++ b/htdocs/templates_c/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/templates_c/index.php
+++ b/htdocs/templates_c/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/default/icons/index.html
+++ b/htdocs/themes/default/icons/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/default/icons/index.php
+++ b/htdocs/themes/default/icons/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/default/index.html
+++ b/htdocs/themes/default/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/default/index.php
+++ b/htdocs/themes/default/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/default/modules/index.html
+++ b/htdocs/themes/default/modules/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/default/modules/index.php
+++ b/htdocs/themes/default/modules/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/default/modules/system/index.html
+++ b/htdocs/themes/default/modules/system/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/default/modules/system/index.php
+++ b/htdocs/themes/default/modules/system/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/index.html
+++ b/htdocs/themes/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/index.php
+++ b/htdocs/themes/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/fonts/index.html
+++ b/htdocs/themes/xbootstrap/fonts/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/fonts/index.php
+++ b/htdocs/themes/xbootstrap/fonts/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/index.html
+++ b/htdocs/themes/xbootstrap/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/index.php
+++ b/htdocs/themes/xbootstrap/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/language/index.html
+++ b/htdocs/themes/xbootstrap/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/language/index.php
+++ b/htdocs/themes/xbootstrap/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/contact/index.html
+++ b/htdocs/themes/xbootstrap/modules/contact/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/contact/index.php
+++ b/htdocs/themes/xbootstrap/modules/contact/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/extcal/index.html
+++ b/htdocs/themes/xbootstrap/modules/extcal/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/extcal/index.php
+++ b/htdocs/themes/xbootstrap/modules/extcal/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/extgallery/blocks/index.html
+++ b/htdocs/themes/xbootstrap/modules/extgallery/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/extgallery/blocks/index.php
+++ b/htdocs/themes/xbootstrap/modules/extgallery/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/extgallery/index.html
+++ b/htdocs/themes/xbootstrap/modules/extgallery/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/extgallery/index.php
+++ b/htdocs/themes/xbootstrap/modules/extgallery/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/lexikon/index.html
+++ b/htdocs/themes/xbootstrap/modules/lexikon/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/lexikon/index.php
+++ b/htdocs/themes/xbootstrap/modules/lexikon/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/newbb/index.html
+++ b/htdocs/themes/xbootstrap/modules/newbb/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/newbb/index.php
+++ b/htdocs/themes/xbootstrap/modules/newbb/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/news/blocks/index.html
+++ b/htdocs/themes/xbootstrap/modules/news/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/news/blocks/index.php
+++ b/htdocs/themes/xbootstrap/modules/news/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/news/index.html
+++ b/htdocs/themes/xbootstrap/modules/news/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/news/index.php
+++ b/htdocs/themes/xbootstrap/modules/news/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/obituaries/index.html
+++ b/htdocs/themes/xbootstrap/modules/obituaries/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/obituaries/index.php
+++ b/htdocs/themes/xbootstrap/modules/obituaries/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/pm/index.html
+++ b/htdocs/themes/xbootstrap/modules/pm/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/pm/index.php
+++ b/htdocs/themes/xbootstrap/modules/pm/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/profile/index.html
+++ b/htdocs/themes/xbootstrap/modules/profile/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/profile/index.php
+++ b/htdocs/themes/xbootstrap/modules/profile/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/publisher/blocks/index.html
+++ b/htdocs/themes/xbootstrap/modules/publisher/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/publisher/blocks/index.php
+++ b/htdocs/themes/xbootstrap/modules/publisher/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/publisher/index.html
+++ b/htdocs/themes/xbootstrap/modules/publisher/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/publisher/index.php
+++ b/htdocs/themes/xbootstrap/modules/publisher/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/system/blocks/index.html
+++ b/htdocs/themes/xbootstrap/modules/system/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/system/blocks/index.php
+++ b/htdocs/themes/xbootstrap/modules/system/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/system/index.html
+++ b/htdocs/themes/xbootstrap/modules/system/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/system/index.php
+++ b/htdocs/themes/xbootstrap/modules/system/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/tag/index.html
+++ b/htdocs/themes/xbootstrap/modules/tag/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/tag/index.php
+++ b/htdocs/themes/xbootstrap/modules/tag/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/tdmdownloads/blocks/index.html
+++ b/htdocs/themes/xbootstrap/modules/tdmdownloads/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/tdmdownloads/blocks/index.php
+++ b/htdocs/themes/xbootstrap/modules/tdmdownloads/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/tdmdownloads/index.html
+++ b/htdocs/themes/xbootstrap/modules/tdmdownloads/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/tdmdownloads/index.php
+++ b/htdocs/themes/xbootstrap/modules/tdmdownloads/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/xoopsfaq/index.html
+++ b/htdocs/themes/xbootstrap/modules/xoopsfaq/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/xoopsfaq/index.php
+++ b/htdocs/themes/xbootstrap/modules/xoopsfaq/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/xoopstube/blocks/index.html
+++ b/htdocs/themes/xbootstrap/modules/xoopstube/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/xoopstube/blocks/index.php
+++ b/htdocs/themes/xbootstrap/modules/xoopstube/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/modules/xoopstube/index.html
+++ b/htdocs/themes/xbootstrap/modules/xoopstube/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/modules/xoopstube/index.php
+++ b/htdocs/themes/xbootstrap/modules/xoopstube/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xbootstrap/tpl/index.html
+++ b/htdocs/themes/xbootstrap/tpl/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xbootstrap/tpl/index.php
+++ b/htdocs/themes/xbootstrap/tpl/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/fonts/index.html
+++ b/htdocs/themes/xswatch/fonts/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/fonts/index.php
+++ b/htdocs/themes/xswatch/fonts/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/index.html
+++ b/htdocs/themes/xswatch/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/index.php
+++ b/htdocs/themes/xswatch/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/language/index.html
+++ b/htdocs/themes/xswatch/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/language/index.php
+++ b/htdocs/themes/xswatch/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/contact/index.html
+++ b/htdocs/themes/xswatch/modules/contact/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/contact/index.php
+++ b/htdocs/themes/xswatch/modules/contact/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/extcal/index.html
+++ b/htdocs/themes/xswatch/modules/extcal/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/extcal/index.php
+++ b/htdocs/themes/xswatch/modules/extcal/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/extgallery/blocks/index.html
+++ b/htdocs/themes/xswatch/modules/extgallery/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/extgallery/blocks/index.php
+++ b/htdocs/themes/xswatch/modules/extgallery/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/extgallery/index.html
+++ b/htdocs/themes/xswatch/modules/extgallery/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/extgallery/index.php
+++ b/htdocs/themes/xswatch/modules/extgallery/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/newbb/index.html
+++ b/htdocs/themes/xswatch/modules/newbb/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/newbb/index.php
+++ b/htdocs/themes/xswatch/modules/newbb/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/news/blocks/index.html
+++ b/htdocs/themes/xswatch/modules/news/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/news/blocks/index.php
+++ b/htdocs/themes/xswatch/modules/news/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/news/index.html
+++ b/htdocs/themes/xswatch/modules/news/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/news/index.php
+++ b/htdocs/themes/xswatch/modules/news/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/obituaries/index.html
+++ b/htdocs/themes/xswatch/modules/obituaries/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/obituaries/index.php
+++ b/htdocs/themes/xswatch/modules/obituaries/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/pm/index.html
+++ b/htdocs/themes/xswatch/modules/pm/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/pm/index.php
+++ b/htdocs/themes/xswatch/modules/pm/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/profile/index.html
+++ b/htdocs/themes/xswatch/modules/profile/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/profile/index.php
+++ b/htdocs/themes/xswatch/modules/profile/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/publisher/blocks/index.html
+++ b/htdocs/themes/xswatch/modules/publisher/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/publisher/blocks/index.php
+++ b/htdocs/themes/xswatch/modules/publisher/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/publisher/index.html
+++ b/htdocs/themes/xswatch/modules/publisher/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/publisher/index.php
+++ b/htdocs/themes/xswatch/modules/publisher/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/system/blocks/index.html
+++ b/htdocs/themes/xswatch/modules/system/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/system/blocks/index.php
+++ b/htdocs/themes/xswatch/modules/system/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/system/index.html
+++ b/htdocs/themes/xswatch/modules/system/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/system/index.php
+++ b/htdocs/themes/xswatch/modules/system/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/tag/index.html
+++ b/htdocs/themes/xswatch/modules/tag/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/tag/index.php
+++ b/htdocs/themes/xswatch/modules/tag/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/tdmdownloads/blocks/index.html
+++ b/htdocs/themes/xswatch/modules/tdmdownloads/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/tdmdownloads/blocks/index.php
+++ b/htdocs/themes/xswatch/modules/tdmdownloads/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/tdmdownloads/index.html
+++ b/htdocs/themes/xswatch/modules/tdmdownloads/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/tdmdownloads/index.php
+++ b/htdocs/themes/xswatch/modules/tdmdownloads/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/modules/xoopsfaq/index.html
+++ b/htdocs/themes/xswatch/modules/xoopsfaq/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/modules/xoopsfaq/index.php
+++ b/htdocs/themes/xswatch/modules/xoopsfaq/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch/tpl/index.html
+++ b/htdocs/themes/xswatch/tpl/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch/tpl/index.php
+++ b/htdocs/themes/xswatch/tpl/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/index.html
+++ b/htdocs/themes/xswatch4/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/index.php
+++ b/htdocs/themes/xswatch4/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/language/index.html
+++ b/htdocs/themes/xswatch4/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/language/index.php
+++ b/htdocs/themes/xswatch4/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/contact/index.html
+++ b/htdocs/themes/xswatch4/modules/contact/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/contact/index.php
+++ b/htdocs/themes/xswatch4/modules/contact/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/extcal/index.html
+++ b/htdocs/themes/xswatch4/modules/extcal/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/extcal/index.php
+++ b/htdocs/themes/xswatch4/modules/extcal/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/newbb/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/newbb/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/newbb/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/newbb/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/newbb/index.html
+++ b/htdocs/themes/xswatch4/modules/newbb/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/newbb/index.php
+++ b/htdocs/themes/xswatch4/modules/newbb/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/obituaries/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/obituaries/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/obituaries/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/obituaries/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/obituaries/index.html
+++ b/htdocs/themes/xswatch4/modules/obituaries/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/obituaries/index.php
+++ b/htdocs/themes/xswatch4/modules/obituaries/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/pm/index.html
+++ b/htdocs/themes/xswatch4/modules/pm/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/pm/index.php
+++ b/htdocs/themes/xswatch4/modules/pm/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/profile/index.html
+++ b/htdocs/themes/xswatch4/modules/profile/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/profile/index.php
+++ b/htdocs/themes/xswatch4/modules/profile/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/publisher/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/publisher/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/publisher/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/publisher/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/publisher/index.html
+++ b/htdocs/themes/xswatch4/modules/publisher/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/publisher/index.php
+++ b/htdocs/themes/xswatch4/modules/publisher/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/system/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/system/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/system/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/system/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/system/index.html
+++ b/htdocs/themes/xswatch4/modules/system/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/system/index.php
+++ b/htdocs/themes/xswatch4/modules/system/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/tag/index.html
+++ b/htdocs/themes/xswatch4/modules/tag/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/tag/index.php
+++ b/htdocs/themes/xswatch4/modules/tag/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/tdmdownloads/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/tdmdownloads/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/tdmdownloads/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/tdmdownloads/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/tdmdownloads/index.html
+++ b/htdocs/themes/xswatch4/modules/tdmdownloads/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/tdmdownloads/index.php
+++ b/htdocs/themes/xswatch4/modules/tdmdownloads/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/wggallery/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/wggallery/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/wggallery/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/wggallery/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/wggallery/index.html
+++ b/htdocs/themes/xswatch4/modules/wggallery/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/wggallery/index.php
+++ b/htdocs/themes/xswatch4/modules/wggallery/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xmcontact/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/xmcontact/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xmcontact/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/xmcontact/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xmcontact/index.html
+++ b/htdocs/themes/xswatch4/modules/xmcontact/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xmcontact/index.php
+++ b/htdocs/themes/xswatch4/modules/xmcontact/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xmcontent/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/xmcontent/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xmcontent/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/xmcontent/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xmcontent/index.html
+++ b/htdocs/themes/xswatch4/modules/xmcontent/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xmcontent/index.php
+++ b/htdocs/themes/xswatch4/modules/xmcontent/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xmdoc/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/xmdoc/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xmdoc/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/xmdoc/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xmdoc/index.html
+++ b/htdocs/themes/xswatch4/modules/xmdoc/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xmdoc/index.php
+++ b/htdocs/themes/xswatch4/modules/xmdoc/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xmnews/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/xmnews/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xmnews/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/xmnews/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xmnews/index.html
+++ b/htdocs/themes/xswatch4/modules/xmnews/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xmnews/index.php
+++ b/htdocs/themes/xswatch4/modules/xmnews/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xmsocial/index.html
+++ b/htdocs/themes/xswatch4/modules/xmsocial/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xmsocial/index.php
+++ b/htdocs/themes/xswatch4/modules/xmsocial/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xoopsfaq/blocks/index.html
+++ b/htdocs/themes/xswatch4/modules/xoopsfaq/blocks/index.html
@@ -1,1 +1,0 @@
- <script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xoopsfaq/blocks/index.php
+++ b/htdocs/themes/xswatch4/modules/xoopsfaq/blocks/index.php
@@ -1,0 +1,2 @@
+ <?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/modules/xoopsfaq/index.html
+++ b/htdocs/themes/xswatch4/modules/xoopsfaq/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/modules/xoopsfaq/index.php
+++ b/htdocs/themes/xswatch4/modules/xoopsfaq/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/themes/xswatch4/tpl/index.html
+++ b/htdocs/themes/xswatch4/tpl/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/themes/xswatch4/tpl/index.php
+++ b/htdocs/themes/xswatch4/tpl/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/uploads/avatars/index.html
+++ b/htdocs/uploads/avatars/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/uploads/avatars/index.php
+++ b/htdocs/uploads/avatars/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/uploads/files/index.html
+++ b/htdocs/uploads/files/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/uploads/files/index.php
+++ b/htdocs/uploads/files/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/uploads/images/index.html
+++ b/htdocs/uploads/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/uploads/images/index.php
+++ b/htdocs/uploads/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/uploads/index.html
+++ b/htdocs/uploads/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/uploads/index.php
+++ b/htdocs/uploads/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/uploads/ranks/index.html
+++ b/htdocs/uploads/ranks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/uploads/ranks/index.php
+++ b/htdocs/uploads/ranks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/uploads/smilies/index.html
+++ b/htdocs/uploads/smilies/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/uploads/smilies/index.php
+++ b/htdocs/uploads/smilies/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_data/caches/index.html
+++ b/htdocs/xoops_data/caches/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_data/caches/index.php
+++ b/htdocs/xoops_data/caches/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_data/caches/smarty_cache/index.html
+++ b/htdocs/xoops_data/caches/smarty_cache/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_data/caches/smarty_compile/index.html
+++ b/htdocs/xoops_data/caches/smarty_compile/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_data/caches/xoops_cache/index.html
+++ b/htdocs/xoops_data/caches/xoops_cache/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_data/configs/index.html
+++ b/htdocs/xoops_data/configs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_data/data/index.html
+++ b/htdocs/xoops_data/data/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_data/data/index.php
+++ b/htdocs/xoops_data/data/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_data/index.html
+++ b/htdocs/xoops_data/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_data/index.php
+++ b/htdocs/xoops_data/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_data/protector/index.html
+++ b/htdocs/xoops_data/protector/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/Frameworks/index.html
+++ b/htdocs/xoops_lib/Frameworks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/Frameworks/index.php
+++ b/htdocs/xoops_lib/Frameworks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/Frameworks/jquery/index.html
+++ b/htdocs/xoops_lib/Frameworks/jquery/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/Frameworks/jquery/index.php
+++ b/htdocs/xoops_lib/Frameworks/jquery/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/Frameworks/jquery/plugins/index.html
+++ b/htdocs/xoops_lib/Frameworks/jquery/plugins/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/Frameworks/jquery/plugins/index.php
+++ b/htdocs/xoops_lib/Frameworks/jquery/plugins/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/index.html
+++ b/htdocs/xoops_lib/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/index.php
+++ b/htdocs/xoops_lib/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/index.html
+++ b/htdocs/xoops_lib/modules/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/index.php
+++ b/htdocs/xoops_lib/modules/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/blocks/index.html
+++ b/htdocs/xoops_lib/modules/protector/blocks/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/blocks/index.php
+++ b/htdocs/xoops_lib/modules/protector/blocks/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/class/index.html
+++ b/htdocs/xoops_lib/modules/protector/class/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/class/index.php
+++ b/htdocs/xoops_lib/modules/protector/class/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/docs/index.html
+++ b/htdocs/xoops_lib/modules/protector/docs/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/docs/index.php
+++ b/htdocs/xoops_lib/modules/protector/docs/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/filters_disabled/index.html
+++ b/htdocs/xoops_lib/modules/protector/filters_disabled/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/filters_disabled/index.php
+++ b/htdocs/xoops_lib/modules/protector/filters_disabled/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/filters_enabled/index.html
+++ b/htdocs/xoops_lib/modules/protector/filters_enabled/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/filters_enabled/index.php
+++ b/htdocs/xoops_lib/modules/protector/filters_enabled/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/images/index.html
+++ b/htdocs/xoops_lib/modules/protector/images/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/images/index.php
+++ b/htdocs/xoops_lib/modules/protector/images/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/include/index.html
+++ b/htdocs/xoops_lib/modules/protector/include/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/include/index.php
+++ b/htdocs/xoops_lib/modules/protector/include/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/index.html
+++ b/htdocs/xoops_lib/modules/protector/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/index.php
+++ b/htdocs/xoops_lib/modules/protector/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/language/english/index.html
+++ b/htdocs/xoops_lib/modules/protector/language/english/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/language/english/index.php
+++ b/htdocs/xoops_lib/modules/protector/language/english/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/language/index.html
+++ b/htdocs/xoops_lib/modules/protector/language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/language/index.php
+++ b/htdocs/xoops_lib/modules/protector/language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/CSS/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/CSS/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/CSS/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/CSS/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/HTML/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/HTML/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/HTML/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/HTML/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/URI/Email/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/URI/Email/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/URI/Email/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/URI/Email/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/URI/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/URI/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/URI/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/URI/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrDef/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrTransform/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrTransform/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrTransform/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/AttrTransform/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ChildDef/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ChildDef/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ChildDef/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ChildDef/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/Builder/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/Builder/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/Builder/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/Builder/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/Interchange/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/Interchange/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/Interchange/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/Interchange/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/schema/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/schema/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/schema/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/ConfigSchema/schema/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/Decorator/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/Decorator/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/Decorator/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/Decorator/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/Serializer/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/Serializer/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/Serializer/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/Serializer/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/DefinitionCache/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/EntityLookup/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/EntityLookup/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/EntityLookup/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/EntityLookup/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Filter/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Filter/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Filter/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Filter/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/HTMLModule/Tidy/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/HTMLModule/Tidy/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/HTMLModule/Tidy/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/HTMLModule/Tidy/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/HTMLModule/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/HTMLModule/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/HTMLModule/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/HTMLModule/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Injector/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Injector/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Injector/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Injector/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Language/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Language/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Language/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Language/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Language/messages/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Language/messages/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Language/messages/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Language/messages/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Lexer/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Lexer/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Lexer/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Lexer/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Printer/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Printer/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Printer/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Printer/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Strategy/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Strategy/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Strategy/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Strategy/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/TagTransform/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/TagTransform/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/TagTransform/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/TagTransform/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Token/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Token/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Token/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Token/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/URIFilter/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/URIFilter/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/URIFilter/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/URIFilter/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/URIScheme/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/URIScheme/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/URIScheme/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/URIScheme/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/VarParser/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/VarParser/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/VarParser/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/VarParser/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/library/index.html
+++ b/htdocs/xoops_lib/modules/protector/library/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/library/index.php
+++ b/htdocs/xoops_lib/modules/protector/library/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/htdocs/xoops_lib/modules/protector/sql/index.html
+++ b/htdocs/xoops_lib/modules/protector/sql/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/htdocs/xoops_lib/modules/protector/sql/index.php
+++ b/htdocs/xoops_lib/modules/protector/sql/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/upgrade/assets/css/index.html
+++ b/upgrade/assets/css/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/upgrade/assets/css/index.php
+++ b/upgrade/assets/css/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/upgrade/assets/img/index.html
+++ b/upgrade/assets/img/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/upgrade/assets/img/index.php
+++ b/upgrade/assets/img/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/upgrade/assets/index.html
+++ b/upgrade/assets/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/upgrade/assets/index.php
+++ b/upgrade/assets/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/upgrade/assets/js/index.html
+++ b/upgrade/assets/js/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/upgrade/assets/js/index.php
+++ b/upgrade/assets/js/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/upgrade/language/english/index.html
+++ b/upgrade/language/english/index.html
@@ -1,1 +1,0 @@
- <script>history.go(-1);</script>

--- a/upgrade/language/english/index.php
+++ b/upgrade/language/english/index.php
@@ -1,0 +1,2 @@
+ <?php
+header("HTTP/1.0 404 Not Found");

--- a/upgrade/language/index.html
+++ b/upgrade/language/index.html
@@ -1,1 +1,0 @@
- <script>history.go(-1);</script>

--- a/upgrade/language/index.php
+++ b/upgrade/language/index.php
@@ -1,0 +1,2 @@
+ <?php
+header("HTTP/1.0 404 Not Found");


### PR DESCRIPTION
Replace index.html files with javascript with index.php files that will cause a 404 error if accessed.

This fixes errors encountered with #884 caused by processing of preloads/index.php files in modules directories.