### PR TITLE
Add two new events

### DIFF
--- a/htdocs/class/template.php
+++ b/htdocs/class/template.php
@@ -9,7 +9,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * @copyright       (c) 2000-2016 XOOPS Project (www.xoops.org)
+ * @copyright       (c) 2000-2021 XOOPS Project (https://xoops.org)
  * @license             GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
  * @author              Kazumi Ono <onokazu@xoops.org>
  * @author              Skalpa Keo <skalpa@xoops.org>
@@ -33,7 +33,7 @@ xoops_loadLanguage('global');
  * @package             kernel
  * @subpackage          core
  * @author              Kazumi Ono <onokazu@xoops.org>
- * @copyright       (c) 2000-2016 XOOPS Project (www.xoops.org)
+ * @copyright       (c) 2000-2021 XOOPS Project (https://xoops.org)
  */
 class XoopsTpl extends Smarty
 {
@@ -69,6 +69,8 @@ class XoopsTpl extends Smarty
                           'xoops_charset'    => _CHARSET,
                           'xoops_version'    => XOOPS_VERSION,
                           'xoops_upload_url' => XOOPS_UPLOAD_URL));
+        $xoopsPreload = XoopsPreload::getInstance();
+        $xoopsPreload->triggerEvent('core.class.template.new', array($this));
     }
 
     /**

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -292,9 +292,10 @@ if (!empty($_SESSION['xoopsUserId'])) {
         $xoopsUserIsAdmin = $xoopsUser->isAdmin();
     }
 }
+// user characteristics are established
+$xoopsPreload->triggerEvent('core.include.common.auth.success');
 
 /**
- * *#@+
  * Debug level for XOOPS
  * Check /xoops_data/configs/xoopsconfig.php for details
  *


### PR DESCRIPTION
Adds triggers of two new events.

**core.include.common.auth.success**

Event is triggered when the establishment, or re-establishment, of the current user is complete.

At this point valid security decisions can be made based on the state of the current user.

**core.class.template.new event**

This event is triggered when a new XoopsTpl (an extended Smarty object) is created. This allows customization of the Smarty environment from within a module.

One possible use would be to support a module based plugin library. An simplified example event listener:

```php
public static function eventCoreClassTemplateNew($arg)
{
    $smartyObject = $arg[0];
    $smartyObject->plugins_dir[] = __DIR__;
}
```