### PR TITLE
Bootstrap 4 online templates for xswatch4

### DIFF
--- a/htdocs/themes/xswatch4/language/english/main.php
+++ b/htdocs/themes/xswatch4/language/english/main.php
@@ -103,3 +103,9 @@ define('THEME_FILE_SIZE', 'Size');
 
 define('THEME_CONTROL_NEXT', 'Next');
 define('THEME_CONTROL_PREVIOUS', 'Previous');
+
+// Bloc online
+define('THEME_OL_MEMBERS', 'Members');
+define('THEME_OL_MEMBER', 'Member');
+define('THEME_OL_GUESTS', 'Guests');
+define('THEME_OL_GUEST', 'Guest');

--- a/htdocs/themes/xswatch4/modules/system/blocks/system_block_online.tpl
+++ b/htdocs/themes/xswatch4/modules/system/blocks/system_block_online.tpl
@@ -1,6 +1,21 @@
-<p><{$block.online_total}></p>
-<p><{$block.lang_members}>: <{$block.online_members}></p>
-<p><{$block.lang_guests}>: <{$block.online_guests}></p>
-<p><{$block.online_names}></p>
-<a class="btn btn-xs btn-info" href="javascript:openWithSelfMain('<{$xoops_url}>/misc.php?action=showpopups&amp;type=online','Online',420,350);"
-   title="<{$block.lang_more}>"><{$block.lang_more}></a>
+<div class="d-flex flex-row mt-1 mb-3">
+   <div class=""><span class="fa fa-users fa-lg fa-fw text-success"></span></div>
+   <div class="ml-2"><{$block.online_total}></div>
+</div>
+<p>
+   <{if $block.online_guests > 1}>
+      <span class="fa fa-users fa-fw text-secondary"></span> <{$block.online_guests}> <{$smarty.const.THEME_OL_GUESTS}>
+   <{else}>
+      <span class="fa fa-user fa-fw text-secondary"></span> <{$block.online_guests}>  <{$smarty.const.THEME_OL_GUEST}>
+   <{/if}>
+   <br />
+   <{if $block.online_members > 1}>
+      <span class="fa fa-users fa-fw text-info"></span> <{$block.online_members}> <{$smarty.const.THEME_OL_MEMBERS}>
+   <{else}>
+      <span class="fa fa-user fa-fw text-info"></span> <{$block.online_members}> <{$smarty.const.THEME_OL_MEMBER}>
+   <{/if}>
+</p>
+<p>
+   <{$block.online_names}> <a class="" href="javascript:openWithSelfMain('<{$xoops_url}>/misc.php?action=showpopups&amp;type=online','Online',420,350);"
+      title="<{$block.lang_more}>"><span class="fa fa-search-plus fa-lg fa-fw "></span></a>
+</p>

--- a/htdocs/themes/xswatch4/modules/system/system_misc_online.tpl
+++ b/htdocs/themes/xswatch4/modules/system/system_misc_online.tpl
@@ -1,0 +1,45 @@
+<{* online details popup *}>
+<{if $closeHead|default:true}>
+    <{$headContents|default:''}>
+    <script>window.resizeTo(260, 560)</script>
+    </head>
+    <body>
+<{/if}>
+
+<h4 class="text-center"><{$lang_whoisonline}></h4>
+
+<{foreach item=online from=$onlineUserInfo}>
+    <div class="row justify-content-center align-items-center <{cycle values='alert-primary,alert-secondary'}>">
+        <div class="col-12 col-sm-3 text-center mt-2">
+            <{if $online.uid == 0}>
+                <h6><{$online.uname}></h6>
+            <{else}>
+                <{if $online.avatar != "avatars/blank.gif" }>
+                    <img src="<{$upload_url}><{$online.avatar}>" alt="<{$lang_avatar}>" class="img-fluid rounded mt-2"/><br /> 
+                    <a href="javascript:window.opener.location='<{$xoops_url}>/userinfo.php?uid=<{$online.uid}>';window.close();">
+                        <{if $online.name==''}><{$online.uname}><{else}><{$online.name}><{/if}>
+                    </a>
+                <{else}>        
+                    <h6><{if $online.name==''}><{$online.uname}><{else}><{$online.name}><{/if}></h6>
+                <{/if}>	
+            <{/if}>
+        </div>
+    
+        <div class="col-12 col-sm-6 my-1">
+            <{if $online.module_name <> "" }>
+                <h5 class="text-center text-sm-left font-weight-bold"><{$online.module_name}></h5>
+            <{/if}>
+            <{if $isadmin|default:false}>
+                <div class="ml-5 ml-sm-0">
+                    <span class="fa fa-map-marker fa-fw "></span> <{$online.ip}>
+                    <br>
+                    <span class="fa fa-calendar fa-fw "></span> <{$online.updated}>
+                </div>    
+            <{/if}>
+        </div>
+    </div>
+<{/foreach}>
+
+<{if $closeButton|default:true}>
+    <div class="text-center m-3"><input class="btn btn-primary btn-lg btn-block" value="<{$lang_close}>" type="button" onclick="window.close();" /></div>
+<{/if}>


### PR DESCRIPTION
Since Richard modify misc.php, we can use overloaded templates.

Improvement :

system_bloc_online:
- Full Bt4
- Add icons
- Icons depends number (<2 and >1)
- Icons color depend groups (all, anonymous, members)
- Text depends number
- Add icon for "more"

system_misc_online:
- Full BT4
- All redesigned
- No avatar for anonymous
- No avatar for members if they have not (space saving)
- Icons for IP and date
- Add a cycle value for background colors
- Large button to close window
- More readable if you expand larger windows size

### Display 1
![Capture d’écran 2021-03-29 143550](https://user-images.githubusercontent.com/5336960/112841797-38158180-90a1-11eb-9904-5e25db6ca955.png)
### Display 2
![Capture d’écran 2021-03-29 143635](https://user-images.githubusercontent.com/5336960/112841818-3ea3f900-90a1-11eb-8128-a3e012ea20c0.png)
### For Webmasters
![Capture d’écran 2021-03-29 143828](https://user-images.githubusercontent.com/5336960/112841932-58ddd700-90a1-11eb-808e-dbbc18012551.jpg)
### For others 
![Capture d’écran 2021-03-29 144012](https://user-images.githubusercontent.com/5336960/112841953-5da28b00-90a1-11eb-972a-fdf7c655fed8.jpg)
### For Webmasters, large windows
![Capture d’écran 2021-03-29 144040](https://user-images.githubusercontent.com/5336960/112841963-609d7b80-90a1-11eb-91da-07932d62c6b7.jpg)
### For others, large windows 
![Capture d’écran 2021-03-29 144105](https://user-images.githubusercontent.com/5336960/112841971-62673f00-90a1-11eb-942a-450da5a3c31b.jpg)



