### PR TITLE
xoops_getUserTimestamp has to return integer

### DIFF
--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -476,7 +476,7 @@ function xoops_getUserTimestamp($time, $timeoffset = '')
     }
     $usertimestamp = (int)$time + ((float)$timeoffset - $xoopsConfig['server_TZ']) * 3600;
 
-    return $usertimestamp;
+    return (int)$usertimestamp;
 }
 
 /**


### PR DESCRIPTION
creates errors when used in date(), e.g.
`TypeError: date(): Argument #2 ($timestamp) must be of type ?int, float given in file /modules/xoopspoll/class/Renderer.php line 168`