### PR TITLE
Mark deleted PM as read

### DIFF
--- a/htdocs/modules/pm/class/message.php
+++ b/htdocs/modules/pm/class/message.php
@@ -97,8 +97,13 @@ class PmMessageHandler extends XoopsPersistableObjectHandler
      */
     public function setTodelete(PmMessage $pm, $val = 1)
     {
+        $val = (int)$val;
         if ($pm->getVar('from_delete') == 0 || $pm->getVar('from_userid') == 0) {
-            return $this->updateAll('to_delete', (int)$val, new Criteria('msg_id', $pm->getVar('msg_id')));
+            $pm->setVar('to_delete', $val);
+            if ($val) {
+                $pm->setVar('read_msg', 1);
+            }
+            return $this->insert($pm);
         } else {
             return parent::delete($pm);
         }


### PR DESCRIPTION
An inbox count issue is triggered when:
- "From" user saves a copy of a PM to outbox during send
- "To" user deletes PM without reading it

This results in the "To" user's inbox count being inaccurate until the outbox copy is deleted.

This change marks the message read when it is marked for deletion by the recipient.

Replaces #927