### PR TITLE
Skip scan if directory is not present

### DIFF
--- a/upgrade/upd_2.5.10-to-2.5.11/index.php
+++ b/upgrade/upd_2.5.10-to-2.5.11/index.php
@@ -460,6 +460,9 @@ class Upgrade_2511 extends XoopsUpgrade
      */
     private function checkDirForIndexHtml($startingPath, \Closure $onFound)
     {
+        if (!is_dir($startingPath)) {
+            return 0;
+        }
         $i = 0;
         $rdi = new \RecursiveDirectoryIterator($startingPath);
         $rii = new \RecursiveIteratorIterator($rdi);


### PR DESCRIPTION
During upgrade, if a directory is removed (i.e. an unwanted theme) don't try to scan.