### PR TITLE
Display warning if xml extension not available

### DIFF
--- a/docs/lang_diff.txt
+++ b/docs/lang_diff.txt
@@ -8,6 +8,9 @@ Below are language differences from a version to next version.
 ================================
 
 CHANGED FILES:
+htdocs/language/english/admin.php
+- added define('_AD_WARNING_NO_XML', 'The PHP XML Extension is required for this function.');
+
 htdocs/xoops_lib/modules/protector/language/english/admin.php
 - added define('_AM_ADMINSTATS_LAST_MONTH', 'Last Month');
 - added define('_AM_ADMINSTATS_LAST_WEEK', 'Last Week');

--- a/htdocs/admin.php
+++ b/htdocs/admin.php
@@ -76,6 +76,12 @@ if (!isset($xoopsConfig['admin_warnings_enable']) || $xoopsConfig['admin_warning
     }
 }
 
+if (!empty($_GET['xoopsorgnews']) && !function_exists('xml_parser_create')) {
+    xoops_result(_AD_WARNING_NO_XML);
+    echo '<br>';
+    unset($_GET['xoopsorgnews']);
+}
+
 if (!empty($_GET['xoopsorgnews'])) {
     // Multiple feeds
     $myts     = MyTextSanitizer::getInstance();

--- a/htdocs/language/english/admin.php
+++ b/htdocs/language/english/admin.php
@@ -20,3 +20,4 @@ define('_AD_WARNINGWRITEABLE', 'WARNING: File %s is writeable by the server. <br
 define('_AD_WARNINGNOTWRITEABLE', 'WARNING: Folder %s is not writeable by the server. <br>Please change the permission of this folder.<br> in Unix (777), in Win32 (writable)');
 define('_AD_WARNINGXOOPSLIBINSIDE', 'WARNING: Folder %s is inside DocumentRoot! <br>For security considerations it is highly suggested to move it out of DocumentRoot.');
 define('_AD_WARNING_OLD_PHP', 'WARNING: Consider upgrading to a newer version of PHP. Version %s or newer is recommended and will be required in future XOOPS versions.');
+define('_AD_WARNING_NO_XML', 'The PHP XML Extension is required for this function.');


### PR DESCRIPTION
Display a proper message if Xoops News in admin cannot function.

Fixes #1096