### PR TITLE
 update siteinfo bloc and 1 question

### DIFF
--- a/htdocs/modules/system/templates/blocks/system_block_siteinfo.tpl
+++ b/htdocs/modules/system/templates/blocks/system_block_siteinfo.tpl
@@ -1,12 +1,18 @@
-<table class="outer collapse">
-
-    <{if $block.showgroups == true}>
+<{if $block.showgroups == true}>
+	
+	<table class="outer collapse">
 
         <!-- start group loop -->
         <{foreach item=group from=$block.groups}>
-            <tr>
-                <th colspan="2"><{$group.name}></th>
-            </tr>
+
+			<{if $group.name|default:'' != ''}>
+				<thead> 
+					<tr>
+						<th colspan="2"><{$group.name}></th>
+					</tr>
+				</thead> 
+            <{/if}>
+
             <!-- start group member loop -->
             <{foreach item=user from=$group.users}>
                 <tr>
@@ -23,8 +29,8 @@
 
         <{/foreach}>
         <!-- end group loop -->
-    <{/if}>
-</table>
+	</table>
+<{/if}>
 
 <br>
 

--- a/htdocs/themes/xbootstrap/modules/system/blocks/system_block_siteinfo.tpl
+++ b/htdocs/themes/xbootstrap/modules/system/blocks/system_block_siteinfo.tpl
@@ -1,12 +1,17 @@
-<table class="outer">
-
-    <{if $block.showgroups == true}>
+<{if $block.showgroups == true}>
+	<table style="background-color: inherit;">
 
         <!-- start group loop -->
         <{foreach item=group from=$block.groups}>
-            <tr>
-                <th colspan="2"><{$group.name|default:''}></th>
-            </tr>
+
+			<{if $group.name|default:'' != ''}>
+				<thead> 
+					<tr>
+						<th colspan="2"><{$group.name}></th>
+					</tr>
+				</thead> 
+            <{/if}>
+
             <!-- start group member loop -->
             <{foreach item=user from=$group.users}>
                 <tr>
@@ -25,9 +30,9 @@
 
         <{/foreach}>
         <!-- end group loop -->
-    <{/if}>
-</table>
 
+	</table>
+<{/if}>
 <br>
 
 <div>

--- a/htdocs/themes/xswatch4/modules/system/blocks/system_block_siteinfo.tpl
+++ b/htdocs/themes/xswatch4/modules/system/blocks/system_block_siteinfo.tpl
@@ -3,9 +3,15 @@
 
         <!-- start group loop -->
         <{foreach item=group from=$block.groups}>
-            <tr>
-                <th colspan="2"><{$group.name|default:''}></th>
-            </tr>
+
+			<{if $group.name|default:'' != ''}>
+				<thead> 
+					<tr>
+						<th colspan="2"><{$group.name}></th>
+					</tr>
+				</thead> 
+            <{/if}>
+
             <!-- start group member loop -->
             <{foreach item=user from=$group.users}>
                 <tr>
@@ -30,7 +36,5 @@
 <br>
 
 <div>
-    <img src="<{$block.logourl}>" alt=""/>
-	<br>
-	<{$block.recommendlink}>
+    <img src="<{$block.logourl}>" alt=""/><br><{$block.recommendlink}>
 </div>

--- a/htdocs/themes/xswatch4/modules/system/blocks/system_block_siteinfo.tpl
+++ b/htdocs/themes/xswatch4/modules/system/blocks/system_block_siteinfo.tpl
@@ -29,7 +29,7 @@
 <{/if}>
 <br>
 
-<div class="text-center bg-secondary">
+<div>
     <img src="<{$block.logourl}>" alt=""/>
 	<br>
 	<{$block.recommendlink}>

--- a/htdocs/themes/xswatch4/modules/system/blocks/system_block_siteinfo.tpl
+++ b/htdocs/themes/xswatch4/modules/system/blocks/system_block_siteinfo.tpl
@@ -1,6 +1,5 @@
-<table style="background-color: inherit;">
-
-    <{if $block.showgroups == true}>
+<{if $block.showgroups == true}>
+	<table style="background-color: inherit;">
 
         <!-- start group loop -->
         <{foreach item=group from=$block.groups}>
@@ -25,11 +24,13 @@
 
         <{/foreach}>
         <!-- end group loop -->
-    <{/if}>
-</table>
 
+	</table>
+<{/if}>
 <br>
 
-<div>
-    <img src="<{$block.logourl}>" alt=""/><br><{$block.recommendlink}>
+<div class="text-center bg-secondary">
+    <img src="<{$block.logourl}>" alt=""/>
+	<br>
+	<{$block.recommendlink}>
 </div>


### PR DESCRIPTION
The test  of $block.showgroups should be **before** the table tag. Why ?
Cause if $block.showgroups == false, the result is a useless empty table in the code.

I have a question on another point :
Why test 
```
        <!-- start group loop -->
        <{foreach item=group from=$block.groups}>
```
 ?
Cause there is only the webmasters group displayed, no other group in this bloc.
So, I think this test is useless, I think we should pick up the group webmasters, no need to use a foreach for that.
No ?