### PR TITLE
bt4 search for xswatch4

### DIFF
--- a/htdocs/themes/xswatch4/modules/profile/profile_userinfo.tpl
+++ b/htdocs/themes/xswatch4/modules/profile/profile_userinfo.tpl
@@ -1,20 +1,18 @@
 <{include file="db:profile_breadcrumbs.tpl"}>
 <div class="row">
-    <div class="col-xs-6 col-md-6 aligncenter">
+    <div class="col-md-6 text-center">
         <{if $avatar}>
             <img src="<{$avatar}>" alt="<{$uname}>" class="img-responsive img-rounded img-thumbnail">
         <{/if}>
-        <div class="aligncenter">
             <ul class="list-unstyled">
                 <li><span class="label label-info"><{$uname}></span></li>
                 <{if $email}>
                     <li><span class="label label-info"><{$email}></span></li>
                 <{/if}>
             </ul>
-        </div><!-- .aligncenter -->
-    </div><!-- .col-md-6 .aligncenter -->
+    </div><!-- .col-md-6 -->
 
-    <div class="col-xs-6 col-md-6">
+    <div class="col-md-6">
         <{if !$user_ownpage && $xoops_isuser == true}>
             <form name="usernav" action="user.php" method="post">
                 <input class="btn btn-primary btn-xs btn-block" type="button" value="<{$smarty.const._PROFILE_MA_SENDPM}>"
@@ -73,11 +71,29 @@
     <ul class="profile-values list-unstyled">
         <li class="profile-category-title"><{$recent_activity}></li>
         <{foreach item=module from=$modules}>
-            <li><strong><{$module.name}></strong></li>
-            <{foreach item=result from=$module.results}>
-                <li><img src="<{$result.image}>" alt="<{$module.name}>"> <a href="<{$result.link}>"><{$result.title}></a> (<{$result.time}>)</li>
-            <{/foreach}>
-            <{$module.showall_link}>
-        <{/foreach}>
+<!-- alain01 -->
+            <div class="card my-3">
+                <div class="card-header"><h5><{$module.name}> <{if $module.showall_link}><span class="x-small">| <{$module.showall_link}></span><{/if}></h5></div>
+                <div class="card-body">
+                    <ul class="list-group list-group-flush">
+                        <{foreach item=result from=$module.results}>
+                        <li class="list-group-item list-group-item-action">
+                            <{assign var="url_image_overloaded" value=$xoops_imageurl|cat:"modules/"|cat:$result.image|replace:"$xoops_url/modules/":''}>
+                            <{assign var="path_image_overloaded" value=$xoops_rootpath|cat:"/themes/"|cat:$xoops_theme|cat:"/"|cat:$url_image_overloaded|replace:$xoops_imageurl:''}>
+
+                            <{if file_exists($path_image_overloaded)}>
+                                <div class="d-inline"><img src="<{$url_image_overloaded}>" alt="<{$module.name}>"> <a href="<{$result.link}>"><{$result.title}></a></div>
+                                <span class="d-inline d-sm-none"><br /></span>
+                                <div class="d-inline text-muted"><small><span class="fa fa-calendar fa-sm ml-2"></span> <{$result.time}></small></div>
+                                <br />
+                            <{else}>
+                                <img src="<{$result.image}>" alt="<{$module.name}>"> <a href="<{$result.link}>"><{$result.title}></a> <small><span class="fa fa-calendar fa-sm ml-2"></span> <{$result.time}></small><br />
+                            <{/if}>
+                        </li>
+                        <{/foreach}>
+                    </ul>
+                </div>
+            </div>
+       <{/foreach}>
     </ul>
 <{/if}>

