### PR TITLE
Clear some Smarty and other php8.1 issues

### DIFF
--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -531,6 +531,7 @@ class MyTextSanitizer
      */
     public function &displayTarea($text, $html = 0, $smiley = 1, $xcode = 1, $image = 1, $br = 1)
     {
+        $text = (string) $text;
         $charset = (defined('_CHARSET') ? _CHARSET : 'UTF-8');
         if (function_exists('mb_convert_encoding')) {
             $text = mb_convert_encoding($text, $charset, mb_detect_encoding($text, mb_detect_order(), true));

--- a/htdocs/class/smarty/Smarty_Compiler.class.php
+++ b/htdocs/class/smarty/Smarty_Compiler.class.php
@@ -161,7 +161,7 @@ class Smarty_Compiler extends Smarty {
                 . '(?:\s*,\s*' . $this->_obj_single_param_regexp . ')*)?\)';
         $this->_obj_start_regexp = '(?:' . $this->_dvar_regexp . '(?:' . $this->_obj_ext_regexp . ')+)';
         $this->_obj_call_regexp = '(?:' . $this->_obj_start_regexp . '(?:' . $this->_obj_params_regexp . ')?(?:' . $this->_dvar_math_regexp . '(?:' . $this->_num_const_regexp . '|' . $this->_dvar_math_var_regexp . ')*)?)';
-        
+
         // matches valid modifier syntax:
         // |foo
         // |@foo
@@ -255,7 +255,7 @@ class Smarty_Compiler extends Smarty {
 
         /* fetch all special blocks */
         $search = "~{$ldq}\*(.*?)\*{$rdq}|{$ldq}\s*literal\s*{$rdq}(.*?){$ldq}\s*/literal\s*{$rdq}|{$ldq}\s*php\s*{$rdq}(.*?){$ldq}\s*/php\s*{$rdq}~s";
-
+        $source_content = (null === $source_content) ? '' : $source_content; // added for XOOPS
         preg_match_all($search, $source_content, $match,  PREG_SET_ORDER);
         $this->_folded_blocks = $match;
 
@@ -298,7 +298,7 @@ class Smarty_Compiler extends Smarty {
                 }
             }
         }
-        
+
         /* Compile the template tags into PHP code. */
         $compiled_tags = array();
         for ($i = 0, $for_max = count($template_tags); $i < $for_max; $i++) {
@@ -327,7 +327,7 @@ class Smarty_Compiler extends Smarty {
                 for ($j = $i + 1; $j < $for_max; $j++) {
                     /* remove leading and trailing whitespaces of each line */
                     $text_blocks[$j] = preg_replace('![\t ]*[\r\n]+[\t ]*!', '', $text_blocks[$j]);
-                    if ($compiled_tags[$j] == '{/strip}') {                       
+                    if ($compiled_tags[$j] == '{/strip}') {
                         /* remove trailing whitespaces from the last text_block */
                         $text_blocks[$j] = rtrim($text_blocks[$j]);
                     }
@@ -343,9 +343,9 @@ class Smarty_Compiler extends Smarty {
             }
         }
         $compiled_content = '';
-        
+
         $tag_guard = '%%%SMARTYOTG' . md5(uniqid(rand(), true)) . '%%%';
-        
+
         /* Interleave the compiled contents and text blocks to get the final result. */
         for ($i = 0, $for_max = count($compiled_tags); $i < $for_max; $i++) {
             if ($compiled_tags[$i] == '') {
@@ -355,7 +355,7 @@ class Smarty_Compiler extends Smarty {
             // replace legit PHP tags with placeholder
             $text_blocks[$i] = str_replace('<?', $tag_guard, $text_blocks[$i]);
             $compiled_tags[$i] = str_replace('<?', $tag_guard, $compiled_tags[$i]);
-            
+
             $compiled_content .= $text_blocks[$i] . $compiled_tags[$i];
         }
         $compiled_content .= str_replace('<?', $tag_guard, $text_blocks[$i]);
@@ -365,8 +365,8 @@ class Smarty_Compiler extends Smarty {
         $compiled_content = preg_replace("~(?<!')language\s*=\s*[\"\']?\s*php\s*[\"\']?~", "<?php echo 'language=php' ?>\n", $compiled_content);
 
         // recover legit tags
-        $compiled_content = str_replace($tag_guard, '<?', $compiled_content); 
-        
+        $compiled_content = str_replace($tag_guard, '<?', $compiled_content);
+
         // remove \n from the end of the file, if any
         if (strlen($compiled_content) && (substr($compiled_content, -1) == "\n") ) {
             $compiled_content = substr($compiled_content, 0, -1);
@@ -390,8 +390,9 @@ class Smarty_Compiler extends Smarty {
             }
         }
 
-        // put header at the top of the compiled template
-        $template_header = "<?php /* Smarty version ".$this->_version.", created on ".strftime("%Y-%m-%d %H:%M:%S")."\n";
+        // put header at the top of the compiled template -- Modified for XOOPS
+        $time = new DateTime();
+        $template_header = "<?php /* Smarty version ".$this->_version.", created on ".$time->format('Y-m-d H:i:s')."\n";
         $template_header .= "         compiled from ".strtr(urlencode($resource_name), array('%2F'=>'/', '%3A'=>':'))." */ ?>\n";
 
         /* Emit code to load needed plugins. */
@@ -431,7 +432,7 @@ class Smarty_Compiler extends Smarty {
         /* Matched comment. */
         if (substr($template_tag, 0, 1) == '*' && substr($template_tag, -1) == '*')
             return '';
-        
+
         /* Split tag into two three parts: command, command modifiers and the arguments. */
         if(! preg_match('~^(?:(' . $this->_num_const_regexp . '|' . $this->_obj_call_regexp . '|' . $this->_var_regexp
                 . '|\/?' . $this->_reg_obj_regexp . '|\/?' . $this->_func_regexp . ')(' . $this->_mod_regexp . '*))
@@ -439,7 +440,7 @@ class Smarty_Compiler extends Smarty {
                     ~xs', $template_tag, $match)) {
             $this->_syntax_error("unrecognized tag: $template_tag", E_USER_ERROR, __FILE__, __LINE__);
         }
-        
+
         $tag_command = $match[1];
         $tag_modifier = isset($match[2]) ? $match[2] : null;
         $tag_args = isset($match[3]) ? $match[3] : null;
@@ -579,7 +580,7 @@ class Smarty_Compiler extends Smarty {
                 } else if ($this->_compile_block_tag($tag_command, $tag_args, $tag_modifier, $output)) {
                     return $output;
                 } else if ($this->_compile_custom_tag($tag_command, $tag_args, $tag_modifier, $output)) {
-                    return $output;                    
+                    return $output;
                 } else {
                     $this->_syntax_error("unrecognized tag '$tag_command'", E_USER_ERROR, __FILE__, __LINE__);
                 }
@@ -935,7 +936,7 @@ class Smarty_Compiler extends Smarty {
         if (empty($name)) {
             return $this->_syntax_error("missing insert name", E_USER_ERROR, __FILE__, __LINE__);
         }
-        
+
         if (!preg_match('~^\w+$~', $name)) {
             return $this->_syntax_error("'insert: 'name' must be an insert function name", E_USER_ERROR, __FILE__, __LINE__);
         }
@@ -1224,7 +1225,7 @@ class Smarty_Compiler extends Smarty {
             $buffer = isset($attrs['name']) ? $attrs['name'] : "'default'";
             $assign = isset($attrs['assign']) ? $attrs['assign'] : null;
             $append = isset($attrs['append']) ? $attrs['append'] : null;
-            
+
             $output = "<?php ob_start(); ?>";
             $this->_capture_stack[] = array($buffer, $assign, $append);
         } else {
@@ -1265,11 +1266,11 @@ class Smarty_Compiler extends Smarty {
 
         if(empty($tokens)) {
             $_error_msg = $elseif ? "'elseif'" : "'if'";
-            $_error_msg .= ' statement requires arguments'; 
+            $_error_msg .= ' statement requires arguments';
             $this->_syntax_error($_error_msg, E_USER_ERROR, __FILE__, __LINE__);
         }
-            
-                
+
+
         // make sure we have balanced parenthesis
         $token_count = array_count_values($tokens);
         if(isset($token_count['(']) && $token_count['('] != $token_count[')']) {
@@ -1367,8 +1368,8 @@ class Smarty_Compiler extends Smarty {
                         if ($is_arg_start != 0) {
                             if (preg_match('~^' . $this->_func_regexp . '$~', $tokens[$is_arg_start-1])) {
                                 $is_arg_start--;
-                            } 
-                        } 
+                            }
+                        }
                     } else
                         $is_arg_start = $i-1;
                     /* Construct the argument for 'is' expression, so it knows
@@ -1399,7 +1400,7 @@ class Smarty_Compiler extends Smarty {
                             }
                     } elseif(preg_match('~^' . $this->_var_regexp . '$~', $token) && (strpos('+-*/^%&|', substr($token, -1)) === false) && isset($tokens[$i+1]) && $tokens[$i+1] == '(') {
                         // variable function call
-                        $this->_syntax_error("variable function call '$token' not allowed in if statement", E_USER_ERROR, __FILE__, __LINE__);                      
+                        $this->_syntax_error("variable function call '$token' not allowed in if statement", E_USER_ERROR, __FILE__, __LINE__);
                     } elseif(preg_match('~^' . $this->_obj_call_regexp . '|' . $this->_var_regexp . '(?:' . $this->_mod_regexp . '*)$~', $token)) {
                         // object or variable
                         $token = $this->_parse_var_props($token);
@@ -1522,7 +1523,7 @@ class Smarty_Compiler extends Smarty {
      */
     function _parse_attrs($tag_args)
     {
-
+        $tag_args = (string) $tag_args; // modified for XOOPS
         /* Tokenize tag attributes. */
         preg_match_all('~(?:' . $this->_obj_call_regexp . '|' . $this->_qstr_regexp . ' | (?>[^"\'=\s]+)
                          )+ |
@@ -1752,12 +1753,12 @@ class Smarty_Compiler extends Smarty {
             $_var_ref = $var_expr;
         else
             $_var_ref = substr($var_expr, 1);
-        
+
         if(!$_has_math) {
-            
+
             // get [foo] and .foo and ->foo and (...) pieces
             preg_match_all('~(?:^\w+)|' . $this->_obj_params_regexp . '|(?:' . $this->_var_bracket_regexp . ')|->\$?\w+|\.\$?\w+|\S+~', $_var_ref, $match);
-                        
+
             $_indexes = $match[0];
             $_var_name = array_shift($_indexes);
 
@@ -2017,7 +2018,7 @@ class Smarty_Compiler extends Smarty {
                         array_shift($indexes);
                         $compiled_ref = "(\$this->_foreach[$_var]['iteration']-1)";
                         break;
-                        
+
                     case 'first':
                         array_shift($indexes);
                         $compiled_ref = "(\$this->_foreach[$_var]['iteration'] <= 1)";
@@ -2027,12 +2028,12 @@ class Smarty_Compiler extends Smarty {
                         array_shift($indexes);
                         $compiled_ref = "(\$this->_foreach[$_var]['iteration'] == \$this->_foreach[$_var]['total'])";
                         break;
-                        
+
                     case 'show':
                         array_shift($indexes);
                         $compiled_ref = "(\$this->_foreach[$_var]['total'] > 0)";
                         break;
-                        
+
                     default:
                         unset($_max_index);
                         $compiled_ref = "\$this->_foreach[$_var]";
@@ -2158,7 +2159,7 @@ class Smarty_Compiler extends Smarty {
             case 'rdelim':
                 $compiled_ref = "'$this->right_delimiter'";
                 break;
-                
+
             default:
                 $this->_syntax_error('$smarty.' . $_ref . ' is an unknown reference', E_USER_ERROR, __FILE__, __LINE__);
                 break;

--- a/htdocs/class/smarty/xoops_plugins/function.year.php
+++ b/htdocs/class/smarty/xoops_plugins/function.year.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * XOOPS year Smarty plug-in -- returns the current year
+ *
+ * @copyright   XOOPS Project (http://xoops.org)
+ * @license     GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @author      Richard Griffith <richard@geekwright.com>
+ */
+
+/**
+ * Insert the current year
+ *
+ * @param $params
+ * @param $smarty
+ * @return null
+ */
+function smarty_function_year($params, &$smarty)
+{
+    $time = new DateTime();
+    echo $time->format('Y');
+}

--- a/htdocs/class/theme.php
+++ b/htdocs/class/theme.php
@@ -498,7 +498,10 @@ class xos_opal_Theme
             $GLOBALS['xoopsOption']['xoops_pagetitle']     = $content['xoops_pagetitle'];
             $GLOBALS['xoopsOption']['xoops_module_header'] = $content['header'];
         }
-
+        /* if cache was not found, define $content[] */
+        if (!isset($content) || false === $content) {
+            $content = array();
+        }
         if (!empty($GLOBALS['xoopsOption']['xoops_pagetitle'])) {
             $this->template->assign('xoops_pagetitle', $GLOBALS['xoopsOption']['xoops_pagetitle']);
         }
@@ -878,6 +881,7 @@ class xos_opal_Theme
      */
     public function resourcePath($path)
     {
+        $path = (string) $path;
         if (substr($path, 0, 1) === '/') {
             $path = substr($path, 1);
         }

--- a/htdocs/modules/system/themes/dark/xotpl/xo_footer.tpl
+++ b/htdocs/modules/system/themes/dark/xotpl/xo_footer.tpl
@@ -1,7 +1,7 @@
 <!--{xo-logger-output}-->
 
 <div id='xo-footer'>
-    <div id="xo-footer-body">Powered by <a class="tooltip" rel="external" href="http://xoops.org" title="Xoops Project"><{$xoops_version}></a> &copy; 2001-<{$smarty.now|date_format:"%Y"}></div>
+    <div id="xo-footer-body">Powered by <a class="tooltip" rel="external" href="http://xoops.org" title="Xoops Project"><{$xoops_version}></a> &copy; 2001-<{year}></div>
     <div id="xo-footer-rss"><a class="tooltip" rel="external" href="<{xoAppUrl backend.php}>" title="<{$smarty.const._OXYGEN_RSS}>"><img src="<{xoImgUrl images/feed.png}>"/></a></div>
     <div><{include file="$theme_tpl/xo_uptop.tpl"}></div>
 </div>

--- a/htdocs/modules/system/themes/default/xotpl/xo_footer.tpl
+++ b/htdocs/modules/system/themes/default/xotpl/xo_footer.tpl
@@ -1,5 +1,5 @@
 <div id='xo-footer'>
-    <div id="xo-footer-body">Powered by <a class="tooltip" rel="external" href="http://xoops.org" title="Xoops Project"><{$xoops_version}></a> &copy; 2001-<{$smarty.now|date_format:"%Y"}></div>
+    <div id="xo-footer-body">Powered by <a class="tooltip" rel="external" href="http://xoops.org" title="Xoops Project"><{$xoops_version}></a> &copy; 2001-<{year}></div>
     <div id="xo-footer-rss"><a class="tooltip" rel="external" href="<{xoAppUrl backend.php}>" title="<{$smarty.const._OXYGEN_RSS}>"><img src="<{xoImgUrl img/feed.png}>"/></a></div>
     <div><{include file="$theme_tpl/xo_uptop.tpl"}></div>
 </div>

--- a/htdocs/modules/system/themes/transition/xotpl/xo_footer.tpl
+++ b/htdocs/modules/system/themes/transition/xotpl/xo_footer.tpl
@@ -1,7 +1,7 @@
 <!--{xo-logger-output}-->
 
 <div id='xo-footer'>
-    <div id="xo-footer-body">Powered by <a class="tooltip" rel="external" href="http://xoops.org" title="Xoops Project"><{$xoops_version}></a> &copy; 2001-<{$smarty.now|date_format:"%Y"}></div>
+    <div id="xo-footer-body">Powered by <a class="tooltip" rel="external" href="http://xoops.org" title="Xoops Project"><{$xoops_version}></a> &copy; 2001-<{year}></div>
     <div id="xo-footer-rss"><a class="tooltip" rel="external" href="<{xoAppUrl backend.php}>" title="<{$smarty.const._OXYGEN_RSS}>"><img src="<{xoImgUrl images/feed.png}>"/></a></div>
     <div><{include file="$theme_tpl/xo_uptop.tpl"}></div>
 </div>


### PR DESCRIPTION
Smarty even at the latest version has dependence on some function deprecated in PHP8.1 (i.e. strftime)
We need some work arounds to get by:

- Implement a `<{year}>` function to replace the current `<{$smarty.now|date_format:"%Y"}>` used in admin footers.
- Patch Smarty_Compiler.class.php to fix timestamp added to compile files along with other very visible errors under PHP 8.1 (sorry, there are many whitespace only changes, specifically tabs to spaces.) 
- PHP 8.1 issue in \xos_opal_Theme class
- PHP 8.1 issue in MyTextSanitizer