### PR TITLE
Protector config cache for htmlpurifier written to xoops_lib, should go to xoops_data

### DIFF
--- a/htdocs/xoops_lib/modules/protector/filters_disabled/postcommon_post_htmlpurify4everyone.php
+++ b/htdocs/xoops_lib/modules/protector/filters_disabled/postcommon_post_htmlpurify4everyone.php
@@ -30,7 +30,7 @@ class Protector_postcommon_post_htmlpurify4everyone extends ProtectorFilterAbstr
         // use HTMLPurifier inside Protector
         require_once dirname(__DIR__) . '/library/HTMLPurifier.auto.php';
         $config = HTMLPurifier_Config::createDefault();
-        $config->set('Cache', 'SerializerPath', XOOPS_TRUST_PATH . '/modules/protector/configs');
+        $config->set('Cache', 'SerializerPath', XOOPS_VAR_PATH . '/configs/protector');
         $config->set('Core', 'Encoding', _CHARSET);
         //$config->set('HTML', 'Doctype', 'HTML 4.01 Transitional');
         $this->purifier = new HTMLPurifier($config);

--- a/htdocs/xoops_lib/modules/protector/filters_disabled/postcommon_post_htmlpurify4guest.php
+++ b/htdocs/xoops_lib/modules/protector/filters_disabled/postcommon_post_htmlpurify4guest.php
@@ -39,7 +39,7 @@ class Protector_postcommon_post_htmlpurify4guest extends ProtectorFilterAbstract
         // use HTMLPurifier inside Protector
         require_once dirname(__DIR__) . '/library/HTMLPurifier.auto.php';
         $config = HTMLPurifier_Config::createDefault();
-        $config->set('Cache', 'SerializerPath', XOOPS_TRUST_PATH . '/modules/protector/configs');
+        $config->set('Cache', 'SerializerPath', XOOPS_VAR_PATH . '/configs/protector');
         $config->set('Core', 'Encoding', _CHARSET);
         //$config->set('HTML', 'Doctype', 'HTML 4.01 Transitional');
         $this->purifier = new HTMLPurifier($config);


### PR DESCRIPTION
These were missed in an earlier move of protector configs from xoops_lib to xoops_data.