### PR TITLE
Fix pagenav in protector center

### DIFF
--- a/htdocs/xoops_lib/modules/protector/admin/admin_header.php
+++ b/htdocs/xoops_lib/modules/protector/admin/admin_header.php
@@ -19,8 +19,10 @@
 //include_once dirname(dirname(dirname(__DIR__))) . '/mainfile.php';
 include_once XOOPS_ROOT_PATH . '/mainfile.php';
 
-//include_once XOOPS_ROOT_PATH . '/include/cp_functions.php';
-include '../../../include/cp_header.php';
+include_once XOOPS_ROOT_PATH . '/include/cp_header.php';
+include_once XOOPS_ROOT_PATH . '/include/cp_functions.php';
+
+//include '../../../include/cp_header.php';
 //require_once XOOPS_ROOT_PATH . '/modules/' . $GLOBALS['xoopsModule']->getVar('dirname') . '/include/functions.php';
 
 if (file_exists($GLOBALS['xoops']->path('/Frameworks/moduleclasses/moduleadmin/moduleadmin.php'))) {

--- a/htdocs/xoops_lib/modules/protector/admin/center.php
+++ b/htdocs/xoops_lib/modules/protector/admin/center.php
@@ -1,6 +1,8 @@
 <?php
 //require_once XOOPS_ROOT_PATH.'/include/cp_header.php' ;
 include_once 'admin_header.php'; //mb problem: it shows always the same "Center" tab
+xoops_cp_header();
+include __DIR__ . '/mymenu.php';
 require_once XOOPS_ROOT_PATH . '/class/pagenav.php';
 require_once dirname(__DIR__) . '/class/gtickets.php';
 
@@ -135,8 +137,6 @@ foreach ($num_array as $n) {
 }
 
 // beggining of Output
-xoops_cp_header();
-include __DIR__ . '/mymenu.php';
 
 // title
 echo "<h3 style='text-align:left;'>" . $xoopsModule->name() . "</h3>\n";


### PR DESCRIPTION
center.php actually rendered the pagenav before it did the typical admin xoops_cp_header() that establishees it as a control panel themed page.