### PR TITLE
Recognize error return from db->query()

### DIFF
--- a/htdocs/class/model/read.php
+++ b/htdocs/class/model/read.php
@@ -56,40 +56,37 @@ class XoopsModelRead extends XoopsModelAbstract
             }
             if ($sort = $criteria->getSort()) {
                 $sql .= " ORDER BY {$sort} " . $criteria->getOrder();
-                $orderSet = true;
             }
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();
         }
-        if (empty($orderSet)) {
-            //$sql .= " ORDER BY `{$this->handler->keyName}` DESC";
-        }
         $result = $this->handler->db->query($sql, $limit, $start);
         $ret    = array();
-        if ($asObject) {
-            while (false !== ($myrow = $this->handler->db->fetchArray($result))) {
+        if (false !== $result) {
+            if ($asObject) {
+                while (false !== ($myrow = $this->handler->db->fetchArray($result))) {
+                    $object = $this->handler->create(false);
+                    $object->assignVars($myrow);
+                    if ($id_as_key) {
+                        $ret[$myrow[$this->handler->keyName]] = $object;
+                    } else {
+                        $ret[] = $object;
+                    }
+                    unset($object);
+                }
+            } else {
                 $object = $this->handler->create(false);
-                $object->assignVars($myrow);
-                if ($id_as_key) {
-                    $ret[$myrow[$this->handler->keyName]] = $object;
-                } else {
-                    $ret[] = $object;
+                while (false !== ($myrow = $this->handler->db->fetchArray($result))) {
+                    $object->assignVars($myrow);
+                    if ($id_as_key) {
+                        $ret[$myrow[$this->handler->keyName]] = $object->getValues(array_keys($myrow));
+                    } else {
+                        $ret[] = $object->getValues(array_keys($myrow));
+                    }
                 }
                 unset($object);
             }
-        } else {
-            $object = $this->handler->create(false);
-            while (false !== ($myrow = $this->handler->db->fetchArray($result))) {
-                $object->assignVars($myrow);
-                if ($id_as_key) {
-                    $ret[$myrow[$this->handler->keyName]] = $object->getValues(array_keys($myrow));
-                } else {
-                    $ret[] = $object->getValues(array_keys($myrow));
-                }
-            }
-            unset($object);
         }
-
         return $ret;
     }
 


### PR DESCRIPTION
\XoopsModelRead::getAll() fails to handle a return of false from a database query(). It then attempts to use the false value as a result set which now causes a nasty failure.

As there is no documented failure return mechanism, the return in the case of failure is now an empty array. This may not be ideal, but should not break compatibility.

Also, removed some dead code regarding an $orderSet variable.