### PR TITLE
Untrusted files inclusion, not guaranteed to load the right file

### DIFF
--- a/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
@@ -77,7 +77,7 @@ class ModuleAdmin
         /**
          * version is rev of this class
          */
-        include_once 'xoops_version.php';
+        include_once __DIR__ . '/xoops_version.php';
         $version = XOOPS_FRAMEWORKS_MODULEADMIN_VERSION;
 
         return $version;
@@ -92,7 +92,7 @@ class ModuleAdmin
         /**
          * version is rev of this class
          */
-        include_once 'xoops_version.php';
+        include_once __DIR__ . '/xoops_version.php';
         $releasedate = XOOPS_FRAMEWORKS_MODULEADMIN_RELEASEDATE;
 
         return $releasedate;

--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -30,7 +30,7 @@ include __DIR__ . '/mainfile.php';
 function clientlogin()
 {
     global $xoopsDB, $xoopsLogger, $xoopsConfig;
-    include 'header.php';
+    include __DIR__ . '/header.php';
     $GLOBALS['xoTheme']->addStylesheet(null, null, '
         #login_window  {
             max-width:                          480px;

--- a/htdocs/class/snoopy.php
+++ b/htdocs/class/snoopy.php
@@ -1151,7 +1151,7 @@ class Snoopy
                 break;
 
             case "multipart/form-data":
-                $this->_mime_boundary = "Snoopy" . md5(uniqid(microtime()));
+                $this->_mime_boundary = "Snoopy" . md5(uniqid(microtime(), true));
 
                 reset($formvars);
                 while (list($key, $val) = each($formvars)) {

--- a/htdocs/class/snoopy.php
+++ b/htdocs/class/snoopy.php
@@ -1151,7 +1151,7 @@ class Snoopy
                 break;
 
             case "multipart/form-data":
-                $this->_mime_boundary = "Snoopy" . md5(uniqid(microtime(), true));
+                $this->_mime_boundary = "Snoopy" . md5(uniqid(microtime()));
 
                 reset($formvars);
                 while (list($key, $val) = each($formvars)) {

--- a/htdocs/class/uploader.php
+++ b/htdocs/class/uploader.php
@@ -24,7 +24,7 @@ defined('XOOPS_ROOT_PATH') || exit('Restricted access');
  *
  * Example of usage (single file):
  * <code>
- * include_once 'uploader.php';
+ * include_once __DIR__ . '/uploader.php';
  * $allowed_mimetypes = array('image/gif', 'image/jpeg', 'image/pjpeg', 'image/x-png');
  * $maxfilesize = 50000;
  * $maxfilewidth = 120;
@@ -46,7 +46,7 @@ defined('XOOPS_ROOT_PATH') || exit('Restricted access');
  *
  * Example of usage (multiple file):
  * <code>
- * include_once 'uploader.php';
+ * include_once __DIR__ . '/uploader.php';
  * $allowed_mimetypes = array('image/gif', 'image/jpeg', 'image/pjpeg', 'image/x-png');
  * $maxfilesize = 50000;
  * $maxfilewidth = 120;

--- a/htdocs/class/xoopseditor/tinymce5/tinymce5/jscripts/tiny_mce/plugins/xoopsimagemanager/xoopsimagemanager.php
+++ b/htdocs/class/xoopseditor/tinymce5/tinymce5/jscripts/tiny_mce/plugins/xoopsimagemanager/xoopsimagemanager.php
@@ -66,7 +66,7 @@ $catwritelist   = $imgcat_handler->getList($groups, 'imgcat_write', 1);  // get 
 $catreadcount  = count($catreadlist);        // count readable categories
 $catwritecount = count($catwritelist);      // count writable categories
 
-include_once 'XoopsFormRendererBootstrap4.php';
+include_once __DIR__ . '/XoopsFormRendererBootstrap4.php';
 XoopsFormRenderer::getInstance()->set(new XoopsFormRendererBootstrap4());
 
 // check/set parameters - start

--- a/htdocs/install/class/installwizard.php
+++ b/htdocs/install/class/installwizard.php
@@ -44,11 +44,11 @@ class XoopsInstallWizard
         // Load the main language file
         $this->initLanguage(!empty($_COOKIE['xo_install_lang']) ? $_COOKIE['xo_install_lang'] : 'english');
         // Setup pages
-        include_once './include/page.php';
+        include_once __DIR__ . '/include/page.php';
         $this->pages = $pages;
 
         // Load default configs
-        include_once './include/config.php';
+        include_once __DIR__ . '/include/config.php';
         $this->configs = $configs;
         /*
         // Database type
@@ -143,9 +143,9 @@ class XoopsInstallWizard
     public function loadLangFile($file)
     {
         if (file_exists("./language/{$this->language}/{$file}.php")) {
-            include_once "./language/{$this->language}/{$file}.php";
+            include_once __DIR__ . "/language/{$this->language}/{$file}.php";
         } else {
-            include_once "./language/english/$file.php";
+            include_once __DIR__ . "/language/english/$file.php";
         }
     }
 

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -213,8 +213,8 @@ class PathStuffController
         if ($PATH === 'root' || empty($PATH)) {
             $path = 'root';
             if (is_dir($this->xoopsPath[$path]) && is_readable($this->xoopsPath[$path])) {
-                @include_once "{$this->xoopsPath[$path]}/include/version.php";
-                if (file_exists("{$this->xoopsPath[$path]}/mainfile.dist.php") && defined('XOOPS_VERSION')) {
+                @include_once __DIR__ . "/{$this->xoopsPath[$path]}/include/version.php";
+                if (file_exists(__DIR__ . "/{$this->xoopsPath[$path]}/mainfile.dist.php") && defined('XOOPS_VERSION')) {
                     $this->validPath[$path] = 1;
                 }
             }

--- a/htdocs/install/cleanup.php
+++ b/htdocs/install/cleanup.php
@@ -23,7 +23,7 @@
  * @author          Richard Griffith <richard@geekwright.com>
  */
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $install_rename_suffix = $_POST['instsuffix'];

--- a/htdocs/install/include/common.inc.php
+++ b/htdocs/install/include/common.inc.php
@@ -69,24 +69,24 @@ if (empty($xoopsOption['hascommon'])) {
     session_start();
 
     if (PHP_VERSION_ID < 70300) {
-        require_once '../include/xoopssetcookie.php';
+        require_once __DIR__ . '/../include/xoopssetcookie.php';
         xoops_setcookie(session_name(), session_id(), $options);
     }
 
 }
 
-@include '../mainfile.php';
+@include __DIR__ . '/../mainfile.php';
 if (!defined('XOOPS_ROOT_PATH')) {
     define('XOOPS_ROOT_PATH', str_replace("\\", '/', realpath('../')));
 }
 
 date_default_timezone_set(@date_default_timezone_get());
-include './class/installwizard.php';
-include_once '../include/version.php';
-require_once '../include/xoopssetcookie.php';
-include_once './include/functions.php';
-include_once '../class/module.textsanitizer.php';
-include_once '../class/libraries/vendor/autoload.php';
+include __DIR__ . '/class/installwizard.php';
+include_once __DIR__ . '/../include/version.php';
+require_once __DIR__ . '/../include/xoopssetcookie.php';
+include_once __DIR__ . '/include/functions.php';
+include_once __DIR__ . '/../class/module.textsanitizer.php';
+include_once __DIR__ . '/../class/libraries/vendor/autoload.php';
 
 $pageHasHelp = false;
 $pageHasForm = false;

--- a/htdocs/install/include/install_tpl.php
+++ b/htdocs/install/include/install_tpl.php
@@ -28,7 +28,7 @@
  **/
 
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
-include_once '../language/' . $wizard->language . '/global.php';
+include_once __DIR__ . '/../language/' . $wizard->language . '/global.php';
 ?><!doctype html>
 <html lang="<?php echo _LANGCODE; ?>">
 
@@ -94,7 +94,7 @@ include_once '../language/' . $wizard->language . '/global.php';
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-book"></i> <?php echo SUPPORT; ?> <b class="caret"></b></a>
                 <ul class="dropdown-menu">
                     <?php
-                    @include_once './language/' . $wizard->language . '/support.php';
+                    @include_once __DIR__ . '/language/' . $wizard->language . '/support.php';
                     foreach ($supports as $lang => $support) {
                         echo '<li><a href="' . $support['url'] . '" target="_blank">' . $support['title'] . '</a></li>';
                     }

--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -26,7 +26,7 @@
  * @param $dbm
  * @return bool
  */
-// include_once './class/dbmanager.php';
+// include_once __DIR__ . '/class/dbmanager.php';
 // RMV
 // TODO: Shouldn't we insert specific field names??  That way we can use
 // the defaults specified in the database...!!!! (and don't have problem
@@ -94,14 +94,14 @@ function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $
     $dbm->insert('tplset', " VALUES (1, 'default', 'XOOPS Default Template Set', '', " . $time . ')');
     // system modules
     if (file_exists('../modules/system/language/' . $language . '/modinfo.php')) {
-        include '../modules/system/language/' . $language . '/modinfo.php';
+        include __DIR__ . '/../modules/system/language/' . $language . '/modinfo.php';
     } else {
-        include '../modules/system/language/english/modinfo.php';
+        include __DIR__ . '/../modules/system/language/english/modinfo.php';
         $language = 'english';
     }
 
     $modversion = array();
-    include_once '../modules/system/xoops_version.php';
+    include_once __DIR__ . '/../modules/system/xoops_version.php';
     $time = time();
     // RMV-NOTIFY (updated for extra column in table)
     $dbm->insert('modules', " VALUES (1, '" . _MI_SYSTEM_NAME . "', '" . $modversion['version'] . "', " . $time . ", 0, 1, 'system', 0, 1, 0, 0, 0, 0)");
@@ -312,7 +312,7 @@ function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $
 
     $dbm->insert('config', " VALUES (134, 0, 1, 'redirect_message_ajax', '_MD_AM_CUSTOM_REDIRECT', '1', '_MD_AM_CUSTOM_REDIRECT_DESC', 'yesno', 'int', 12)");
 
-    require_once '../class/xoopslists.php';
+    require_once __DIR__ . '/../class/xoopslists.php';
     $editors = XoopsLists::getDirListAsArray('../class/xoopseditor');
     $conf    = 36;
     foreach ($editors as $dir) {

--- a/htdocs/install/index.php
+++ b/htdocs/install/index.php
@@ -26,5 +26,5 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once 'page_langselect.php';
+require_once __DIR__ . '/page_langselect.php';
 exit();

--- a/htdocs/install/page_configsave.php
+++ b/htdocs/install/page_configsave.php
@@ -26,7 +26,7 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $pageHasForm = false;
@@ -103,7 +103,7 @@ if (true === $writeCheck) {
         $content .= '<div class="alert alert-danger"><span class="fa fa-ban text-danger"></span> ' . $errorMsg . '</div>' . "\n";
     }
 }
-include './include/install_tpl.php';
+include __DIR__ . '/include/install_tpl.php';
 
 /**
  * Copy a configuration file from template, then rewrite with actual configuration values

--- a/htdocs/install/page_configsite.php
+++ b/htdocs/install/page_configsite.php
@@ -16,13 +16,13 @@
 
 $xoopsOption['checkadmin'] = true;
 $xoopsOption['hascommon']  = true;
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
-if (!@include_once "../modules/system/language/{$wizard->language}/admin.php") {
-    include_once '../modules/system/language/english/admin.php';
+if (!@include_once __DIR__ . "/../modules/system/language/{$wizard->language}/admin.php") {
+    include_once __DIR__ . '/../modules/system/language/english/admin.php';
 }
-if (!@include_once "../modules/system/language/{$wizard->language}/admin/preferences.php") {
-    include_once '../modules/system/language/english/admin/preferences.php';
+if (!@include_once __DIR__ . "/../modules/system/language/{$wizard->language}/admin/preferences.php") {
+    include_once __DIR__ . '/../modules/system/language/english/admin/preferences.php';
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -55,7 +55,7 @@ $criteria->add($criteria2);
 $criteria->setSort('conf_catid ASC, conf_order ASC');
 $configs = $config_handler->getConfigs($criteria);
 
-include './include/createconfigform.php';
+include __DIR__ . '/include/createconfigform.php';
 $wizard->form = createConfigform($configs);
 $content      = $wizard->CreateForm();
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_configsite.php
+++ b/htdocs/install/page_configsite.php
@@ -58,4 +58,4 @@ $configs = $config_handler->getConfigs($criteria);
 include __DIR__ . '/include/createconfigform.php';
 $wizard->form = createConfigform($configs);
 $content      = $wizard->CreateForm();
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_dbconnection.php
+++ b/htdocs/install/page_dbconnection.php
@@ -25,7 +25,7 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $pageHasForm = true;
@@ -90,4 +90,4 @@ ob_start();
 <?php
 $content = ob_get_contents();
 ob_end_clean();
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_dbconnection.php
+++ b/htdocs/install/page_dbconnection.php
@@ -90,4 +90,4 @@ ob_start();
 <?php
 $content = ob_get_contents();
 ob_end_clean();
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -121,4 +121,4 @@ ob_start();
 <?php
 $content = ob_get_contents();
 ob_end_clean();
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -25,7 +25,7 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $pageHasForm = true;
@@ -121,4 +121,4 @@ ob_start();
 <?php
 $content = ob_get_contents();
 ob_end_clean();
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_end.php
+++ b/htdocs/install/page_end.php
@@ -25,11 +25,11 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
-include_once '../class/xoopsload.php';
-include_once '../class/preload.php';
-include_once '../class/database/databasefactory.php';
-include_once '../class/logger/xoopslogger.php';
+require_once __DIR__ . '/include/common.inc.php';
+include_once __DIR__ . '/../class/xoopsload.php';
+include_once __DIR__ . '/../class/preload.php';
+include_once __DIR__ . '/../class/database/databasefactory.php';
+include_once __DIR__ . '/../class/logger/xoopslogger.php';
 
 $_SESSION = array();
 xoops_setcookie('xo_install_user', '', null, null, null);
@@ -43,6 +43,6 @@ $installer_modified    = 'install_remove_' . $install_rename_suffix;
 $pageHasForm = false;
 
 $content = '';
-include "./language/{$wizard->language}/finish.php";
+include __DIR__ . "/language/{$wizard->language}/finish.php";
 
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_end.php
+++ b/htdocs/install/page_end.php
@@ -45,4 +45,4 @@ $pageHasForm = false;
 $content = '';
 include __DIR__ . "/language/{$wizard->language}/finish.php";
 
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_langselect.php
+++ b/htdocs/install/page_langselect.php
@@ -61,4 +61,4 @@ $content .=<<<EOB
 EOB;
 
 
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_langselect.php
+++ b/htdocs/install/page_langselect.php
@@ -26,7 +26,7 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 xoops_setcookie('xo_install_lang', 'english', null, null, null);
@@ -61,4 +61,4 @@ $content .=<<<EOB
 EOB;
 
 
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -25,7 +25,7 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $pageHasForm = false;
@@ -105,4 +105,4 @@ ob_start();
 $content = ob_get_contents();
 ob_end_clean();
 
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -105,4 +105,4 @@ ob_start();
 $content = ob_get_contents();
 ob_end_clean();
 
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_moduleinstaller.php
+++ b/htdocs/install/page_moduleinstaller.php
@@ -16,31 +16,31 @@
 
 $xoopsOption['checkadmin'] = true;
 $xoopsOption['hascommon']  = true;
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
-if (!@include_once "../language/{$wizard->language}/global.php") {
-    include_once '../language/english/global.php';
+if (!@include_once __DIR__ . "/../language/{$wizard->language}/global.php") {
+    include_once __DIR__ . '/../language/english/global.php';
 }
-if (!@include_once "../modules/system/language/{$wizard->language}/admin.php") {
-    include_once '../modules/system/language/english/admin.php';
+if (!@include_once __DIR__ . "/../modules/system/language/{$wizard->language}/admin.php") {
+    include_once __DIR__ . '/../modules/system/language/english/admin.php';
 }
-if (!@include_once "../modules/system/language/{$wizard->language}/admin/modulesadmin.php") {
-    include_once '../modules/system/language/english/admin/modulesadmin.php';
+if (!@include_once __DIR__ . "/../modules/system/language/{$wizard->language}/admin/modulesadmin.php") {
+    include_once __DIR__ . '/../modules/system/language/english/admin/modulesadmin.php';
 }
 
-require_once '../class/xoopsformloader.php';
-require_once '../class/xoopslists.php';
+require_once __DIR__ . '/../class/xoopsformloader.php';
+require_once __DIR__ . '/../class/xoopslists.php';
 
 $pageHasForm = true;
 $pageHasHelp = false;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    include_once '../class/xoopsblock.php';
-    include_once '../kernel/module.php';
-    include_once '../include/cp_functions.php';
-    include_once '../include/version.php';
-    include_once './include/modulesadmin.php';
+    include_once __DIR__ . '/../class/xoopsblock.php';
+    include_once __DIR__ . '/../kernel/module.php';
+    include_once __DIR__ . '/../include/cp_functions.php';
+    include_once __DIR__ . '/../include/version.php';
+    include_once __DIR__ . '/include/modulesadmin.php';
 
     /* @var XoopsConfigHandler $config_handler */
     $config_handler = xoops_getHandler('config');
@@ -89,7 +89,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $listed_mods[] = $module->getVar('dirname');
     }
 
-    include_once '../class/xoopslists.php';
+    include_once __DIR__ . '/../class/xoopslists.php';
     $dirlist  = XoopsLists::getModulesList();
     $toinstal = 0;
 
@@ -156,4 +156,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_moduleinstaller.php
+++ b/htdocs/install/page_moduleinstaller.php
@@ -156,4 +156,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -154,4 +154,4 @@ ob_start();
 $content = ob_get_contents();
 ob_end_clean();
 
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -25,11 +25,11 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
-include_once './class/pathcontroller.php';
-include_once '../include/functions.php';
+include_once __DIR__ . '/class/pathcontroller.php';
+include_once __DIR__ . '/../include/functions.php';
 
 $pageHasForm = true;
 $pageHasHelp = true;
@@ -154,4 +154,4 @@ ob_start();
 $content = ob_get_contents();
 ob_end_clean();
 
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_siteinit.php
+++ b/htdocs/install/page_siteinit.php
@@ -163,4 +163,4 @@ if ($isadmin) {
 $content = ob_get_contents();
 ob_end_clean();
 $error = !empty($error);
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_siteinit.php
+++ b/htdocs/install/page_siteinit.php
@@ -25,7 +25,7 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $pageHasForm = true;
@@ -67,7 +67,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         return 302;
     }
 } else {
-    include_once './class/dbmanager.php';
+    include_once __DIR__ . '/class/dbmanager.php';
     $dbm = new Db_manager();
 
     if (!$dbm->isConnectable()) {
@@ -163,4 +163,4 @@ if ($isadmin) {
 $content = ob_get_contents();
 ob_end_clean();
 $error = !empty($error);
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_start.php
+++ b/htdocs/install/page_start.php
@@ -25,13 +25,13 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $pageHasForm = false;
 
 $content = '';
-include "./language/{$wizard->language}/welcome.php";
+include __DIR__ . "/language/{$wizard->language}/welcome.php";
 
 $writable = '<div class="alert alert-warning"><ul style="list-style: none;">';
 foreach ($wizard->configs['writable'] as $key => $value) {
@@ -62,4 +62,4 @@ $writable_trust .= '</ul></div>';
 
 $content = sprintf($content, $writable, $xoops_trust, $writable_trust);
 
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_start.php
+++ b/htdocs/install/page_start.php
@@ -62,4 +62,4 @@ $writable_trust .= '</ul></div>';
 
 $content = sprintf($content, $writable, $xoops_trust, $writable_trust);
 
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_tablescreate.php
+++ b/htdocs/install/page_tablescreate.php
@@ -25,7 +25,7 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  **/
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $pageHasForm = false;
@@ -33,8 +33,8 @@ $pageHasHelp = false;
 
 $vars =& $_SESSION['settings'];
 
-include_once '../mainfile.php';
-include_once './class/dbmanager.php';
+include_once __DIR__ . '/../mainfile.php';
+include_once __DIR__ . '/class/dbmanager.php';
 $dbm = new Db_manager();
 
 if (!$dbm->isConnectable()) {
@@ -49,4 +49,4 @@ if ($dbm->tableExists('users')) {
     $content = '<div class="alert alert-success"><span class="fa fa-check text-success"></span> ' . XOOPS_TABLES_CREATED
         . '</div><div class="well">' . $dbm->report() . '</div>';
 }
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_tablescreate.php
+++ b/htdocs/install/page_tablescreate.php
@@ -49,4 +49,4 @@ if ($dbm->tableExists('users')) {
     $content = '<div class="alert alert-success"><span class="fa fa-check text-success"></span> ' . XOOPS_TABLES_CREATED
         . '</div><div class="well">' . $dbm->report() . '</div>';
 }
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_tablesfill.php
+++ b/htdocs/install/page_tablesfill.php
@@ -101,4 +101,4 @@ if (!empty($_SESSION['settings']['authorized']) && !empty($adminname) && !empty(
     xoops_setcookie('xo_install_user', $token, 0, null, null, null, true);
 }
 
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_tablesfill.php
+++ b/htdocs/install/page_tablesfill.php
@@ -25,7 +25,7 @@
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
  */
 
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $pageHasForm = false;
@@ -33,8 +33,8 @@ $pageHasHelp = false;
 
 $vars =& $_SESSION['settings'];
 
-include_once '../mainfile.php';
-include_once './class/dbmanager.php';
+include_once __DIR__ . '/../mainfile.php';
+include_once __DIR__ . '/class/dbmanager.php';
 $dbm = new Db_manager();
 
 if (!$dbm->isConnectable()) {
@@ -60,7 +60,7 @@ $update  = false;
 
 extract($_SESSION['siteconfig'], EXTR_SKIP);
 
-include_once './include/makedata.php';
+include_once __DIR__ . '/include/makedata.php';
 //$cm = 'dummy';
 $wizard->loadLangFile('install2');
 
@@ -101,4 +101,4 @@ if (!empty($_SESSION['settings']['authorized']) && !empty($adminname) && !empty(
     xoops_setcookie('xo_install_user', $token, 0, null, null, null, true);
 }
 
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/install/page_theme.php
+++ b/htdocs/install/page_theme.php
@@ -59,4 +59,4 @@ include __DIR__ . '/includecreateconfigform.php';
 $wizard->form = createThemeform($config);
 $content      = $wizard->CreateForm();
 
-include __DIR__ . '/includeinstall_tpl.php';
+include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_theme.php
+++ b/htdocs/install/page_theme.php
@@ -16,13 +16,13 @@
 
 $xoopsOption['checkadmin'] = true;
 $xoopsOption['hascommon']  = true;
-require_once './include/common.inc.php';
+require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
-if (!@include_once "../modules/system/language/{$wizard->language}/admin.php") {
-    include_once '../modules/system/language/english/admin.php';
+if (!@include_once __DIR__ . "/../modules/system/language/{$wizard->language}/admin.php") {
+    include_once __DIR__ . '/../modules/system/language/english/admin.php';
 }
-if (!@include_once "../modules/system/language/{$wizard->language}/admin/preferences.php") {
-    include_once '../modules/system/language/english/admin/preferences.php';
+if (!@include_once __DIR__ . "/../modules/system/language/{$wizard->language}/admin/preferences.php") {
+    include_once __DIR__ . '/../modules/system/language/english/admin/preferences.php';
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -55,8 +55,8 @@ $criteria->add(new Criteria('conf_name', 'theme_set'));
 
 $tempConfig = $config_handler->getConfigs($criteria);
 $config = array_pop($tempConfig);
-include './include/createconfigform.php';
+include __DIR__ . '/includecreateconfigform.php';
 $wizard->form = createThemeform($config);
 $content      = $wizard->CreateForm();
 
-include './include/install_tpl.php';
+include __DIR__ . '/includeinstall_tpl.php';

--- a/htdocs/xoops_lib/modules/protector/admin/about.php
+++ b/htdocs/xoops_lib/modules/protector/admin/about.php
@@ -16,9 +16,9 @@
  * @author              Mage, Mamba
  **/
 
-include '../../../include/cp_header.php';
-include '../../../class/xoopsformloader.php';
-include 'admin_header.php';
+include __DIR__ . '/../../../include/cp_header.php';
+include __DIR__ . '/../../../class/xoopsformloader.php';
+include __DIR__ . '/admin_header.php';
 xoops_cp_header();
 
 $aboutAdmin = new ModuleAdmin();
@@ -26,5 +26,5 @@ $aboutAdmin = new ModuleAdmin();
 echo $aboutAdmin->addNavigation(basename(__FILE__));
 echo $aboutAdmin->renderAbout('xoopsfoundation@gmail.com', false);
 
-include 'admin_footer.php';
+include __DIR__ . '/admin_footer.php';
 xoops_cp_footer();

--- a/htdocs/xoops_lib/modules/protector/admin/admin_header.php
+++ b/htdocs/xoops_lib/modules/protector/admin/admin_header.php
@@ -22,7 +22,7 @@ include_once XOOPS_ROOT_PATH . '/mainfile.php';
 include_once XOOPS_ROOT_PATH . '/include/cp_header.php';
 include_once XOOPS_ROOT_PATH . '/include/cp_functions.php';
 
-//include '../../../include/cp_header.php';
+//include __DIR__ . '/../../../include/cp_header.php';
 //require_once XOOPS_ROOT_PATH . '/modules/' . $GLOBALS['xoopsModule']->getVar('dirname') . '/include/functions.php';
 
 if (file_exists($GLOBALS['xoops']->path('/Frameworks/moduleclasses/moduleadmin/moduleadmin.php'))) {

--- a/htdocs/xoops_lib/modules/protector/admin/advisory.php
+++ b/htdocs/xoops_lib/modules/protector/admin/advisory.php
@@ -1,6 +1,6 @@
 <?php
-include '../../../include/cp_header.php';
-include 'admin_header.php';
+include __DIR__ . '/../../../include/cp_header.php';
+include __DIR__ . '/admin_header.php';
 $db = XoopsDatabaseFactory::getDatabaseConnection();
 
 // beggining of Output

--- a/htdocs/xoops_lib/modules/protector/admin/center.php
+++ b/htdocs/xoops_lib/modules/protector/admin/center.php
@@ -1,6 +1,6 @@
 <?php
 //require_once XOOPS_ROOT_PATH.'/include/cp_header.php' ;
-include_once 'admin_header.php'; //mb problem: it shows always the same "Center" tab
+include_once __DIR__ . '/admin_header.php'; //mb problem: it shows always the same "Center" tab
 xoops_cp_header();
 include __DIR__ . '/mymenu.php';
 require_once XOOPS_ROOT_PATH . '/class/pagenav.php';

--- a/htdocs/xoops_lib/modules/protector/admin/index.php
+++ b/htdocs/xoops_lib/modules/protector/admin/index.php
@@ -17,7 +17,7 @@
  * @author       XOOPS Development Team, Raul Recio (AKA UNFOR)
  */
 
-include_once 'admin_header.php';
+include_once __DIR__ . '/admin_header.php';
 xoops_cp_header();
 
 $indexAdmin = new ModuleAdmin();
@@ -25,6 +25,6 @@ $indexAdmin = new ModuleAdmin();
 echo $indexAdmin->addNavigation(basename(__FILE__));
 echo $indexAdmin->renderIndex();
 
-include 'admin_footer.php';
+include __DIR__ . '/admin_footer.php';
 //xoops_cp_footer();
 

--- a/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
+++ b/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
@@ -1,6 +1,6 @@
 <?php
-include '../../../include/cp_header.php';
-include 'admin_header.php';
+include __DIR__ . '/../../../include/cp_header.php';
+include __DIR__ . '/admin_header.php';
 require_once dirname(__DIR__) . '/class/gtickets.php';
 $db = XoopsDatabaseFactory::getDatabaseConnection();
 

--- a/upgrade/checkmainfile.php
+++ b/upgrade/checkmainfile.php
@@ -20,7 +20,7 @@
 
 $loadCommon = !isset($xoopsOption['nocommon']);
 $xoopsOption['nocommon'] = true;
-include_once '../mainfile.php';
+include_once __DIR__ . '/../mainfile.php';
 
 $mainfileKeys = array(
     // in mainfile.php

--- a/upgrade/class/control.php
+++ b/upgrade/class/control.php
@@ -69,11 +69,12 @@ class UpgradeControl
 
         $language = (null === $language) ? $this->upgradeLanguage : $language;
 
-        if (file_exists("./language/{$language}/{$domain}.php")) {
-            include_once "./language/{$language}/{$domain}.php";
-        } elseif (file_exists("./language/english/{$domain}.php")) {
-            include_once "./language/english/{$domain}.php";
+        if (file_exists(__DIR__ . "/language/{$language}/{$domain}.php")) {
+            include_once __DIR__ . "/language/{$language}/{$domain}.php";
+        } elseif (file_exists(__DIR__ . "/language/english/{$domain}.php")) {
+            include_once __DIR__ . "/language/english/{$domain}.php";
         }
+
 
         if (null !== $supports) {
             $this->supportSites = array_merge($this->supportSites, $supports);

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -50,7 +50,7 @@ if (strlen($_SERVER['REMOTE_ADDR']) > 15) {
     $_SERVER['REMOTE_ADDR'] = '::1';
 }
 
-include_once 'checkmainfile.php';
+include_once __DIR__ . '/checkmainfile.php';
 defined('XOOPS_ROOT_PATH') or die('Bad installation: please add this folder to the XOOPS install you want to upgrade');
 
 $reporting = 0;
@@ -63,9 +63,9 @@ $xoopsLogger->enableRendering();
 xoops_loadLanguage('logger');
 set_exception_handler('fatalPhpErrorHandler'); // should have been changed by now, reset to ours
 
-require './class/abstract.php';
-require './class/patchstatus.php';
-require './class/control.php';
+require __DIR__ . '/class/abstract.php';
+require __DIR__ . '/class/patchstatus.php';
+require __DIR__ . '/class/control.php';
 
 $GLOBALS['error'] = false;
 $GLOBALS['upgradeControl'] = new UpgradeControl();
@@ -77,7 +77,7 @@ $upgradeControl->buildUpgradeQueue();
 ob_start();
 global $xoopsUser;
 if (!$xoopsUser || !$xoopsUser->isAdmin()) {
-    include_once 'login.php';
+    include_once __DIR__ . '/login.php';
 } else {
     $op = Xmf\Request::getCmd('action', '');
     if (!$upgradeControl->needUpgrade) {
@@ -124,4 +124,4 @@ if (!$xoopsUser || !$xoopsUser->isAdmin()) {
 $content = ob_get_contents();
 ob_end_clean();
 
-include_once 'upgrade_tpl.php';
+include_once __DIR__ . '/upgrade_tpl.php';

--- a/upgrade/upd-2.4.x-to-2.5.0/index.php
+++ b/upgrade/upd-2.4.x-to-2.5.0/index.php
@@ -16,7 +16,7 @@
  * @author              Andricq Nicolas (AKA MusS)
  */
 
-require_once 'dbmanager.php';
+require_once __DIR__ . '/dbmanager.php';
 
 /**
  * Class upgrade_250
@@ -112,7 +112,7 @@ class Upgrade_250 extends XoopsUpgrade
 
         $dbm->insert('config', " (conf_modid,conf_catid,conf_name,conf_title,conf_value,conf_desc,conf_formtype,conf_valuetype,conf_order) VALUES (0, 1, 'redirect_message_ajax', '_MD_AM_CUSTOM_REDIRECT', '1', '_MD_AM_CUSTOM_REDIRECT_DESC', 'yesno', 'int', 12)");
 
-        require_once '../class/xoopslists.php';
+        require_once __DIR__ . '/../class/xoopslists.php';
         $editors = XoopsLists::getDirListAsArray('../class/xoopseditor');
         foreach ($editors as $dir) {
             $dbm->insert('configoption', " (confop_name,confop_value,conf_id) VALUES ('" . $dir . "', '" . $dir . "', $block_id)");
@@ -144,7 +144,7 @@ class Upgrade_250 extends XoopsUpgrade
      */
     public function apply_templates()
     {
-        include_once '../modules/system/xoops_version.php';
+        include_once __DIR__ . '/../modules/system/xoops_version.php';
 
         $dbm  = new Db_manager();
         $time = time();


### PR DESCRIPTION
Replacing relative paths in the include/require statements with absolute paths based on the current directory by using __DIR__
it ensures that the file paths are resolved relative to the directory of the current file, rather than relying on the include path.