### PR TITLE
Add trailing end of line

### DIFF
--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -118,7 +118,7 @@ class SystemMaintenance
                 }
                 closedir($dirHandle);
             }
-			file_put_contents($dir . 'index.php', '<?php' . PHP_EOL  . 'header("HTTP/1.0 404 Not Found");');
+			file_put_contents($dir . 'index.php', '<?php' . PHP_EOL  . 'header("HTTP/1.0 404 Not Found");' . PHP_EOL);
         }
     }
 


### PR DESCRIPTION
After cleaning caches, the now recreated index.php files show as changed in git comparisons. This restores the proper EOL so files match.