### PR TITLE
Update XoopsFormRendererBootstrap5.php

### DIFF
--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
@@ -487,7 +487,7 @@ EOJS;
      */
     public function renderFormLabel(XoopsFormLabel $element)
     {
-        return '<div class="form-control-static" id="' . $element->getName() . '>' . $element->getValue() . '</div>';
+        return '<div class="form-control-static" id="' . $element->getName() . '">' . $element->getValue() . '</div>';
     }
 
     /**


### PR DESCRIPTION
XoopsFormRendererBootstrap5 renderFormLabel id= is missing the closing quote