### PR TITLE
Update theme.tpl

### DIFF
--- a/htdocs/themes/xswatch4/theme.tpl
+++ b/htdocs/themes/xswatch4/theme.tpl
@@ -31,13 +31,13 @@
         <link rel="stylesheet" media="(prefers-color-scheme: light)" href="<{xoImgUrl}><{$xswatchCss}>/bootstrap.min.css">
         <link rel="stylesheet" media="(prefers-color-scheme: light)" href="<{xoImgUrl}><{$xswatchCss}>/cookieconsent.css">
         <{* Edit css/my_xoops.css to customize your css definitions and override Bootstrap definitions for the light variant *}>
-        <link rel="stylesheet" type="text/css" href="<{xoImgUrl}>css/my_xoops.css">
-        
+        <link rel="stylesheet" media="(prefers-color-scheme: light)" href="<{xoImgUrl}>css/my_xoops.css">
+
         <link rel="stylesheet" media="(prefers-color-scheme: dark)" href="<{xoImgUrl}><{$xswatchDarkCss}>/xoops.css">
         <link rel="stylesheet" media="(prefers-color-scheme: dark)" href="<{xoImgUrl}><{$xswatchDarkCss}>/bootstrap.min.css">
         <link rel="stylesheet" media="(prefers-color-scheme: dark)" href="<{xoImgUrl}><{$xswatchDarkCss}>/cookieconsent.css">
         <{* Edit css/my_xoops_dark.css to customize your css definitions and override Bootstrap definitions for the dark variant *}>
-        <link rel="stylesheet" type="text/css" href="<{xoImgUrl}>css/my_xoops_dark.css">
+        <link rel="stylesheet" media="(prefers-color-scheme: dark)" href="<{xoImgUrl}>css/my_xoops_dark.css">
     <{/if}>
 
     <script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>


### PR DESCRIPTION
In light/dark mode, there was a problem with overloads if the definitions were the same in my_xoops.css and my_xoops_dark.css. The system was reading the last declared definitions, so in my_xoops_dark.css, even if the system was in light mode.
Now, there is no more overwriting between the 2 files