### PR TITLE
Added security with the "install" folder.

### DIFF
--- a/htdocs/admin.php
+++ b/htdocs/admin.php
@@ -43,10 +43,13 @@ if (!isset($xoopsConfig['admin_warnings_enable']) || $xoopsConfig['admin_warning
         echo '<br>';
     }
 
-	if (!empty(glob(XOOPS_ROOT_PATH . '/install*', GLOB_ONLYDIR))) {
-		xoops_error(sprintf(_AD_WARNINGINSTALL, XOOPS_ROOT_PATH . '/install/'));
-        echo '<br>';
-	}
+	$installDirs = glob(XOOPS_ROOT_PATH . '/install*', GLOB_ONLYDIR);
+    if (!empty($installDirs)) {
+        foreach ($installDirs as $installDir) {
+            xoops_error(sprintf(_AD_WARNINGINSTALL, $installDir));
+			echo '<br>';
+        }
+    }
 
     if (is_writable(XOOPS_ROOT_PATH . '/mainfile.php')) {
         xoops_error(sprintf(_AD_WARNINGWRITEABLE, XOOPS_ROOT_PATH . '/mainfile.php'));

--- a/htdocs/admin.php
+++ b/htdocs/admin.php
@@ -43,10 +43,10 @@ if (!isset($xoopsConfig['admin_warnings_enable']) || $xoopsConfig['admin_warning
         echo '<br>';
     }
 
-    if (is_dir(XOOPS_ROOT_PATH . '/install/')) {
-        xoops_error(sprintf(_AD_WARNINGINSTALL, XOOPS_ROOT_PATH . '/install/'));
+	if (!empty(glob(XOOPS_ROOT_PATH . '/install*', GLOB_ONLYDIR))) {
+		xoops_error(sprintf(_AD_WARNINGINSTALL, XOOPS_ROOT_PATH . '/install/'));
         echo '<br>';
-    }
+	}
 
     if (is_writable(XOOPS_ROOT_PATH . '/mainfile.php')) {
         xoops_error(sprintf(_AD_WARNINGWRITEABLE, XOOPS_ROOT_PATH . '/mainfile.php'));


### PR DESCRIPTION
Now XOOPS detects all "install" folders and displays a warning in the administration page.
For example, the folder "install_remove_096134593763c074f133e13" was not detected before and there was no warning message to say to remove this folder. Now all "install*" folders are detected. This is better for security.