### PR TITLE
Changed to use gender-neutral pronouns

### DIFF
--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -225,7 +225,7 @@ function bannerstats()
 }
 
 /**
- * Function to let the client E-mail his banner Stats
+ * Function to let the client E-mail their banner stats
  * @param int|string $cid
  * @param int|string $bid
  * @return void
@@ -276,7 +276,7 @@ function emailStats($cid, $bid)
 }
 
 /**
- * Function to let the client to change the  url for his banner
+ * Function to let the client change the URL for their banner
  * @param int|string $cid
  * @param int|string $bid
  * @param string $url

--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -225,7 +225,7 @@ function bannerstats()
 }
 
 /**
- * Function to let the client E-mail their banner stats
+ * Function to let clients email their banner's stats
  * @param int|string $cid
  * @param int|string $bid
  * @return void
@@ -276,7 +276,7 @@ function emailStats($cid, $bid)
 }
 
 /**
- * Function to let the client change the URL for their banner
+ * Function to let clients change their banner's URL
  * @param int|string $cid
  * @param int|string $bid
  * @param string $url

--- a/htdocs/language/english/user.php
+++ b/htdocs/language/english/user.php
@@ -44,7 +44,7 @@ define('_US_NOREGISTER', 'Sorry, we are currently closed for new user registrati
 // %s is username. This is a subject for email
 define('_US_USERKEYFOR', 'User activation key for %s');
 define('_US_YOURREGISTERED', 'You are now registered. An email containing an user activation key has been sent to the email account you provided. Please follow the instructions in the email to activate your account. ');
-define('_US_YOURREGMAILNG', 'You are now registered. However, we were unable to send the activation email to your email account due to an internal error that had occurred on our server. We are sorry for the inconvenience, please send the webmaster an email notifying him/her of the situation.');
+define('_US_YOURREGMAILNG', 'You are now registered. However, we were unable to send the activation email to your email account due to an internal error that has occurred on our server. We are sorry for the inconvenience, please send the webmaster an email to notify them of the situation.');
 define('_US_YOURREGISTERED2', 'You are now registered.  Please wait for your account to be activated by the adminstrators.  You will receive an email once you are activated.  This could take a while so please be patient.');
 // %s is your site name
 define('_US_NEWUSERREGAT', 'New user registration at %s');

--- a/htdocs/modules/profile/language/english/admin.php
+++ b/htdocs/modules/profile/language/english/admin.php
@@ -44,7 +44,7 @@ define('_PROFILE_AM_PROF_EDITABLE', 'Field editable from profile');
 define('_PROFILE_AM_PROF_REGISTER', 'Show in registration form');
 define('_PROFILE_AM_PROF_SEARCH', 'Searchable by these groups');
 define('_PROFILE_AM_PROF_ACCESS', 'Profile accessible by these groups');
-define('_PROFILE_AM_PROF_ACCESS_DESC', '<ul>' . "<li>Admin groups: If a user belongs to admin groups, the current user has access if and only if one of the current user's groups is allowed to access admin group; else</li>" . "<li>Non basic groups: If a user belongs to one or more non basic groups (NOT admin, user, anonymous), the current user has access if and only if one of the current user's groups is allowed to allowed to any of the non basic groups; else</li>" . '<li>User group: If a user belongs to User group only, the current user has access if and only if one of his groups is allowed to access User group</li>' . '</ul>');
+define('_PROFILE_AM_PROF_ACCESS_DESC', '<ul>' . "<li>Admin groups: If a user belongs to admin groups, the current user has access if and only if one of the current user's groups is allowed to access admin group; else</li>" . "<li>Non basic groups: If a user belongs to one or more non basic groups (NOT admin, user, anonymous), the current user has access if and only if one of the current user's groups is allowed to access any of the non basic groups; else</li>" . '<li>User group: If a user belongs to User group only, the current user has access if and only if one of their groups is allowed to access User group</li>' . '</ul>');
 define('_PROFILE_AM_FIELDVISIBLE', 'The field ');
 define('_PROFILE_AM_FIELDVISIBLEFOR', ' is visible for ');
 define('_PROFILE_AM_FIELDVISIBLEON', ' viewing a profile of ');

--- a/htdocs/modules/profile/userinfo.php
+++ b/htdocs/modules/profile/userinfo.php
@@ -77,8 +77,8 @@ if (is_object($GLOBALS['xoopsUser']) && $uid == $GLOBALS['xoopsUser']->getVar('u
      * "Non Basic Groups" refer to all other custom groups
      *
      * Admin groups: If thisUser belongs to admin groups, the xoopsUser has access if and only if one of xoopsUser's groups is allowed to access admin group; else
-     * Non basic groups: If thisUser belongs to one or more non basic groups, the xoopsUser has access if and only if one of xoopsUser's groups is allowed to allowed to any of the non basic groups; else
-     * User group: If thisUser belongs to User group only, the xoopsUser has access if and only if one of his groups is allowed to access User group
+     * Non basic groups: If thisUser belongs to one or more non basic groups, the xoopsUser has access if and only if one of xoopsUser's groups is allowed to access any of the non basic groups; else
+     * User group: If thisUser belongs to User group only, the xoopsUser has access if and only if one of their groups is allowed to access User group
      *
      */
     // Redirect if current user is not allowed to access the user's profile based on group permission

