### PR TITLE
Wrong default for debugLevel configuration

### DIFF
--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -302,7 +302,7 @@ $xoopsPreload->triggerEvent('core.include.common.auth.success');
  * Note: temporary solution only. Will be re-designed in XOOPS 3.0
  */
 if ($xoopsLogger->activated) {
-    $level = isset($xoopsConfig['debugLevel']) ? (int)$xoopsConfig['debugLevel'] : 0;
+    $level = isset($xoopsConfig['debugLevel']) ? (int)$xoopsConfig['debugLevel'] : 2;
     if (($level == 2 && empty($xoopsUserIsAdmin)) || ($level == 1 && !$xoopsUser)) {
         error_reporting(0);
         $xoopsLogger->activated = false;

--- a/htdocs/themes/default/modules/system/system_redirect.tpl
+++ b/htdocs/themes/default/modules/system/system_redirect.tpl
@@ -11,15 +11,8 @@
     <meta name="author" content="<{$xoops_meta_author}>"/>
     <meta name="copyright" content="<{$xoops_meta_copyright}>"/>
     <meta name="generator" content="XOOPS"/>
-    <{if $url}>
+    <{if $url|default:false}>
         <meta http-equiv="Refresh" content="<{$time}>; url=<{$url}>"/>
-    <{/if}>
-
-    <!-- Force MSIE without  javascript actived to take the default theme. not conforms to the standards but functional -->
-    <{if $isMsie}>
-        <noscript>
-            <meta http-equiv="refresh" content="0; url=<{xoAppUrl . xoops_theme_select=default}>"/>
-        </noscript>
     <{/if}>
 
     <!-- path favicon -->

--- a/htdocs/themes/default/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/default/modules/system/system_siteclosed.tpl
@@ -11,15 +11,8 @@
     <meta name="author" content="<{$xoops_meta_author}>"/>
     <meta name="copyright" content="<{$xoops_meta_copyright}>"/>
     <meta name="generator" content="XOOPS"/>
-    <{if $url}>
+    <{if $url|default:false}>
         <meta http-equiv="Refresh" content="<{$time}>; url=<{$url}>"/>
-    <{/if}>
-
-    <!-- Force MSIE without  javascript actived to take the default theme. not conforms to the standards but functional -->
-    <{if $isMsie}>
-        <noscript>
-            <meta http-equiv="refresh" content="0; url=<{xoAppUrl . xoops_theme_select=default}>"/>
-        </noscript>
     <{/if}>
 
     <!-- path favicon -->
@@ -27,7 +20,7 @@
     <link rel="icon" type="image/png" href="<{xoImgUrl icons/favicon.png}>"/>
 
     <!-- include xoops.js and others via header.php -->
-    <{$xoops_module_header}>
+    <{$xoops_module_header|default:''}>
 
     <!-- Xoops style sheet -->
     <link rel="stylesheet" type="text/css" media="screen" href="<{xoAppUrl xoops.css}>"/>
@@ -38,7 +31,7 @@
 <body>
 
 <div id="xo-canvas"
-        <{if $columns_layout}> class="<{$columns_layout}>"<{/if}>>
+        <{if $columns_layout|default:false}> class="<{$columns_layout}>"<{/if}>>
     <div class="xo-wrapper">
         <div id="xo-bgstatic" class="<{$xoops_dirname}>"></div>
         <div id="xo-header" class="<{$xoops_dirname}>">

--- a/htdocs/themes/xbootstrap/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xbootstrap/modules/system/system_siteclosed.tpl
@@ -27,7 +27,7 @@
     <title><{if $xoops_dirname == "system"}><{$xoops_sitename}><{if $xoops_pagetitle !=''}> - <{$xoops_pagetitle}><{/if}><{else}><{if $xoops_pagetitle
         !=''}><{$xoops_pagetitle}> - <{$xoops_sitename}><{/if}><{/if}></title>
     <{includeq file="$theme_name/tpl/shareaholic-script.tpl"}>
-    <{$xoops_module_header}>
+    <{$xoops_module_header|default:''}>
 </head>
 <body class="site-closed-body">
 <div class="container">

--- a/htdocs/themes/xswatch/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xswatch/modules/system/system_siteclosed.tpl
@@ -23,7 +23,7 @@
     <link rel="alternate" type="application/rss+xml" title="" href="<{xoAppUrl backend.php}>">
     <title><{if $xoops_dirname == "system"}><{$xoops_sitename}><{if $xoops_pagetitle !=''}> - <{$xoops_pagetitle}><{/if}><{else}><{if $xoops_pagetitle
         !=''}><{$xoops_pagetitle}> - <{$xoops_sitename}><{/if}><{/if}></title>
-    <{$xoops_module_header}>
+    <{$xoops_module_header|default:''}>
 </head>
 <body class="site-closed-body">
 <div class="container">

--- a/htdocs/themes/xswatch4/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xswatch4/modules/system/system_siteclosed.tpl
@@ -25,7 +25,7 @@
 
     <title><{if $xoops_dirname == "system"}><{$xoops_sitename}><{if $xoops_pagetitle !=''}> - <{$xoops_pagetitle}><{/if}><{else}><{if $xoops_pagetitle
         !=''}><{$xoops_pagetitle}> - <{$xoops_sitename}><{/if}><{/if}></title>
-    <{$xoops_module_header}>
+    <{$xoops_module_header|default:''}>
 </head>
 <body class="site-closed-body">
 <div class="container">


### PR DESCRIPTION
If for any reason the $xoopsConfig['debugLevel'] is not set the default was 0? A default of 2 (admin group) seems more appropriate.