### PR TITLE
fix error with preg_split() and php 8.1

### DIFF
--- a/htdocs/class/smarty/xoops_plugins/modifier.truncateHtml.php
+++ b/htdocs/class/smarty/xoops_plugins/modifier.truncateHtml.php
@@ -184,7 +184,7 @@ if (!class_exists('\BaseStringHelper', false)) {
                 return static::truncateHtml($string, $count, $suffix);
             }
 
-            $words = preg_split('/(\s+)/u', trim($string), null, PREG_SPLIT_DELIM_CAPTURE);
+            $words = preg_split('/(\s+)/u', trim($string), -1, PREG_SPLIT_DELIM_CAPTURE);
             if (count($words) / 2 > $count) {
                 return implode('', array_slice($words, 0, ($count * 2) - 1)) . $suffix;
             }
@@ -350,7 +350,7 @@ if (!class_exists('\BaseStringHelper', false)) {
          */
         public static function countWords($string)
         {
-            return count(preg_split('/\s+/u', $string, null, PREG_SPLIT_NO_EMPTY));
+            return count(preg_split('/\s+/u', $string, -1, PREG_SPLIT_NO_EMPTY));
         }
 
         /**


### PR DESCRIPTION
"preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated" error in php 8.1