### PR TITLE
fix install table modules (version)

### DIFF
--- a/upgrade/upd_2.5.10-to-2.5.11/index.php
+++ b/upgrade/upd_2.5.10-to-2.5.11/index.php
@@ -528,7 +528,7 @@ class Upgrade_2511 extends XoopsUpgrade
     {
         $migrate = new Tables();
         $count = $this->fromSmallintToVarchar($migrate, $this->modulesTableName, $this->modulesColumnNames);
-        return $count > 0;
+        return $count == 0;
     }
 
     /**


### PR DESCRIPTION
During this commit:

https://github.com/XOOPS/XoopsCore25/commit/bffcbdd0380063a1bf9853be4561268a962b26ff

line 531 has been modified. The problem is that the patch is no longer applied to the "version" column of the "modules" table. This creates problems for updating modules. I propose to return as before. We can also put a clearer condition because I don't find the code very easy to read.

What do you think?

