### PR TITLE
Fix non-conforming id elements in module menu tabs

### DIFF
--- a/htdocs/modules/system/class/menu.php
+++ b/htdocs/modules/system/class/menu.php
@@ -170,10 +170,11 @@ class SystemMenuHandler
         $i        = 0;
 
         /**
-         * Selects current menu tab
+         * Select current menu tab, sets id names for menu tabs
          */
+        $j=0;
         foreach ($this->_menutabs as $k => $menus) {
-            $menuItems[] = $menus;
+            $menuItems[] = 'modmenu_' . $j++;
         }
         $breadcrumb                = $menuItems[$currentoption];
         $menuItems[$currentoption] = 'current';


### PR DESCRIPTION
Was mentioned on in #1133 but not properly dealt with.

The menu tab id was built from the display text, which varies with language in use. Also no attempt to conform to HTML spec leaving spaces and other non-permitted characters.

Id values now start with 'modmenu_' and then an integer based on position 0-n. The active menu tab still has id attribute of 'current'