### PR TITLE
Make $redirect_message available in system_siteclosed.tpl

### DIFF
--- a/htdocs/include/site-closed.php
+++ b/htdocs/include/site-closed.php
@@ -60,6 +60,11 @@ if (!$allowed) {
                           'lang_username'     => _USERNAME,
                           'lang_password'     => _PASSWORD,
                           'lang_siteclosemsg' => $xoopsConfig['closesite_text']));
+    if (isset($_SESSION['redirect_message'])) {
+        $xoopsTpl->assign('redirect_message', $_SESSION['redirect_message']);
+        unset($_SESSION['redirect_message']);
+    }
+
     /* @var XoopsConfigHandler $config_handler */
     $config_handler = xoops_getHandler('config');
     $criteria       = new CriteriaCompo(new Criteria('conf_modid', 0));

--- a/htdocs/themes/default/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/default/modules/system/system_siteclosed.tpl
@@ -75,6 +75,9 @@
         <div id="xo-canvas-content">
             <div id="xo-page">
                 <div id="xo-siteclose"><{$lang_siteclosemsg}></div>
+                <{if $redirect_message|default:false}>
+                <div class="center red"><b><{$redirect_message}></b><br><br></div>
+                <{/if}>
             </div>
         </div>
 

--- a/htdocs/themes/xbootstrap/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xbootstrap/modules/system/system_siteclosed.tpl
@@ -40,6 +40,9 @@
 
             <div class="xoops-site-closed-container">
                 <blockquote><p class="text-muted"><{$lang_siteclosemsg}></p></blockquote>
+                <{if $redirect_message|default:false}>
+                <p class="text-warning"><{$redirect_message}></p>
+                <{/if}>
                 <form action="<{xoAppUrl user.php}>" method="post" role="form" class="form-horizontal">
 
                     <label class="control-label"><{$lang_username}></label>

--- a/htdocs/themes/xswatch/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xswatch/modules/system/system_siteclosed.tpl
@@ -36,6 +36,9 @@
 
             <div class="xoops-site-closed-container">
                 <p class="text-muted"><{$lang_siteclosemsg}></p>
+                <{if $redirect_message|default:false}>
+                <p class="text-warning"><{$redirect_message}></p>
+                <{/if}>
                 <form action="<{xoAppUrl user.php}>" method="post" role="form" class="form-horizontal">
                         <label for="xo-login-uname"><{$smarty.const.THEME_LOGIN}></label>
                         <div class="input-group">

--- a/htdocs/themes/xswatch4/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xswatch4/modules/system/system_siteclosed.tpl
@@ -38,6 +38,9 @@
 
             <div class="xoops-site-closed-container">
                 <p class="text-muted"><{$lang_siteclosemsg}></p>
+                <{if $redirect_message|default:false}>
+                    <p class="text-warning"><{$redirect_message}></p>
+                <{/if}>
                 <form action="<{xoAppUrl user.php}>" method="post" role="form" class="form-horizontal">
                     <label for="xo-login-uname"><{$lang_username}></label>
                     <div class="input-group mb-3">


### PR DESCRIPTION
Any error message from an attempted login would normally be displayed by jgrowl, but that function is not included in the minimal site closed page templates. (With jgrowl redirects turned off, the interstitial page does show with any message.)

This change assigns any redirect message to $redirect_message in include/site-closed.php. It can then be utilized in the system_siteclosed.tpl template as desired.

All such templates included in XoopsCore25 now display these messages.

Fixes #901