### PR TITLE
Fix module admin breadcrumb

### DIFF
--- a/htdocs/modules/system/class/menu.php
+++ b/htdocs/modules/system/class/menu.php
@@ -174,9 +174,12 @@ class SystemMenuHandler
          */
         $j=0;
         foreach ($this->_menutabs as $k => $menus) {
+            if ($j == $currentoption) {
+                $breadcrumb = $menus;
+            }
             $menuItems[] = 'modmenu_' . $j++;
         }
-        $breadcrumb                = $menuItems[$currentoption];
+
         $menuItems[$currentoption] = 'current';
         $menu                      = "<div id='buttontop_mod'>";
         $menu .= "<table style='width: 100%; padding: 0;' cellspacing='0'>\n<tr>";


### PR DESCRIPTION
Regression introduced in #1179 showed new element id instead of tab name text