### PR TITLE
Avatar display in misc.php should respect avatar_display

### DIFF
--- a/htdocs/kernel/avatar.php
+++ b/htdocs/kernel/avatar.php
@@ -388,8 +388,8 @@ class XoopsAvatarHandler extends XoopsObjectHandler
     /**
      * Get a list of Avatars
      *
-     * @param  string $avatar_type
-     * @param  string $avatar_display
+     * @param  string    $avatar_type 'S' for system, 'C' for custom
+     * @param  bool|null $avatar_display null lists all, bool respects avatar_display
      * @return array
      */
     public function getList($avatar_type = null, $avatar_display = null)

--- a/htdocs/misc.php
+++ b/htdocs/misc.php
@@ -68,7 +68,7 @@ EOSMJS;
         case 'avatars':
             /* @var  XoopsAvatarHandler $avatarHandler */
             $avatarHandler = xoops_getHandler('avatar');
-            $avatarsList = $avatarHandler->getList('S');
+            $avatarsList = $avatarHandler->getList('S', true);
 
             $upload_url = XOOPS_UPLOAD_URL . '/';
             $javaScript = <<<EOAVJS


### PR DESCRIPTION
If a System avatar was marked false for display, it still was displayed in the misc.php window. This caused issues matching selections to edituser display -- off by one for each false avatar_display.