--- a/htdocs/modules/system/language/english/admin/preferences.php
+++ b/htdocs/modules/system/language/english/admin/preferences.php
@@ -48,7 +48,7 @@ define('_MD_AM_STRICT', 'Strict (only alphabets and numbers)');
 define('_MD_AM_MEDIUM', 'Medium');
 define('_MD_AM_LIGHT', 'Light (recommended for multi-byte chars)');
 define('_MD_AM_USERCOOKIE', 'Name for user cookies.');
-define('_MD_AM_USERCOOKIEDSC', "If the cookie name is set, 'Remember me' will be enabled for user login. If a user has chosen 'Remember me', he will be logged in automatically. The expiration for the cookie is one year.");
+define('_MD_AM_USERCOOKIEDSC', "If the cookie name is set, 'Remember me' will be enabled for user login. If a user has chosen 'Remember me', they will be logged in automatically. The expiration for the cookie is one year.");
 define('_MD_AM_USEMYSESS', 'Use custom session');
 define('_MD_AM_USEMYSESSDSC', 'Select yes to customize session related values.');
 define('_MD_AM_SESSNAME', 'Session name');
@@ -291,7 +291,7 @@ define('_MD_AM_LDAP_PROVIS_UPD_DESC', 'The XOOPS User account is always synchron
 define('_MD_AM_CPANEL', 'Control Panel GUI');
 define('_MD_AM_CPANELDSC', 'For backend');
 define('_MD_AM_WELCOMETYPE', 'Sending welcoming message');
-define('_MD_AM_WELCOMETYPE_DESC', 'The way of sending out a welcoming message to a user upon his successful registration.');
+define('_MD_AM_WELCOMETYPE_DESC', 'The method for sending a welcome message to a user upon their successful registration.');
 define('_MD_AM_WELCOMETYPE_EMAIL', 'Email');
 define('_MD_AM_WELCOMETYPE_PM', 'Message');
 define('_MD_AM_WELCOMETYPE_BOTH', 'Email and message');

--- a/htdocs/modules/system/language/english/help/avatars.html
+++ b/htdocs/modules/system/language/english/help/avatars.html
@@ -22,7 +22,7 @@
     <h4 class="odd">Edit and delete Avatars</h4>
 
     <p class="even">
-        The Site administrator can edit the name and the display order of all the System Avatars, as well as deleting anyone of them. Note that if the Site administrator deleted an avatar that is used by a user, this user will lose his avatar.
+        The Site administrator can edit the name and the display order of all the System Avatars, as well as deleting any one of them. Note that if the Site administrator deletes an avatar that a user is using, that user will lose their avatar.
     </p>
 
 

--- a/htdocs/xoops_lib/modules/protector/include/postcheck_functions.php
+++ b/htdocs/xoops_lib/modules/protector/include/postcheck_functions.php
@@ -87,7 +87,7 @@ function protector_postcommon()
         $protector->stopforumspam($uid);
     }
 
