### PR TITLE
Allow for override of any template in admin themes

### DIFF
--- a/htdocs/class/smarty/xoops_plugins/resource.db.php
+++ b/htdocs/class/smarty/xoops_plugins/resource.db.php
@@ -11,7 +11,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * @copyright       (c) 2000-2016 XOOPS Project (www.xoops.org)
+ * @copyright       (c) 2000-2021 XOOPS Project (https://xoops.org)
  * @license             GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
  * @param $tpl_name
  * @param $tpl_source
@@ -101,7 +101,7 @@ function smarty_resource_db_tplinfo($tpl_name)
             return $cache[$tpl_name] = $tplobj[0];
         }
     }
-    // If we'using the default tplset, get the template from the filesystem
+    // If we're using the default tplset, get the template from the filesystem
     $tplobj = $tplfile_handler->find('default', null, null, null, $tpl_name, true);
 
     if (!count($tplobj)) {
@@ -115,6 +115,10 @@ function smarty_resource_db_tplinfo($tpl_name)
         case 'block':
             $directory = XOOPS_THEME_PATH;
             $path      = 'blocks/';
+            if (class_exists('XoopsSystemCpanel', false)) {
+                $directory = XOOPS_ADMINTHEME_PATH;
+                $theme     = isset($xoopsConfig['cpanel']) ? $xoopsConfig['cpanel'] : 'default';
+            }
             break;
         case 'admin':
             $theme     = isset($xoopsConfig['cpanel']) ? $xoopsConfig['cpanel'] : 'default';
@@ -122,8 +126,13 @@ function smarty_resource_db_tplinfo($tpl_name)
             $path      = 'admin/';
             break;
         default:
+            // at time of this comment, this only includes type 'module'
             $directory = XOOPS_THEME_PATH;
             $path      = '';
+            if (class_exists('XoopsSystemCpanel', false)) {
+                $directory = XOOPS_ADMINTHEME_PATH;
+                $theme     = isset($xoopsConfig['cpanel']) ? $xoopsConfig['cpanel'] : 'default';
+            }
             break;
     }
     // First, check for an overloaded version within the theme folder


### PR DESCRIPTION
Re: #974

Example: override system_confirm.tpl in admin transition theme with template here:
`modules/system/themes/transition/modules/system/system_confirm.tpl`

Override of block templates in the directory:
`modules/system/themes/transition/modules/system/blocks/`

Override of admin templates remains unchanged in the directory:
`modules/system/themes/transition/modules/system/admin/`