### PR TITLE
Unknown: preg_match(): Passing null to parameter #2

### DIFF
--- a/htdocs/class/file/folder.php
+++ b/htdocs/class/file/folder.php
@@ -288,7 +288,7 @@ class XoopsFolderHandler
      */
     public function isWindowsPath($path)
     {
-        if (preg_match('/^[A-Z]:\\\\/i', $path)) {
+        if (preg_match('/^[A-Z]:\\\\/i', (string)$path)) {
             return true;
         }
 
@@ -849,7 +849,7 @@ class XoopsFolderHandler
      */
     public function isSlashTerm($path)
     {
-        if (preg_match('/[\/\\\]$/', $path)) {
+        if (preg_match('/[\/\\\]$/', (string)$path)) {
             return true;
         }
 


### PR DESCRIPTION
Unknown: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in file /class/file/folder.php line 291

Unknown: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in file /class/file/folder.php line 852