### PR TITLE
Delete phantom anonymous entry in online left when user logs in

### DIFF
--- a/htdocs/kernel/online.php
+++ b/htdocs/kernel/online.php
@@ -88,6 +88,12 @@ class XoopsOnlineHandler
                 $sql .= " AND online_ip={$ip}";
             }
         } else {
+            if ($uid != 0) {
+                // this condition (no entry for a real user) exists when a user first signs in
+                // first, cleanup the uid == 0 row the user generated before signing in
+                $loginSql = sprintf('DELETE FROM %s WHERE online_uid = 0 AND online_ip=%s', $this->db->prefix('online'), $ip);
+                $this->db->queryF($loginSql);
+            }
             $sql = sprintf(
                 'INSERT INTO %s (online_uid, online_uname, online_updated, online_ip, online_module)'
                 . ' VALUES (%u, %s, %u, %s, %u)',


### PR DESCRIPTION
Rework on #1005  -- Sorry, my bad. :frowning: 

On revisiting, the original change was too late. By the time the newly logged in user has a row in the online table, it is too late to clean up. At that point, just determining there is a problem becomes complex.

Instead, this tries to delete the anonymous user row in the online table that the newly signed in user created before inserting the new row for the user.