### PR TITLE
change utf8 to utf8mb4 in install

### DIFF
--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -87,7 +87,7 @@ if (@empty($vars['DB_NAME'])) {
     // Fill with default values
     $vars = array_merge($vars, array(
                                  'DB_NAME'      => '',
-                                 'DB_CHARSET'   => 'utf8',
+                                 'DB_CHARSET'   => 'utf8mb4',
                                  'DB_COLLATION' => '',
                                  'DB_PREFIX'    => 'x' . substr(md5(time()), 0, 3)));
 }


### PR DESCRIPTION
in mySQL 8.0.30 utf8 as an alias for utf8mb3 character set has been removed, causing an error: 
Undefined index: utf8 in \install\include\functions.php on line 320
The recommended character set is utf8mb4
see: https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8.html