### PR TITLE
Add makeSet()

### DIFF
--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -403,15 +403,15 @@ function xoops_result($msg, $title = '')
  */
 function xoops_confirm($hiddens, $action, $msg, $submit = '', $addtoken = true)
 {
-	if (!isset($GLOBALS['xoTheme']) || !is_object($GLOBALS['xoTheme'])) {
-		include_once $GLOBALS['xoops']->path('/class/theme.php');
-		$GLOBALS['xoTheme'] = new \xos_opal_Theme();
-	}
-	require_once $GLOBALS['xoops']->path('/class/template.php');
-	$confirmTpl = new \XoopsTpl();
-	$confirmTpl->assign('msg', $msg);
-	$confirmTpl->assign('action', $action);
-	$tempHiddens = '';
+    if (!isset($GLOBALS['xoTheme']) || !is_object($GLOBALS['xoTheme'])) {
+        include_once $GLOBALS['xoops']->path('/class/theme.php');
+        $GLOBALS['xoTheme'] = new \xos_opal_Theme();
+    }
+    require_once $GLOBALS['xoops']->path('/class/template.php');
+    $confirmTpl = new \XoopsTpl();
+    $confirmTpl->assign('msg', $msg);
+    $confirmTpl->assign('action', $action);
+    $tempHiddens = '';
     foreach ($hiddens as $name => $value) {
         if (is_array($value)) {
             foreach ($value as $caption => $newvalue) {
@@ -422,39 +422,39 @@ function xoops_confirm($hiddens, $action, $msg, $submit = '', $addtoken = true)
             $tempHiddens .= '<input type="hidden" name="' . $name . '" value="' . htmlspecialchars($value) . '" />';
         }
     }
-	$confirmTpl->assign('hiddens', $tempHiddens);
-	$confirmTpl->assign('addtoken', $addtoken);
-	if ($addtoken != false) {
-		$confirmTpl->assign('token', $GLOBALS['xoopsSecurity']->getTokenHTML());
-	}
+    $confirmTpl->assign('hiddens', $tempHiddens);
+    $confirmTpl->assign('addtoken', $addtoken);
+    if ($addtoken != false) {
+        $confirmTpl->assign('token', $GLOBALS['xoopsSecurity']->getTokenHTML());
+    }
     $submit = ($submit != '') ? trim($submit) : _SUBMIT;
-	$confirmTpl->assign('submit', $submit);
-	$html = $confirmTpl->fetch("db:system_confirm.tpl");
-	if (!empty($html)) {
-		echo $html;
-	} else {
-		$submit = ($submit != '') ? trim($submit) : _SUBMIT;
-		echo '<div class="confirmMsg">' . $msg . '<br>
-			  <form method="post" action="' . $action . '">';
-		foreach ($hiddens as $name => $value) {
-			if (is_array($value)) {
-				foreach ($value as $caption => $newvalue) {
-					echo '<input type="radio" name="' . $name . '" value="' . htmlspecialchars($newvalue) . '" /> ' . $caption;
-				}
-				echo '<br>';
-			} else {
-				echo '<input type="hidden" name="' . $name . '" value="' . htmlspecialchars($value) . '" />';
-			}
-		}
-		if ($addtoken != false) {
-			echo $GLOBALS['xoopsSecurity']->getTokenHTML();
-		}
-		// TODO - these buttons should go through formRenderer
-		echo '<input type="submit" class="btn btn-default btn-secondary" name="confirm_submit" value="' . $submit . '" title="' . $submit . '"/>
-			  <input type="button" class="btn btn-default btn-secondary" name="confirm_back" value="' . _CANCEL . '" onclick="history.go(-1);" title="' . _CANCEL . '" />
-			  </form>
-			  </div>';
-	}
+    $confirmTpl->assign('submit', $submit);
+    $html = $confirmTpl->fetch("db:system_confirm.tpl");
+    if (!empty($html)) {
+        echo $html;
+    } else {
+        $submit = ($submit != '') ? trim($submit) : _SUBMIT;
+        echo '<div class="confirmMsg">' . $msg . '<br>
+              <form method="post" action="' . $action . '">';
+        foreach ($hiddens as $name => $value) {
+            if (is_array($value)) {
+                foreach ($value as $caption => $newvalue) {
+                    echo '<input type="radio" name="' . $name . '" value="' . htmlspecialchars($newvalue) . '" /> ' . $caption;
+                }
+                echo '<br>';
+            } else {
+                echo '<input type="hidden" name="' . $name . '" value="' . htmlspecialchars($value) . '" />';
+            }
+        }
+        if ($addtoken != false) {
+            echo $GLOBALS['xoopsSecurity']->getTokenHTML();
+        }
+        // TODO - these buttons should go through formRenderer
+        echo '<input type="submit" class="btn btn-default btn-secondary" name="confirm_submit" value="' . $submit . '" title="' . $submit . '"/>
+              <input type="button" class="btn btn-default btn-secondary" name="confirm_back" value="' . _CANCEL . '" onclick="history.go(-1);" title="' . _CANCEL . '" />
+              </form>
+              </div>';
+    }
 }
 
 /**
@@ -1288,6 +1288,25 @@ function xoops_getUrlDomain($url)
     }
 
     return $domain;
+}
+
+/**
+ * Check that the variable passed as $name is set, and if not, set with the specified $default.
+ *
+ * Note that $name is passed by reference, so it will be established in the caller's context
+ * if not already set. The value of $name is returned for convenience as well.
+ *
+ * @param mixed $name    Passed by reference variable. Will be created if is not set.
+ * @param mixed $default The default to use if $name is not set
+ *
+ * @return mixed the value in $name
+ */
+function makeSet(&$name, $default)
+{
+    if (!isset($name)) {
+        $name = $default;
+    }
+    return $name;
 }
 
 include_once __DIR__ . '/functions.encoding.php';


### PR DESCRIPTION
- add makeSet() function to simplify setting default for a missing variable
- also has tab to space conversion for file

The makeSet() function is intended to reduce the complexity often proliferated using the PHP isset() function. 

In short, this function can replace:
```PHP
    if (!isset($options) {
        $options = '';
    }
    doStuff($options);
```

with:
```PHP
    doStuff(makeSet($options,''));
```
