### PR TITLE
Require fileinfo PHP extension during install

### DIFF
--- a/docs/changelog.250.txt
+++ b/docs/changelog.250.txt
@@ -1,7 +1,7 @@
 XOOPS 2.5.x Changelog (Language changes: see: /docs/lang_diff.txt)
 
 ===================================
-2.5.11 RC1           NOT RELEASED
+2.5.11 Beta2           NOT RELEASED
 ===================================
 
 - update xmsocial, xmmodules, xmdoc and xmnews (mage)
@@ -54,6 +54,7 @@ XOOPS 2.5.x Changelog (Language changes: see: /docs/lang_diff.txt)
 - Return proper null value for integer columns (geekwright)
 - Add macro substitutions for {X_SITEURL} and {X_YEAR}
 - Patch a few issues when using PHP 8 (geekwright)
+- explicitly require fileinfo extension in install
 
 Updated libraries and assets:
 - Smarty: allow StdClass to be cast to array when compiling foreach (mamba)

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -14,7 +14,7 @@
  * See the enclosed file license.txt for licensing information.
  * If you did not receive this file, get it at https://www.gnu.org/licenses/gpl-2.0.html
  *
- * @copyright    (c) 2000-2016 XOOPS Project (www.xoops.org)
+ * @copyright    (c) 2000-2021 XOOPS Project (https://xoops.org)
  * @license          GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  * @package          installer
  * @since            2.3.0
@@ -80,6 +80,11 @@ ob_start();
         <tr>
             <th scope="row">file_uploads</th>
             <td><?php echo xoDiagBoolSetting('file_uploads', true); ?></td>
+        </tr>
+
+        <tr>
+            <th><?php printf(PHP_EXTENSION, 'fileinfo'); ?></th>
+            <td><?php echo xoDiag(extension_loaded('fileinfo') ? 1 : -1); ?></td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Extension is enabled by default but can be disabled in some installations.

See #888