### PR TITLE
Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/htdocs/class/xoopsform/formelement.php
+++ b/htdocs/class/xoopsform/formelement.php
@@ -157,7 +157,7 @@ class XoopsFormElement
     public function getName($encode = true)
     {
         if (false !== (bool)$encode) {
-            return str_replace('&amp;', '&', htmlspecialchars($this->_name, ENT_QUOTES));
+            return str_replace('&amp;', '&', htmlspecialchars((string)$this->_name, ENT_QUOTES));
         }
 
         return $this->_name;


### PR DESCRIPTION
Passing null to parameter #1 ($string) of type string is deprecated in file /class/xoopsform/formelement.php line 160