### PR TITLE
Errors using XOOPS_VAR_PATH early in install

### DIFF
--- a/htdocs/install/include/common.inc.php
+++ b/htdocs/install/include/common.inc.php
@@ -14,7 +14,7 @@
  * See the enclosed file license.txt for licensing information.
  * If you did not receive this file, get it at https://www.gnu.org/licenses/gpl-2.0.html
  *
- * @copyright    (c) 2000-2016 XOOPS Project (www.xoops.org)
+ * @copyright    (c) 2000-2021 XOOPS Project (www.xoops.org)
  * @license          GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  * @package          installer
  * @since            2.3.0
@@ -60,15 +60,6 @@ if (empty($xoopsOption['hascommon'])) {
 if (!defined('XOOPS_ROOT_PATH')) {
     define('XOOPS_ROOT_PATH', str_replace("\\", '/', realpath('../')));
 }
-
-/*
-error_reporting( 0 );
-if (isset($xoopsLogger)) {
-    $xoopsLogger->activated = false;
-}
-error_reporting(E_ALL);
-$xoopsLogger->activated = true;
-*/
 
 date_default_timezone_set(@date_default_timezone_get());
 include './class/installwizard.php';

--- a/htdocs/install/include/createconfigform.php
+++ b/htdocs/install/include/createconfigform.php
@@ -3,7 +3,7 @@
  * See the enclosed file license.txt for licensing information.
  * If you did not receive this file, get it at https://www.gnu.org/licenses/gpl-2.0.html
  *
- * @copyright    (c) 2000-2016 XOOPS Project (www.xoops.org)
+ * @copyright    (c) 2000-2021 XOOPS Project (www.xoops.org)
  * @license          GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  * @package          installer
  * @since            2.3.0
@@ -59,12 +59,11 @@ function createConfigform($config)
 
         switch ($config[$i]->getVar('conf_formtype')) {
             case 'textarea':
-                $myts = MyTextSanitizer::getInstance();
                 if ($config[$i]->getVar('conf_valuetype') === 'array') {
                     // this is exceptional.. only when value type is arrayneed a smarter way for this
-                    $ele = ($config[$i]->getVar('conf_value') != '') ? new XoopsFormTextArea($title, $config[$i]->getVar('conf_name'), $myts->htmlSpecialChars(implode('|', $config[$i]->getConfValueForOutput())), 5, 50) : new XoopsFormTextArea($title, $config[$i]->getVar('conf_name'), '', 5, 50);
+                    $ele = ($config[$i]->getVar('conf_value') != '') ? new XoopsFormTextArea($title, $config[$i]->getVar('conf_name'), installerHtmlSpecialChars(implode('|', $config[$i]->getConfValueForOutput())), 5, 50) : new XoopsFormTextArea($title, $config[$i]->getVar('conf_name'), '', 5, 50);
                 } else {
-                    $ele = new XoopsFormTextArea($title, $config[$i]->getVar('conf_name'), $myts->htmlSpecialChars($config[$i]->getConfValueForOutput()), 5, 100);
+                    $ele = new XoopsFormTextArea($title, $config[$i]->getVar('conf_name'), installerHtmlSpecialChars($config[$i]->getConfValueForOutput()), 5, 100);
                 }
                 break;
 
@@ -201,24 +200,20 @@ function createConfigform($config)
                 break;
 
             case 'password':
-                $myts = MyTextSanitizer::getInstance();
-                $ele  = new XoopsFormPassword($title, $config[$i]->getVar('conf_name'), 50, 255, $myts->htmlSpecialChars($config[$i]->getConfValueForOutput()));
+                $ele  = new XoopsFormPassword($title, $config[$i]->getVar('conf_name'), 50, 255, installerHtmlSpecialChars($config[$i]->getConfValueForOutput()));
                 break;
 
             case 'color':
-                $myts = MyTextSanitizer::getInstance();
-                $ele  = new XoopsFormColorPicker($title, $config[$i]->getVar('conf_name'), $myts->htmlSpecialChars($config[$i]->getConfValueForOutput()));
+                $ele  = new XoopsFormColorPicker($title, $config[$i]->getVar('conf_name'), installerHtmlSpecialChars($config[$i]->getConfValueForOutput()));
                 break;
 
             case 'hidden':
-                $myts = MyTextSanitizer::getInstance();
-                $ele  = new XoopsFormHidden($config[$i]->getVar('conf_name'), $myts->htmlSpecialChars($config[$i]->getConfValueForOutput()));
+                $ele  = new XoopsFormHidden($config[$i]->getVar('conf_name'), installerHtmlSpecialChars($config[$i]->getConfValueForOutput()));
                 break;
 
             case 'textbox':
             default:
-                $myts = MyTextSanitizer::getInstance();
-                $ele  = new XoopsFormText($title, $config[$i]->getVar('conf_name'), 50, 255, $myts->htmlSpecialChars($config[$i]->getConfValueForOutput()));
+                $ele  = new XoopsFormText($title, $config[$i]->getVar('conf_name'), 50, 255, installerHtmlSpecialChars($config[$i]->getConfValueForOutput()));
                 break;
         }
 

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -3,7 +3,7 @@
  * See the enclosed file license.txt for licensing information.
  * If you did not receive this file, get it at https://www.gnu.org/licenses/gpl-2.0.html
  *
- * @copyright    (c) 2000-2016 XOOPS Project (www.xoops.org)
+ * @copyright    (c) 2000-2021 XOOPS Project (www.xoops.org)
  * @license          GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  * @package          installer
  * @since            2.3.0
@@ -15,6 +15,16 @@
  * @param string $hash
  * @return bool
  */
+
+/**
+ * call htmlspecialchars with standard arguments
+ * @param $value string
+ * @return string
+ */
+function installerHtmlSpecialChars($value)
+{
+    return htmlspecialchars($value, ENT_QUOTES, _INSTALL_CHARSET, true);
+}
 
 function install_acceptUser($hash = '')
 {
@@ -29,7 +39,8 @@ function install_acceptUser($hash = '')
     $uname = $claims->uname;
     /* @var XoopsMemberHandler $memberHandler */
     $memberHandler = xoops_getHandler('member');
-    $user = array_pop($memberHandler->getUsers(new Criteria('uname', $uname)));
+    $users = $memberHandler->getUsers(new Criteria('uname', $uname));
+    $user = array_pop($users);
 
     if (is_object($GLOBALS['xoops']) && method_exists($GLOBALS['xoops'], 'acceptUser')) {
         $res = $GLOBALS['xoops']->acceptUser($uname, true, '');
@@ -65,10 +76,9 @@ function install_finalize($installer_modified)
  */
 function xoFormField($name, $value, $label, $help = '')
 {
-    $myts  = MyTextSanitizer::getInstance();
-    $label = $myts->htmlSpecialChars($label, ENT_QUOTES, _INSTALL_CHARSET, false);
-    $name  = $myts->htmlSpecialChars($name, ENT_QUOTES, _INSTALL_CHARSET, false);
-    $value = $myts->htmlSpecialChars($value, ENT_QUOTES);
+    $label = installerHtmlSpecialChars($label);
+    $name  = installerHtmlSpecialChars($name);
+    $value = installerHtmlSpecialChars($value);
     echo '<div class="form-group">';
     echo '<label class="xolabel" for="' . $name . '">' . $label . '</label>';
     if ($help) {
@@ -86,10 +96,9 @@ function xoFormField($name, $value, $label, $help = '')
  */
 function xoPassField($name, $value, $label, $help = '')
 {
-    $myts  = MyTextSanitizer::getInstance();
-    $label = $myts->htmlSpecialChars($label, ENT_QUOTES, _INSTALL_CHARSET, false);
-    $name  = $myts->htmlSpecialChars($name, ENT_QUOTES, _INSTALL_CHARSET, false);
-    $value = $myts->htmlSpecialChars($value, ENT_QUOTES);
+    $label = installerHtmlSpecialChars($label);
+    $name  = installerHtmlSpecialChars($name);
+    $value = installerHtmlSpecialChars($value);
     echo '<div class="form-group">';
     echo '<label class="xolabel" for="' . $name . '">' . $label . '</label>';
     if ($help) {
@@ -113,10 +122,9 @@ function xoPassField($name, $value, $label, $help = '')
  */
 function xoFormSelect($name, $value, $label, $options, $help = '', $extra='')
 {
-    $myts  = MyTextSanitizer::getInstance();
-    $label = $myts->htmlSpecialChars($label, ENT_QUOTES, _INSTALL_CHARSET, false);
-    $name  = $myts->htmlSpecialChars($name, ENT_QUOTES, _INSTALL_CHARSET, false);
-    $value = $myts->htmlSpecialChars($value, ENT_QUOTES);
+    $label = installerHtmlSpecialChars($label);
+    $name  = installerHtmlSpecialChars($name);
+    $value = installerHtmlSpecialChars($value);
     echo '<div class="form-group">';
     echo '<label class="xolabel" for="' . $name . '">' . $label . '</label>';
     if ($help) {
@@ -404,10 +412,9 @@ function xoFormFieldCharset($name, $value, $label, $help, $link)
         $charsets[$k] = $v . ' (' . $k . ')';
     }
     asort($charsets);
-    $myts  = MyTextSanitizer::getInstance();
-    $label = $myts->htmlSpecialChars($label, ENT_QUOTES, _INSTALL_CHARSET, false);
-    $name  = $myts->htmlSpecialChars($name, ENT_QUOTES, _INSTALL_CHARSET, false);
-    $value = $myts->htmlSpecialChars($value, ENT_QUOTES);
+    $label = installerHtmlSpecialChars($label);
+    $name  = installerHtmlSpecialChars($name);
+    $value = installerHtmlSpecialChars($value);
     $extra = 'onchange="setFormFieldCollation(\'DB_COLLATION\', this.value)"';
     return xoFormSelect($name, $value, $label, $charsets, $help, $extra);
 }


### PR DESCRIPTION
Before mainfile.php is written, XOOPS_ROOT_PATH is defined based on the filesystem location of installer. The forms used to collect install data use textsanitizer in some situations. Textsanitizer now uses XOOPS_VAR_PATH in locating config files, and in this case, before that define is established.

The only method used is MyTextSanitizer::htmlSpecialChars so this commit replaces those calls with calls to a work-alike local function.