-    // If precheck has already judged that he should be banned
+    // If precheck has already judged that they should be banned
     if ($can_ban && $protector->_should_be_banned) {
         $protector->register_bad_ips();
     } elseif ($can_ban && $protector->_should_be_banned_time0) {

--- a/htdocs/xoops_lib/modules/protector/language/english/modinfo.php
+++ b/htdocs/xoops_lib/modules/protector/language/english/modinfo.php
@@ -62,7 +62,7 @@ if (defined('FOR_XOOPS_LANG_CHECKER') || !defined($constpref . '_LOADED')) {
     define($constpref . '_FILE_DOTDOTDSC', 'It eliminates ".." from all requests looks like Directory Traversals');
 
     define($constpref . '_BF_COUNT', 'Anti Brute Force');
-    define($constpref . '_BF_COUNTDSC', 'Set the maximum number of times a guest is allowed to try and login within 10 minutes. If their failed attempts to login exceed this, their IP will be banned.');
+    define($constpref . '_BF_COUNTDSC', "Set the maximum number of times a guest is allowed to try and login within 10 minutes. If the failed attempts to login exceed this, the guest's IP address will be banned.");
 
     define($constpref . '_BWLIMIT_COUNT', 'Bandwidth limitation');
     define($constpref . '_BWLIMIT_COUNTDSC', 'Specify the max access to mainfile.php during watching time. This value should be 0 for normal environments which have enough CPU bandwidth. The number fewer than 10 will be ignored.');

--- a/htdocs/xoops_lib/modules/protector/language/english/modinfo.php
+++ b/htdocs/xoops_lib/modules/protector/language/english/modinfo.php
@@ -62,7 +62,7 @@ if (defined('FOR_XOOPS_LANG_CHECKER') || !defined($constpref . '_LOADED')) {
     define($constpref . '_FILE_DOTDOTDSC', 'It eliminates ".." from all requests looks like Directory Traversals');
 
     define($constpref . '_BF_COUNT', 'Anti Brute Force');
-    define($constpref . '_BF_COUNTDSC', 'Set count you allow guest try to login within 10 minutes. If someone fails to login more than this number, her/his IP will be banned.');
+    define($constpref . '_BF_COUNTDSC', 'Set the maximum number of times a guest is allowed to try and login within 10 minutes. If their failed attempts to login exceed this, their IP will be banned.');
 
     define($constpref . '_BWLIMIT_COUNT', 'Bandwidth limitation');
     define($constpref . '_BWLIMIT_COUNTDSC', 'Specify the max access to mainfile.php during watching time. This value should be 0 for normal environments which have enough CPU bandwidth. The number fewer than 10 will be ignored.');

--- a/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Strategy/MakeWellFormed.php
+++ b/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/Strategy/MakeWellFormed.php
@@ -313,7 +313,7 @@ class HTMLPurifier_Strategy_MakeWellFormed extends HTMLPurifier_Strategy
 
                     if ($autoclose) {
                         // check if this autoclose is doomed to fail
-                        // (this rechecks $parent, which his harmless)
+                        // (this rechecks $parent, which is harmless)
                         $autoclose_ok = isset($global_parent_allowed_elements[$token->name]);
                         if (!$autoclose_ok) {
                             foreach ($this->stack as $ancestor) {


### PR DESCRIPTION
and fixed some typos/adjusted some wording in related lines.

Replacing "allowed to allowed to" with "allowed to access" is very much a guess as to the original intended meaning (based on the surrounding lines), I may well have misinterpreted these lines.

Also, I skipped an instance of "his" in the following (on line 41):
https://github.com/XOOPS/XoopsCore25/blob/dfc2ef634c69db8ff337098021faa2c822aed547/htdocs/xoops_lib/modules/protector/library/HTMLPurifier/URIScheme.php#L39-L41
My guess is that that was supposed to be "this" or "is" (or possibly could be omitted entirely?) but the phrasing of the proceeding line is not clear enough (for me) to determine precisely what should be written here.