### PR TITLE
all modules are using 'id", and this is causing issues in PHP8

### DIFF
--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -1120,11 +1120,11 @@ class XoopsObjectHandler
     /**
      * gets a value object
      *
-     * @param int $int_id
+     * @param int $id
      * @abstract
      * @return XoopsObject
      */
-    public function get($int_id)
+    public function get($id)
     {
     }
 


### PR DESCRIPTION
signatures have to be the same or PHP8 complains.
All the modules that I checked are using "id"