### PR TITLE
add link to image of an activated module

### DIFF
--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -1426,9 +1426,15 @@ function xoops_module_log_header($module, $title)
 {
     $msgs[] = '<div class="header">';
     $msgs[] = $errs[] = '<h4>' . $title . $module->getInfo('name', 's') . '</h4>';
+
     if ($module->getInfo('image') !== false && trim($module->getInfo('image')) != '') {
-        $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . $module->getVar('dirname') . '/' . trim($module->getInfo('image')) . '" alt="" />';
+        if (_AM_SYSTEM_MODULES_ACTIVATE === $title) {
+            $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . $module->getInfo('dirname', 'e') . '/' . $module->getInfo('adminindex') . '"><img src="' . XOOPS_URL . '/modules/' . $module->getInfo('dirname', 'e') . '/' . trim($module->getInfo('image')) . '" alt="" /></a>';
+        } else {
+            $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . $module->getVar('dirname') . '/' . trim($module->getInfo('image')) . '" alt="" />';
+        }
     }
+
     $msgs[] = '<strong>' . _VERSION . ':</strong> ' . $module->getInfo('version') . '&nbsp;' . $module->getInfo('module_status');
     if ($module->getInfo('author') !== false && trim($module->getInfo('author')) != '') {
         $msgs[] = '<strong>' . _AUTHOR . ':</strong> ' . htmlspecialchars(trim($module->getInfo('author')));


### PR DESCRIPTION
This is to make it consistent with module installation behavior. It makes also easier to click on the image of the activated module to go to its admin
When module is deactivated then, of course, the image should not have the link
I'm using it in my  https://github.com/mambax7/moduleinstaller