### PR TITLE
Explicitly set default mysqli_report(MYSQLI_REPORT_OFF)

### DIFF
--- a/htdocs/class/database/mysqldatabase.php
+++ b/htdocs/class/database/mysqldatabase.php
@@ -60,6 +60,7 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
         } else {
             $dbname = '';
         }
+        mysqli_report(MYSQLI_REPORT_OFF);
         if (XOOPS_DB_PCONNECT == 1) {
             $this->conn = new mysqli('p:' . XOOPS_DB_HOST, XOOPS_DB_USER, XOOPS_DB_PASS, $dbname);
         } else {

--- a/htdocs/install/page_dbconnection.php
+++ b/htdocs/install/page_dbconnection.php
@@ -44,6 +44,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($vars['DB_HOST']) && !empty($vars['DB_USER'])) {
     $hostConnectPrefix = empty($vars['DB_PCONNECT']) ? '' : 'p:';
+    mysqli_report(MYSQLI_REPORT_OFF);
     $link = new mysqli($hostConnectPrefix.$vars['DB_HOST'], $vars['DB_USER'], $vars['DB_PASS']);
     if (0 !== $link->connect_errno) {
         $error = ERR_NO_DBCONNECTION .' (' . $link->connect_errno . ') ' . $link->connect_error;

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -290,6 +290,7 @@ class Protector
         }
 
         if (empty($this->_conn)) {
+            mysqli_report(MYSQLI_REPORT_OFF);
             $this->_conn = new mysqli(XOOPS_DB_HOST, XOOPS_DB_USER, XOOPS_DB_PASS);
             if (0 !== $this->_conn->connect_errno) {
                 die('db connection failed.');


### PR DESCRIPTION
The default value for this setting is changing in PHP 8.1. With the current default, errors are reported by returning false, while the future default will be to throw an exception.

Explicitly declaring the value we use now, even though it is the default, will prevent future problems.