### PR TITLE
Cleanup in \XoopsSecurity::checkBadips()

### DIFF
--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -227,7 +227,8 @@ class XoopsSecurity
     {
         global $xoopsConfig;
 
-        $ip = IPAddress::fromRequest();
+        $addr = IPAddress::fromRequest();
+        $ip = $addr->asReadable();
         if ($xoopsConfig['enable_badips'] == 1 && $ip != '0.0.0.0') {
             foreach ($xoopsConfig['bad_ips'] as $bi) {
                 if (!empty($bi) && preg_match('/' . $bi . '/', $ip)) {

--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -1,4 +1,7 @@
 <?php
+
+use Xmf\IPAddress;
+
 /**
  * XOOPS security handler
  *
@@ -223,14 +226,15 @@ class XoopsSecurity
     public function checkBadips()
     {
         global $xoopsConfig;
-        if ($xoopsConfig['enable_badips'] == 1 && isset($_SERVER['REMOTE_ADDR']) && $_SERVER['REMOTE_ADDR'] != '') {
+
+        $ip = IPAddress::fromRequest();
+        if ($xoopsConfig['enable_badips'] == 1 && $ip != '0.0.0.0') {
             foreach ($xoopsConfig['bad_ips'] as $bi) {
-                if (!empty($bi) && preg_match('/' . $bi . '/', $_SERVER['REMOTE_ADDR'])) {
+                if (!empty($bi) && preg_match('/' . $bi . '/', $ip)) {
                     exit();
                 }
             }
         }
-        unset($bi, $bad_ips, $xoopsConfig['badips']);
     }
 
     /**

--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -201,7 +201,7 @@ function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $
                                                                                                                '^admin'))) . "', '_MD_AM_BADUNAMESDSC', 'textarea', 'array', 24)");
     $dbm->insert('config', " VALUES (35, 0, 2, 'bad_emails', '_MD_AM_BADEMAILS', '" . addslashes(serialize(array('xoops.org$'))) . "', '_MD_AM_BADEMAILSDSC', 'textarea', 'array', 26)");
     $dbm->insert('config', " VALUES (36, 0, 2, 'maxuname', '_MD_AM_MAXUNAME', '10', '_MD_AM_MAXUNAMEDSC', 'textbox', 'int', 3)");
-    $dbm->insert('config', " VALUES (37, 0, 1, 'bad_ips', '_MD_AM_BADIPS', '" . addslashes(serialize(array('127.0.0.1'))) . "', '_MD_AM_BADIPSDSC', 'textarea', 'array', 42)");
+    $dbm->insert('config', " VALUES (37, 0, 1, 'bad_ips', '_MD_AM_BADIPS', '" . addslashes(serialize(array('127\.0\.0\.1'))) . "', '_MD_AM_BADIPSDSC', 'textarea', 'array', 42)");
     $dbm->insert('config', " VALUES (38, 0, 3, 'meta_keywords', '_MD_AM_METAKEY', 'xoops, web application framework, cms, content management system', '_MD_AM_METAKEYDSC', 'textarea', 'text', 0)");
     $dbm->insert('config', " VALUES (39, 0, 3, 'footer', '_MD_AM_FOOTER', 'Powered by XOOPS &#169; 2001-{X_YEAR} <a href=\"https://xoops.org\" rel=\"external\" title=\"The XOOPS Project\">The XOOPS Project</a>', '_MD_AM_FOOTERDSC', 'textarea', 'text', 20)");
     $dbm->insert('config', " VALUES (40, 0, 4, 'censor_enable', '_MD_AM_DOCENSOR', '0', '_MD_AM_DOCENSORDSC', 'yesno', 'int', 0)");


### PR DESCRIPTION
- Remove unset()s, fixes #1085
- Use Xmf\IPAddress::fromRequest() to obtain address (does proxy check)
- Correct sample added by installer with "\." needed for regex