### PR TITLE
Review filter and escape in findusers 

### DIFF
--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -251,7 +251,7 @@ class XoUserHandler extends XoopsObjectHandler
      *
      * @param  CriteriaElement $criteria
      * @param  array           $groups
-     * @return object
+     * @return array of matching objects
      */
     public function getAll(CriteriaElement $criteria = null, $groups = array())
     {

--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -38,8 +38,9 @@ if ($denied) {
 
 $token         = Request::getString('token', '');
 $name_form     = 'memberslist';
-$name_userid   = 'uid' . (Request::hasVar('multiple') ? '[]' : '');
-$name_username = 'uname' . (Request::hasVar('multiple') ? '[]' : '');
+$multiple = Request::getInt('multiple', 0);
+$name_userid   = 'uid' . ((0 != $multiple) ? '[]' : '');
+$name_username = 'uname' . ((0 != $multiple) ? '[]' : '');
 
 xoops_loadLanguage('findusers');
 
@@ -300,10 +301,11 @@ $items_match = array(
     'uname'     => _MA_USER_UNAME,
     'name'      => _MA_USER_REALNAME,
     'email'     => _MA_USER_EMAIL,
-    'user_icq'  => _MA_USER_ICQ,
-    'user_aim'  => _MA_USER_AIM,
-    'user_yim'  => _MA_USER_YIM,
-    'user_msnm' => _MA_USER_MSNM);
+//  'user_icq'  => _MA_USER_ICQ,
+//  'user_aim'  => _MA_USER_AIM,
+//  'user_yim'  => _MA_USER_YIM,
+//  'user_msnm' => _MA_USER_MSNM,
+);
 
 $items_range = array(
     'user_regdate' => _MA_USER_RANGE_USER_REGDATE,
@@ -312,118 +314,117 @@ $items_range = array(
 
 define('FINDUSERS_MODE_SIMPLE', 0);
 define('FINDUSERS_MODE_ADVANCED', 1);
-define('FINDUSERS_MODE_QUERY', 2);
 
 $modes = array(
     FINDUSERS_MODE_SIMPLE   => _MA_USER_MODE_SIMPLE,
     FINDUSERS_MODE_ADVANCED => _MA_USER_MODE_ADVANCED,
-    FINDUSERS_MODE_QUERY    => _MA_USER_MODE_QUERY);
+);
 
 if (!Request::hasVar('user_submit', 'POST')) {
     include_once $GLOBALS['xoops']->path('class/xoopsformloader.php');
 
     $form = new XoopsThemeForm(_MA_USER_FINDUS, 'user_findform', 'findusers.php', 'post', true);
     $mode = Request::getInt('mode', 0);
-    if (FINDUSERS_MODE_QUERY == $mode) {
-        $form->addElement(new XoopsFormTextArea(_MA_USER_QUERY, 'query', Request::getString('query', '', 'POST')));
-    } else {
-        if (FINDUSERS_MODE_ADVANCED == $mode) {
-            foreach ($items_match as $var => $title) {
-                $text       = new XoopsFormText('', $var, 30, 100, Request::getString($var, '', 'POST'));
-                $match      = new XoopsFormSelectMatchOption('', "{$var}_match", @$_POST["{$var}_match"]);
-                $match_tray = new XoopsFormElementTray($title, '&nbsp;');
-                $match_tray->addElement($match);
-                $match_tray->addElement($text);
-                $form->addElement($match_tray);
-                unset($text, $match, $match_tray);
-            }
-
-            $url_text        = new XoopsFormText(_MA_USER_URLC, 'url', 30, 100, Request::getUrl('url', '', 'POST'));
-            $location_text   = new XoopsFormText(_MA_USER_LOCATION, 'user_from', 30, 100, Request::getString('user_from', '', 'POST'));
-            $occupation_text = new XoopsFormText(_MA_USER_OCCUPATION, 'user_occ', 30, 100, Request::getString('user_occ', '', 'POST'));
-            $interest_text   = new XoopsFormText(_MA_USER_INTEREST, 'user_intrest', 30, 100, Request::getString('user_intrest', '', 'POST'));
-            foreach ($items_range as $var => $title) {
-                $more       = new XoopsFormText('', "{$var}_more", 10, 5, Request::getString("{$var}_more", '', 'POST'));
-                $less       = new XoopsFormText('', "{$var}_less", 10, 5, Request::getString("{$var}_less", '', 'POST'));
-                $range_tray = new XoopsFormElementTray($title, '&nbsp;-&nbsp;&nbsp;');
-                $range_tray->addElement($less);
-                $range_tray->addElement($more);
-                $form->addElement($range_tray);
-                unset($more, $less, $range_tray);
-            }
-
-            $mailok_radio = new XoopsFormRadio(_MA_USER_SHOWMAILOK, 'user_mailok',  Request::hasVar('user_mailok', 'POST')  ? Request::getString('user_mailok', '', 'POST') :'both');
-            $mailok_radio->addOptionArray(array(
-                                              'mailok' => _MA_USER_MAILOK,
-                                              'mailng' => _MA_USER_MAILNG,
-                                              'both' => _MA_USER_BOTH));
-            $avatar_radio = new XoopsFormRadio(_MA_USER_HASAVATAR, 'user_avatar', Request::hasVar('user_avatar', 'POST')  ? Request::getString('user_avatar', '', 'POST') :'both');
-            $avatar_radio->addOptionArray(array(
-                                              'y' => _YES,
-                                              'n' => _NO,
-                                              'both' => _MA_USER_BOTH));
-
-            $level_radio = new XoopsFormRadio(_MA_USER_LEVEL, 'level', @$_POST['level']);
-            $levels      = array(
-                0 => _ALL,
-                1 => _MA_USER_LEVEL_ACTIVE,
-                2 => _MA_USER_LEVEL_INACTIVE,
-                3 => _MA_USER_LEVEL_DISABLED);
-            $level_radio->addOptionArray($levels);
-
-            /* @var XoopsMemberHandler $member_handler */
-            $member_handler = xoops_getHandler('member');
-            $groups         = $member_handler->getGroupList();
-            $groups[0]      = _ALL;
-            $group_select   = new XoopsFormSelect(_MA_USER_GROUP, 'groups', @$_POST['groups'], 3, true);
-            $group_select->addOptionArray($groups);
-
-            $ranks       = $rank_handler->getList();
-            $ranks[0]    = _ALL;
-            $rank_select = new XoopsFormSelect(_MA_USER_RANK, 'rank', Request::getInt('rank', 1, 'POST') );
-            $rank_select->addOptionArray($ranks);
-            $form->addElement($url_text);
-            $form->addElement($location_text);
-            $form->addElement($occupation_text);
-            $form->addElement($interest_text);
-            $form->addElement($mailok_radio);
-            $form->addElement($avatar_radio);
-            $form->addElement($level_radio);
-            $form->addElement($group_select);
-            $form->addElement($rank_select);
-        } else {
-            foreach (array(
-                         'uname',
-                         'email') as $var) {
-                $title      = $items_match[$var];
-                $text       = new XoopsFormText('', $var, 30, 100, Request::getString($var, '', 'POST'));
-                $match      = new XoopsFormSelectMatchOption('', "{$var}_match", @$_POST["{$var}_match"]);
-                $match_tray = new XoopsFormElementTray($title, '&nbsp;');
-                $match_tray->addElement($match);
-                $match_tray->addElement($text);
-                $form->addElement($match_tray);
-                unset($text, $match, $match_tray);
-            }
+    if (FINDUSERS_MODE_ADVANCED == $mode) {
+        foreach ($items_match as $var => $title) {
+            $text = new XoopsFormText('', $var, 30, 100, Request::getString($var, '', 'POST'));
+            $match = new XoopsFormSelectMatchOption('', "{$var}_match", Request::getInt("{$var}_match", 0));
+            $match_tray = new XoopsFormElementTray($title, '&nbsp;');
+            $match_tray->addElement($match);
+            $match_tray->addElement($text);
+            $form->addElement($match_tray);
+            unset($text, $match, $match_tray);
         }
 
-        $sort_select = new XoopsFormSelect(_MA_USER_SORT, 'user_sort', @$_POST['user_sort']);
-        $sort_select->addOptionArray(array(
-                                         'uname' => _MA_USER_UNAME,
-                                         'last_login' => _MA_USER_LASTLOGIN,
-                                         'user_regdate' => _MA_USER_REGDATE,
-                                         'posts' => _MA_USER_POSTS));
-        $order_select = new XoopsFormSelect(_MA_USER_ORDER, 'user_order', @$_POST['user_order']);
-        $order_select->addOptionArray(array(
-                                          'ASC' => _MA_USER_ASC,
-                                          'DESC' => _MA_USER_DESC));
+        $url_text        = new XoopsFormText(_MA_USER_URLC, 'url', 30, 100, Request::getUrl('url', '', 'POST'));
+        $location_text   = new XoopsFormText(_MA_USER_LOCATION, 'user_from', 30, 100, Request::getString('user_from', '', 'POST'));
+        $occupation_text = new XoopsFormText(_MA_USER_OCCUPATION, 'user_occ', 30, 100, Request::getString('user_occ', '', 'POST'));
+        $interest_text   = new XoopsFormText(_MA_USER_INTEREST, 'user_intrest', 30, 100, Request::getString('user_intrest', '', 'POST'));
+        foreach ($items_range as $var => $title) {
+            $more = new XoopsFormText('', "{$var}_more", 10, 5, Request::getString("{$var}_more", '', 'POST'));
+            $less = new XoopsFormText('', "{$var}_less", 10, 5, Request::getString("{$var}_less", '', 'POST'));
+            $range_tray = new XoopsFormElementTray($title, '&nbsp;-&nbsp;&nbsp;');
+            $range_tray->addElement($less);
+            $range_tray->addElement($more);
+            $form->addElement($range_tray);
+            unset($more, $less, $range_tray);
+        }
 
-        $form->addElement($sort_select);
-        $form->addElement($order_select);
+        $mailok_radio = new XoopsFormRadio(_MA_USER_SHOWMAILOK, 'user_mailok',  Request::getString('user_mailok', 'both', 'POST'));
+        $mailok_radio->addOptionArray(array(
+            'mailok' => _MA_USER_MAILOK,
+            'mailng' => _MA_USER_MAILNG,
+            'both' => _MA_USER_BOTH
+        ));
+        $avatar_radio = new XoopsFormRadio(_MA_USER_HASAVATAR, 'user_avatar', Request::getString('user_avatar', 'both', 'POST'));
+        $avatar_radio->addOptionArray(array(
+            'y' => _YES,
+            'n' => _NO,
+            'both' => _MA_USER_BOTH
+        ));
+
+        $level_radio = new XoopsFormRadio(_MA_USER_LEVEL, 'level', @$_POST['level']);
+        $levels      = array(
+            0 => _ALL,
+            1 => _MA_USER_LEVEL_ACTIVE,
+            2 => _MA_USER_LEVEL_INACTIVE,
+            3 => _MA_USER_LEVEL_DISABLED
+        );
+        $level_radio->addOptionArray($levels);
+
+        /* @var XoopsMemberHandler $member_handler */
+        $member_handler = xoops_getHandler('member');
+        $groups         = $member_handler->getGroupList();
+        $groups[0]      = _ALL;
+        $group_select   = new XoopsFormSelect(_MA_USER_GROUP, 'groups', Request::getInt('groups', 0), 3, true);
+        $group_select->addOptionArray($groups);
+
+        $ranks       = $rank_handler->getList();
+        $ranks[0]    = _ALL;
+        $rank_select = new XoopsFormSelect(_MA_USER_RANK, 'rank', Request::getInt('rank', 0) );
+        $rank_select->addOptionArray($ranks);
+        $form->addElement($url_text);
+        $form->addElement($location_text);
+        $form->addElement($occupation_text);
+        $form->addElement($interest_text);
+        $form->addElement($mailok_radio);
+        $form->addElement($avatar_radio);
+        $form->addElement($level_radio);
+        $form->addElement($group_select);
+        $form->addElement($rank_select);
+    } else {
+        foreach (array('uname', 'email') as $var) {
+            $title      = $items_match[$var];
+            $text       = new XoopsFormText('', $var, 30, 100, Request::getString($var, '', 'POST'));
+            $match      = new XoopsFormSelectMatchOption('', "{$var}_match", Request::getInt("{$var}_match", 0));
+            $match_tray = new XoopsFormElementTray($title, '&nbsp;');
+            $match_tray->addElement($match);
+            $match_tray->addElement($text);
+            $form->addElement($match_tray);
+            unset($text, $match, $match_tray);
+        }
     }
+
+    $sort_select = new XoopsFormSelect(_MA_USER_SORT, 'user_sort', @$_POST['user_sort']);
+    $sort_select->addOptionArray(array(
+        'uname' => _MA_USER_UNAME,
+        'last_login' => _MA_USER_LASTLOGIN,
+        'user_regdate' => _MA_USER_REGDATE,
+        'posts' => _MA_USER_POSTS
+    ));
+    $order_select = new XoopsFormSelect(_MA_USER_ORDER, 'user_order', @$_POST['user_order']);
+    $order_select->addOptionArray(array(
+        'ASC' => _MA_USER_ASC,
+        'DESC' => _MA_USER_DESC
+    ));
+
+    $form->addElement($sort_select);
+    $form->addElement($order_select);
+
     $form->addElement(new XoopsFormText(_MA_USER_LIMIT, 'limit', 6, 6, Request::getInt('limit', 50, 'POST')));
     $form->addElement(new XoopsFormHidden('mode', $mode));
     $form->addElement(new XoopsFormHidden('target', Request::getString('target', '', 'POST')));
-    $form->addElement(new XoopsFormHidden('multiple', Request::getString('multiple', '', 'POST')));
+    $form->addElement(new XoopsFormHidden('multiple', $multiple));
     $form->addElement(new XoopsFormHidden('token', $token));
     $form->addElement(new XoopsFormButton('', 'user_submit', _SUBMIT, 'submit'));
 
@@ -436,7 +437,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
         if ($mode == $_mode) {
             continue;
         }
-        $modes_switch[] = "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', ''), ENT_QUOTES) . '&amp;multiple=' . htmlspecialchars(Request::getString('multiple', ''), ENT_QUOTES) . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES) . "&amp;mode={$_mode}'>{$title}</a>";
+        $modes_switch[] = "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', ''), ENT_QUOTES) . '&amp;multiple=' . (string)$multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES) . "&amp;mode={$_mode}'>{$title}</a>";
     }
     echo '<h4>' . implode(' | ', $modes_switch) . '</h4>';
     echo '(' . sprintf(_MA_USER_ACTUS, "<span style='color:#ff0000;'>$acttotal</span>") . ' ' . sprintf(_MA_USER_INACTUS, "<span style='color:#ff0000;'>$inacttotal</span>") . ')';
@@ -445,148 +446,125 @@ if (!Request::hasVar('user_submit', 'POST')) {
     $myts  = MyTextSanitizer::getInstance();
     $limit = Request::getInt('limit', 50, 'POST');
     $start = Request::getInt('start', 0, 'POST');
-    if (!Request::hasVar('query', 'POST')) {
-        $criteria = new CriteriaCompo();
-        foreach (array_keys($items_match) as $var) {
-            if (Request::hasVar($var, 'POST')) {
-                $match = Request::getInt("{$var}_match", XOOPS_MATCH_START, 'POST');
-                $value = str_replace('_', "\\\_", $myts->addSlashes(trim(Request::getString($var, '', 'POST'))));
-                switch ($match) {
-                    case XOOPS_MATCH_START:
-                        $criteria->add(new Criteria($var, $value . '%', 'LIKE'));
-                        break;
-                    case XOOPS_MATCH_END:
-                        $criteria->add(new Criteria($var, '%' . $value, 'LIKE'));
-                        break;
-                    case XOOPS_MATCH_EQUAL:
-                        $criteria->add(new Criteria($var, $value));
-                        break;
-                    case XOOPS_MATCH_CONTAIN:
-                        $criteria->add(new Criteria($var, '%' . $value . '%', 'LIKE'));
-                        break;
-                }
-            }
-        }
-        if (Request::hasVar('url', 'POST')) {
-            $url = formatURL(trim(Request::getUrl('url', '', 'POST')));
-            $criteria->add(new Criteria('url', $url . '%', 'LIKE'));
-        }
-        if (Request::hasVar('user_from', 'POST')) {
-            $criteria->add(new Criteria('user_from', '%' . $myts->addSlashes(trim(Request::getString('user_from', '', 'POST'))) . '%', 'LIKE'));
-        }
-        if (Request::hasVar('user_intrest', 'POST')) {
-            $criteria->add(new Criteria('user_intrest', '%' . $myts->addSlashes(trim(Request::getString('user_intrest', '', 'POST'))) . '%', 'LIKE'));
-        }
-        if (Request::hasVar('user_occ', 'POST')) {
-            $criteria->add(new Criteria('user_occ', '%' . $myts->addSlashes(trim(Request::getString('user_occ', '', 'POST'))) . '%', 'LIKE'));
-        }
-        foreach (array(
-                     'last_login',
-                     'user_regdate') as $var) {
-            if (Request::hasVar("{$var}_more", 'POST') && is_numeric($_POST["{$var}_more"])) {
-                $time = time() - (60 * 60 * 24 *  Request::getInt("{$var}_more", 0, 'POST'));
-                if ($time > 0) {
-                    $criteria->add(new Criteria($var, $time, '<='));
-                }
-            }
-            if (Request::hasVar("{$var}_less", 'POST') && is_numeric($_POST["{$var}_less"])) {
-                $time = time() - (60 * 60 * 24 *  Request::getInt("{$var}_less", 0, 'POST'));
-                if ($time > 0) {
-                    $criteria->add(new Criteria($var, $time, '>='));
-                }
-            }
-        }
-        if (Request::hasVar('posts_more', 'POST') && is_numeric($_POST['posts_more'])) {
-            $criteria->add(new Criteria('posts',  Request::getInt('posts_more', 0, 'POST'), '<='));
-        }
-        if (Request::hasVar('posts_less', 'POST') && is_numeric($_POST['posts_less'])) {
-            $criteria->add(new Criteria('posts', Request::getInt('posts_less', 0, 'POST'), '>='));
-        }
-        if (Request::hasVar('user_mailok', 'POST')) {
-            if (Request::getString('user_mailok', '', 'POST') === 'mailng') {
-                $criteria->add(new Criteria('user_mailok', 0));
-            } elseif (Request::getString('user_mailok', '', 'POST') === 'mailok') {
-                $criteria->add(new Criteria('user_mailok', 1));
-            }
-        }
-        if (Request::hasVar('user_avatar', 'POST')) {
-            if (Request::getString('user_avatar', '', 'POST') === 'y') {
-                $criteria->add(new Criteria('user_avatar', "('', 'blank.gif')", 'NOT IN'));
-            } elseif (Request::getString('user_avatar', '', 'POST') === 'n') {
-                $criteria->add(new Criteria('user_avatar', "('', 'blank.gif')", 'IN'));
-            }
-        }
-        if (Request::hasVar('level', 'POST')) {
-            $level_value = array(
-                1 => 1,
-                2 => 0,
-                3 => -1);
-            $level       = Request::getInt('level', 1, 'POST');
-            $criteria->add(new Criteria('level', $level));
-        }
-        if (Request::hasVar('rank', 'POST')) {
-            $rank_obj = $rank_handler->get(Request::getInt('rank', 0, 'POST'));
-            if ($rank_obj->getVar('rank_special')) {
-                $criteria->add(new Criteria('rank', Request::getInt('rank', 0, 'POST')));
-            } else {
-                if ($rank_obj->getVar('rank_min')) {
-                    $criteria->add(new Criteria('posts', $rank_obj->getVar('rank_min'), '>='));
-                }
-                if ($rank_obj->getVar('rank_max')) {
-                    $criteria->add(new Criteria('posts', $rank_obj->getVar('rank_max'), '<='));
-                }
-            }
-        }
-        $total     = $user_handler->getCount($criteria, @$_POST['groups']);
-        $validsort = array(
-            'uname',
-            'email',
-            'last_login',
-            'user_regdate',
-            'posts');
-        $sort      = (!in_array(Request::getString('user_sort', '', 'POST'), $validsort)) ? 'uname' : Request::getString('user_sort', '', 'POST');
-        $order     = 'ASC';
-        if (Request::hasVar('user_order', 'POST') && Request::getString('user_order', '', 'POST')  === 'DESC') {
-            $order = 'DESC';
-        }
-        $criteria->setSort($sort);
-        $criteria->setOrder($order);
-        $criteria->setLimit($limit);
-        $criteria->setStart($start);
-        $foundusers = $user_handler->getAll($criteria, @$_POST['groups']);
-    } else {
-        $query = trim(Request::getString('query', '', 'POST'));
-        // Query with alias
-        if (preg_match("/select[\s]+.*[\s]+from[\s]+(" . $xoopsDB->prefix('users') . "[\s]+as[\s]+(\S+).*)/i", $query, $matches)) {
-            $alias    = $matches[2];
-            $subquery = $matches[1];
+    if (Request::hasVar('query', 'POST')) {
+        unset($_POST['query']);
+        $query = '';
+    }
 
-            // Query without alias
-        } elseif (preg_match("/select[\s]+.*[\s]+from[\s]+(" . $xoopsDB->prefix('users') . "\b.*)/i", $query, $matches)) {
-            $alias    = '';
-            $subquery = $matches[1];
-
-            // Invalid query
-        } else {
-            $query    = 'SELECT * FROM ' . $xoopsDB->prefix('users');
-            $subquery = $xoopsDB->prefix('users');
-        }
-        $sql_count = 'SELECT COUNT(DISTINCT ' . (empty($alias) ? '' : $alias . '.') . 'uid) FROM ' . $subquery;
-        $result    = $xoopsDB->query($sql_count);
-        list($total) = $xoopsDB->fetchRow($result);
-        $result     = $xoopsDB->query($query, $limit, $start);
-        $foundusers = array();
-        while (false !== ($myrow = $xoopsDB->fetchArray($result))) {
-            $object = $user_handler->create(false);
-            $object->assignVars($myrow);
-            $foundusers[$myrow['uid']] = $object;
-            unset($object);
+    $criteria = new CriteriaCompo();
+    foreach (array_keys($items_match) as $var) {
+        if (Request::hasVar($var, 'POST')) {
+            $match = Request::getInt("{$var}_match", XOOPS_MATCH_START, 'POST');
+            $value = $xoopsDB->escape(Request::getString($var, '', 'POST'));
+            switch ($match) {
+                case XOOPS_MATCH_START:
+                    $criteria->add(new Criteria($var, $value . '%', 'LIKE'));
+                    break;
+                case XOOPS_MATCH_END:
+                    $criteria->add(new Criteria($var, '%' . $value, 'LIKE'));
+                    break;
+                case XOOPS_MATCH_EQUAL:
+                    $criteria->add(new Criteria($var, $value));
+                    break;
+                case XOOPS_MATCH_CONTAIN:
+                    $criteria->add(new Criteria($var, '%' . $value . '%', 'LIKE'));
+                    break;
+            }
         }
     }
+    if (Request::hasVar('url', 'POST')) {
+        $url = formatURL(trim(Request::getUrl('url', '', 'POST')));
+        $criteria->add(new Criteria('url', $url . '%', 'LIKE'));
+    }
+    if (Request::hasVar('user_from', 'POST')) {
+        $criteria->add(new Criteria('user_from', '%' . $xoopsDB->escape(Request::getString('user_from', '', 'POST')) . '%', 'LIKE'));
+    }
+    if (Request::hasVar('user_intrest', 'POST')) {
+        $criteria->add(new Criteria('user_intrest', '%' . $xoopsDB->escape(Request::getString('user_intrest', '', 'POST')) . '%', 'LIKE'));
+    }
+    if (Request::hasVar('user_occ', 'POST')) {
+        $criteria->add(new Criteria('user_occ', '%' . $xoopsDB->escape(Request::getString('user_occ', '', 'POST')) . '%', 'LIKE'));
+    }
+    foreach (array('last_login', 'user_regdate') as $var) {
+        if (Request::hasVar("{$var}_more", 'POST') && is_numeric($_POST["{$var}_more"])) {
+            $time = time() - (60 * 60 * 24 *  Request::getInt("{$var}_more", 0, 'POST'));
+            if ($time > 0) {
+                $criteria->add(new Criteria($var, $time, '<='));
+            }
+        }
+        if (Request::hasVar("{$var}_less", 'POST') && is_numeric($_POST["{$var}_less"])) {
+            $time = time() - (60 * 60 * 24 *  Request::getInt("{$var}_less", 0, 'POST'));
+            if ($time > 0) {
+                $criteria->add(new Criteria($var, $time, '>='));
+            }
+        }
+    }
+    if (Request::hasVar('posts_more', 'POST') && is_numeric($_POST['posts_more'])) {
+        $criteria->add(new Criteria('posts',  Request::getInt('posts_more', 0, 'POST'), '<='));
+    }
+    if (Request::hasVar('posts_less', 'POST') && is_numeric($_POST['posts_less'])) {
+        $criteria->add(new Criteria('posts', Request::getInt('posts_less', 0, 'POST'), '>='));
+    }
+    if (Request::hasVar('user_mailok', 'POST')) {
+        if (Request::getString('user_mailok', '', 'POST') === 'mailng') {
+            $criteria->add(new Criteria('user_mailok', 0));
+        } elseif (Request::getString('user_mailok', '', 'POST') === 'mailok') {
+            $criteria->add(new Criteria('user_mailok', 1));
+        }
+    }
+    if (Request::hasVar('user_avatar', 'POST')) {
+        if (Request::getString('user_avatar', '', 'POST') === 'y') {
+            $criteria->add(new Criteria('user_avatar', "('', 'blank.gif')", 'NOT IN'));
+        } elseif (Request::getString('user_avatar', '', 'POST') === 'n') {
+            $criteria->add(new Criteria('user_avatar', "('', 'blank.gif')", 'IN'));
+        }
+    }
+    if (Request::hasVar('level', 'POST')) {
+//        $level_value = array(
+//            1 => 1,
+//            2 => 0,
+//            3 => -1
+//        );
+        $level       = Request::getInt('level', 0, 'POST');
+        if ($level > 0) {
+            $criteria->add(new Criteria('level', $level));
+        }
+    }
+    if (Request::hasVar('rank', 'POST')) {
+        $rank_obj = $rank_handler->get(Request::getInt('rank', 0, 'POST'));
+        if ($rank_obj->getVar('rank_special')) {
+            $criteria->add(new Criteria('rank', Request::getInt('rank', 0, 'POST')));
+        } else {
+            if ($rank_obj->getVar('rank_min')) {
+                $criteria->add(new Criteria('posts', $rank_obj->getVar('rank_min'), '>='));
+            }
+            if ($rank_obj->getVar('rank_max')) {
+                $criteria->add(new Criteria('posts', $rank_obj->getVar('rank_max'), '<='));
+            }
+        }
+    }
+    $total     = $user_handler->getCount($criteria, @$_POST['groups']);
+    $validsort = array(
+        'uname',
+        'email',
+        'last_login',
+        'user_regdate',
+        'posts'
+    );
+    $sort      = (!in_array(Request::getString('user_sort', '', 'POST'), $validsort)) ? 'uname' : Request::getString('user_sort', '', 'POST');
+    $order     = 'ASC';
+    if (Request::hasVar('user_order', 'POST') && Request::getString('user_order', '', 'POST')  === 'DESC') {
+        $order = 'DESC';
+    }
+    $criteria->setSort($sort);
+    $criteria->setOrder($order);
+    $criteria->setLimit($limit);
+    $criteria->setStart($start);
+    $foundusers = $user_handler->getAll($criteria, Request::getArray('groups', array(), 'POST'));
 
     echo $js_adduser = '
         <script type="text/javascript">
-        var multiple=' . Request::getInt('multiple', 0) . ';
+        var multiple=' . (string) $multiple . ';
         function addusers()
         {
             var sel_str = "";
@@ -618,7 +596,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
     ';
 
     echo '</html><body>';
-    echo "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', '', 'POST'), ENT_QUOTES) . '&amp;multiple=' . Request::getInt('multiple', 0, 'POST')  . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES) . "'>" . _MA_USER_FINDUS . "</a>&nbsp;<span style='font-weight:bold;'>&raquo;</span>&nbsp;" . _MA_USER_RESULTS . '<br><br>';
+    echo "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', '', 'POST'), ENT_QUOTES) . '&amp;multiple=' . (string)$multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES) . "'>" . _MA_USER_FINDUS . "</a>&nbsp;<span style='font-weight:bold;'>&raquo;</span>&nbsp;" . _MA_USER_RESULTS . '<br><br>';
     if (empty($start) && empty($foundusers)) {
         echo '<h4>' . _MA_USER_NOFOUND, '</h4>';
         $hiddenform = "<form name='findnext' action='findusers.php' method='post'>";
@@ -626,8 +604,12 @@ if (!Request::hasVar('user_submit', 'POST')) {
             if ($k === 'XOOPS_TOKEN_REQUEST') {
                 // regenerate token value
                 $hiddenform .= $GLOBALS['xoopsSecurity']->getTokenHTML() . "\n";
+            } elseif (is_array($v)) {
+                foreach ($v as $temp) {
+                    $hiddenform .= "<input type='hidden' name='". htmlspecialchars($k, ENT_QUOTES)."' value='" . htmlspecialchars($temp, ENT_QUOTES) . "' />\n";
+                }
             } else {
-                $hiddenform .= "<input type='hidden' name='" . htmlspecialchars($k, ENT_QUOTES) . "' value='" . htmlspecialchars($myts->stripSlashesGPC($v), ENT_QUOTES) . "' />\n";
+                $hiddenform .= "<input type='hidden' name='" . htmlspecialchars($k, ENT_QUOTES) . "' value='" . htmlspecialchars($v, ENT_QUOTES) . "' />\n";
             }
         }
         if (!Request::hasVar('limit', 'POST')) {
@@ -651,7 +633,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
             <table width='100%' border='0' cellspacing='1' cellpadding='4' class='outer'>
             <tr>
             <th align='center' width='5px'>";
-            if (Request::hasVar('multiple', 'POST')) {
+            if ($multiple > 0 ) {
                 echo "<input type='checkbox' name='memberslist_checkall' id='memberslist_checkall' onclick='xoopsCheckAll(\"{$name_form}\", \"memberslist_checkall\");' />";
             }
             echo "</th>
@@ -671,7 +653,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
                 $fuser_name = $foundusers[$j]->getVar('name') ?: '&nbsp;';
                 echo "<tr class='$class'>
                     <td align='center'>";
-                if (Request::hasVar('multiple', 'POST')) {
+                if ($multiple > 0) {
                     echo "<input type='checkbox' name='{$name_userid}' id='{$name_userid}' value='" . $foundusers[$j]->getVar('uid') . "' />";
                     echo "<input type='hidden' name='{$name_username}' id='{$name_username}' value='" . $foundusers[$j]->getVar('uname') . "' />";
                 } else {
@@ -707,7 +689,12 @@ if (!Request::hasVar('user_submit', 'POST')) {
             if ($k === 'XOOPS_TOKEN_REQUEST') {
                 // regenerate token value
                 $hiddenform .= $GLOBALS['xoopsSecurity']->getTokenHTML() . "\n";
+            } elseif (is_array($v)) {
+                foreach ($v as $temp) {
+                    $hiddenform .= "<input type='hidden' name='". htmlspecialchars($k, ENT_QUOTES)."' value='" . htmlspecialchars($temp, ENT_QUOTES) . "' />\n";
+                }
             } else {
+
                 $hiddenform .= "<input type='hidden' name='" . htmlspecialchars($k, ENT_QUOTES) . "' value='" . htmlspecialchars($myts->stripSlashesGPC($v), ENT_QUOTES) . "' />\n";
             }
         }


### PR DESCRIPTION
Includes and replaces #1131

- Remove query mode
- tweak Xmf\Request() calls
- use database escape() ro replace $ts->addSlashes()
- remove aim, yim, icq and msnm selectors