--- a/htdocs/themes/xswatch4/modules/system/system_search.tpl
+++ b/htdocs/themes/xswatch4/modules/system/system_search.tpl
@@ -1,0 +1,163 @@
+<{if $results}>	
+	<h3><{$smarty.const._SR_SEARCHRESULTS}></h3>
+	<{$smarty.const._SR_KEYWORDS}>: <mark><{$keywords}></mark>
+	<br>
+	<{if $error_length != ''}>
+		<{$error_length}> <strong><{$error_keywords}></strong>
+		<br>
+	<{/if}>
+	<{if $nomatch}>	
+		<br>
+		<{$nomatch}>
+		<br>
+	<{/if}>
+	
+	<{foreach item=search from=$search}>
+
+        <div class="card my-3">
+            <div class="card-header">
+				<h5>
+					<{$search.module_name}> 
+					<{if $search.module_show_all}>
+						<span class="d-none d-sm-inline"><span class="x-small">| <a href="<{$search.module_show_all}>"><{$smarty.const._SR_SHOWALLR}></a></span></span>
+						<span class="d-inline d-sm-none">| <span class="ml-2"></span><a href="<{$search.module_show_all}>"><span class="fa fa-search-plus fa-flip-horizontal fa-lg"></span></a></span>
+					<{/if}>
+				</h5>
+			</div>
+            
+			<div class="card-body">		
+				<ul class="list-group list-group-flush">
+                   	<{foreach item=data from=$search.module_data}>
+ 						<li class="list-group-item list-group-item-action">
+<!-- Alain01 -->
+							<{assign var="url_image_overloaded" value=$xoops_imageurl|cat:$data.image_link}>
+							<{assign var="path_image_overloaded" value=$xoops_rootpath|cat:"/themes/"|cat:$xoops_theme|cat:"/"|cat:$data.image_link}>
+							<{if file_exists($path_image_overloaded)}>
+								<div class="d-inline"><img src="<{$url_image_overloaded}>" title="<{$data.image_title}>" alt="<{$data.image_title}>"/> <a href="<{$data.link}>"><{$data.link_title}></a></div>
+							<{else}>
+								<div class="d-inline"><img src="<{$data.image_link}>" title="<{$data.image_title}>" alt="<{$data.image_title}>"/> <a href="<{$data.link}>"><{$data.link_title}></a></div>
+							<{/if}>
+							
+							<{if $data.uname}>
+								
+								<div class="d-none d-md-inline">
+									<br />
+									<small><span class="fa fa-user fa-sm ml-2 text-muted"></span> <a href="<{$data.uname_link}>"><{$data.uname}></a></small>
+								
+									<{if $data.time}>
+										<small><span class="text-muted"><span class="fa fa-calendar fa-sm ml-2"></span> <{$data.time}></span></small>
+									<{/if}>				
+								</div>
+							<{/if}>	
+						</li>
+                    <{/foreach}>
+ 				</ul>
+			</div>
+        </div>
+
+	<{/foreach}>
+<{/if}>
+<{if $showallbyuser}>	
+	<h3><{$smarty.const._SR_SEARCHRESULTS}></h3>
+	<{if $showall}>
+		<{$smarty.const._SR_KEYWORDS}>: <mark><{$keywords}></mark>
+		<br>
+	<{/if}>
+
+	<div class="card my-3">
+		<div class="card-header">
+			<div class="d-flex justify-content-between">
+				<div>
+					<h5><{$module_name}></h5>
+					<{$showing|replace:"-":"- "}>
+				</div>	
+				<{if $previous || next}>
+					<div>			
+					<{if $previous}>
+						<span class="d-none d-sm-inline"><a class="btn btn-secondary" href="<{$previous}>" role="button"><{$smarty.const._SR_PREVIOUS|replace:"<<":"<span class='fa fa-chevron-left fa-lg'></span>"}></a></span>
+						<span class="d-inline d-sm-none"><a class="btn btn-secondary" href="<{$previous}>" role="button"><span class="fa fa-chevron-left"></span></a></span>
+					<{else}>
+						<span class="d-none d-sm-inline"><a class="btn btn-secondary disabled" role="button" tabindex="-1" aria-disabled="true"><span class="text-muted"><{$smarty.const._SR_PREVIOUS|replace:"<<":"<span class='fa fa-chevron-left fa-lg'></span>"}></span></a></span>		
+						<span class="d-inline d-sm-none"><a class="btn btn-secondary disabled" role="button" tabindex="-1" aria-disabled="true"><span class="text-muted"><span class="fa fa-chevron-left"></span></span></a></span>		
+					<{/if}>
+					<span class="mx-1"></span>
+					<{if $next}>
+						<span class="d-none d-sm-inline"><a class="btn btn-secondary" href="<{$next}>" role="button"><{$smarty.const._SR_NEXT|replace:">>":"<span class='fa fa-chevron-right fa-lg'></span>"}></a></span>
+						<span class="d-inline d-sm-none"><a class="btn btn-secondary" href="<{$next}>" role="button"><span class="fa fa-chevron-right"></span></a></span>
+					<{else}>
+						<span class="d-none d-sm-inline"><a class="btn btn-secondary disabled"  role="button" tabindex="-1" aria-disabled="true"><span class="text-muted"><{$smarty.const._SR_NEXT|replace:">>":"<span class='fa fa-chevron-right fa-lg'></span>"}></span></a></span>
+						<span class="d-inline d-sm-none"><a class="btn btn-secondary disabled"  role="button" tabindex="-1" aria-disabled="true"><span class="text-muted"><span class="fa fa-chevron-right"></span></span></a></span>
+					<{/if}>
+					</div>
+				<{/if}>
+			</div>
+		</div>
+        <div class="card-body">
+			<ul class="list-group list-group-flush">
+				<{foreach item=data from=$results_arr}>
+					<li class="list-group-item list-group-item-action">
+<!-- Alain01 -->
+						<{assign var="url_image_overloaded" value=$xoops_imageurl|cat:$data.image_link}>
+						<{assign var="path_image_overloaded" value=$xoops_rootpath|cat:"/themes/"|cat:$xoops_theme|cat:"/"|cat:$data.image_link}>
+
+						<{if file_exists($path_image_overloaded)}>
+							<div class="d-inline"><img src="<{$url_image_overloaded}>" title="<{$data.image_title}>" alt="<{$data.image_title}>"/> <a href="<{$data.link}>"><{$data.link_title}></a></div>
+						<{else}>
+							<div class="d-inline"><img src="<{$data.image_link}>" title="<{$data.image_title}>" alt="<{$data.image_title}>"/> <a href="<{$data.link}>"><{$data.link_title}></a></div>
+						<{/if}>
+						
+						<{if $data.uname}>
+							
+							<div class="d-none d-md-inline text-muted">
+								<br />
+								<small><span class="fa fa-user fa-sm ml-2"></span> <a href="<{$data.uname_link}>"><{$data.uname}></a></small>
+							
+								<{if $data.time}>
+									<small><span class="fa fa-calendar fa-sm ml-2"></span> <{$data.time}></small>
+								<{/if}>				
+							</div>
+						<{/if}>	
+						<br />	
+					</li>
+				<{/foreach}>
+			</ul>
+        </div>
+		<div class="card-footer">
+			<div class="d-flex justify-content-between">
+				<div>
+					<h5><{$module_name}></h5>
+					<{$showing|replace:"-":"- "}>
+				</div>	
+				<{if $previous || next}>
+					<div>			
+					<{if $previous}>
+						<span class="d-none d-sm-inline"><a class="btn btn-secondary" href="<{$previous}>" role="button"><{$smarty.const._SR_PREVIOUS|replace:"<<":"<span class='fa fa-chevron-left fa-lg'></span>"}></a></span>
+						<span class="d-inline d-sm-none"><a class="btn btn-secondary" href="<{$previous}>" role="button"><span class="fa fa-chevron-left"></span></a></span>
+					<{else}>
+						<span class="d-none d-sm-inline"><a class="btn btn-secondary disabled" role="button" tabindex="-1" aria-disabled="true"><span class="text-muted"><{$smarty.const._SR_PREVIOUS|replace:"<<":"<span class='fa fa-chevron-left fa-lg'></span>"}></span></a></span>		
+						<span class="d-inline d-sm-none"><a class="btn btn-secondary disabled" role="button" tabindex="-1" aria-disabled="true"><span class="text-muted"><span class="fa fa-chevron-left"></span></span></a></span>		
+					<{/if}>
+					<span class="mx-1"></span>
+					<{if $next}>
+						<span class="d-none d-sm-inline"><a class="btn btn-secondary" href="<{$next}>" role="button"><{$smarty.const._SR_NEXT|replace:">>":"<span class='fa fa-chevron-right fa-lg'></span>"}></a></span>
+						<span class="d-inline d-sm-none"><a class="btn btn-secondary" href="<{$next}>" role="button"><span class="fa fa-chevron-right"></span></a></span>
+					<{else}>
+						<span class="d-none d-sm-inline"><a class="btn btn-secondary disabled"  role="button" tabindex="-1" aria-disabled="true"><span class="text-muted"><{$smarty.const._SR_NEXT|replace:">>":"<span class='fa fa-chevron-right fa-lg'></span>"}></span></a></span>
+						<span class="d-inline d-sm-none"><a class="btn btn-secondary disabled"  role="button" tabindex="-1" aria-disabled="true"><span class="text-muted"><span class="fa fa-chevron-right"></span></span></a></span>
+					<{/if}>
+					</div>
+				<{/if}>
+			</div>
+  		</div>
+		
+    </div>
+	<{if $nomatch}>
+		<p>
+			<{$smarty.const._SR_NOMATCH}>
+		</p>
+	<{/if}>
+<{/if}>
+<{if $form}>
+	<hr>
+	<{$form}>
+<{/if}>


### PR DESCRIPTION
- I added an "automatic" image overload mode.
If image overloading is present then use it otherwise use the default image

Exemple to overload the search image for xmnews: ![xmnews_search](https://user-images.githubusercontent.com/5336960/141340330-a7497514-e8fa-4973-b32a-eeb4028d554d.png) => ![xmnews_search](https://user-images.githubusercontent.com/5336960/141340161-c6ac216f-1a96-493d-ab91-67c2337f294e.png)
Add /themes/xswatch4/modules/xmnews/assets/images/xmnews_search.png (new logo ![xmnews_search](https://user-images.githubusercontent.com/5336960/141340161-c6ac216f-1a96-493d-ab91-67c2337f294e.png))

- I modernized the page with a presentation by module in cards
I also changed the location of some elements in order to have an optimal reading

- I replaced "<< Previous Next >>" with nice buttons.
They are now always visible and are simply disabled if the Next or Previous page does not exist

- I also optimized the width and so now the display is responsive.

Exemples: 
Search:
https://www.monxoops.fr/search.php?query=xswatch4&action=results&lang=english

Userinfo :
https://www.monxoops.fr/modules/profile/userinfo.php?uid=2&lang=english