### PR TITLE
Restore missing xoops_data/caches directories

### DIFF
--- a/htdocs/xoops_data/caches/smarty_cache/index.html
+++ b/htdocs/xoops_data/caches/smarty_cache/index.html
@@ -1,0 +1,1 @@
+<script>history.go(-1);</script>

--- a/htdocs/xoops_data/caches/smarty_compile/index.html
+++ b/htdocs/xoops_data/caches/smarty_compile/index.html
@@ -1,0 +1,1 @@
+<script>history.go(-1);</script>

--- a/htdocs/xoops_data/caches/xoops_cache/index.html
+++ b/htdocs/xoops_data/caches/xoops_cache/index.html
@@ -1,0 +1,1 @@
+<script>history.go(-1);</script>


### PR DESCRIPTION
Adding back index.html files. Note these are not index.php as the different extension is used in \SystemMaintenance::clearDirectory and is helpful when clearing manually as well.

Re: #890 