### PR TITLE
Dir install upgrade

### DIFF
--- a/htdocs/install/include/common.inc.php
+++ b/htdocs/install/include/common.inc.php
@@ -75,7 +75,7 @@ if (empty($xoopsOption['hascommon'])) {
 
 }
 
-@include __DIR__ . '/../mainfile.php';
+@include __DIR__ . '/../../mainfile.php';
 if (!defined('XOOPS_ROOT_PATH')) {
     define('XOOPS_ROOT_PATH', str_replace("\\", '/', realpath('../')));
 }

--- a/htdocs/install/include/install_tpl.php
+++ b/htdocs/install/include/install_tpl.php
@@ -94,7 +94,7 @@ include_once __DIR__ . '/../../language/' . $wizard->language . '/global.php';
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-book"></i> <?php echo SUPPORT; ?> <b class="caret"></b></a>
                 <ul class="dropdown-menu">
                     <?php
-                    @include_once __DIR__ . '/language/' . $wizard->language . '/support.php';
+                    @include_once __DIR__ . '/../language/' . $wizard->language . '/support.php';
                     foreach ($supports as $lang => $support) {
                         echo '<li><a href="' . $support['url'] . '" target="_blank">' . $support['title'] . '</a></li>';
                     }

--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -26,12 +26,11 @@
  * @param $dbm
  * @return bool
  */
-// include_once __DIR__ . '/class/dbmanager.php';
 // RMV
 // TODO: Shouldn't we insert specific field names??  That way we can use
 // the defaults specified in the database...!!!! (and don't have problem
 // of missing fields in install file, when add new fields to database)
-function make_groups(&$dbm)
+function make_groups($dbm)
 {
     $groups['XOOPS_GROUP_ADMIN']     = $dbm->insert('groups', " VALUES (1, '" . addslashes(_INSTALL_WEBMASTER) . "', '" . addslashes(_INSTALL_WEBMASTERD) . "', 'Admin')");
     $groups['XOOPS_GROUP_USERS']     = $dbm->insert('groups', " VALUES (2, '" . addslashes(_INSTALL_REGUSERS) . "', '" . addslashes(_INSTALL_REGUSERSD) . "', 'User')");
@@ -53,7 +52,7 @@ function make_groups(&$dbm)
  *
  * @return mixed
  */
-function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $groups)
+function make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $language, $groups)
 {
     $defaultTheme = 'xswatch4';
     // $xoopsDB = Database::getInstance();
@@ -93,40 +92,40 @@ function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $
     $time = time();
     $dbm->insert('tplset', " VALUES (1, 'default', 'XOOPS Default Template Set', '', " . $time . ')');
     // system modules
-    if (file_exists('../modules/system/language/' . $language . '/modinfo.php')) {
-        include __DIR__ . '/../modules/system/language/' . $language . '/modinfo.php';
+    if (file_exists(XOOPS_ROOT_PATH . '/modules/system/language/' . $language . '/modinfo.php')) {
+        require XOOPS_ROOT_PATH . '/modules/system/language/' . $language . '/modinfo.php';
     } else {
-        include __DIR__ . '/../modules/system/language/english/modinfo.php';
+        require XOOPS_ROOT_PATH . '/modules/system/language/english/modinfo.php';
         $language = 'english';
     }
 
     $modversion = array();
-    include_once __DIR__ . '/../modules/system/xoops_version.php';
+    require_once XOOPS_ROOT_PATH . '/modules/system/xoops_version.php';
     $time = time();
     // RMV-NOTIFY (updated for extra column in table)
     $dbm->insert('modules', " VALUES (1, '" . _MI_SYSTEM_NAME . "', '" . $modversion['version'] . "', " . $time . ", 0, 1, 'system', 0, 1, 0, 0, 0, 0)");
 
     foreach ($modversion['templates'] as $tplfile) {
         // Main templates
-        if ($fp = fopen('../modules/system/templates/' . $tplfile['file'], 'r')) {
+        if ($fp = fopen(XOOPS_ROOT_PATH . '/modules/system/templates/' . $tplfile['file'], 'r')) {
             $newtplid = $dbm->insert('tplfile', " VALUES (0, 1, 'system', 'default', '" . addslashes($tplfile['file']) . "', '" . addslashes($tplfile['description']) . "', " . $time . ', ' . $time . ", 'module')");
             // $newtplid = $xoopsDB->getInsertId();
-            $tplsource = fread($fp, filesize('../modules/system/templates/' . $tplfile['file']));
+            $tplsource = fread($fp, filesize(XOOPS_ROOT_PATH . '/modules/system/templates/' . $tplfile['file']));
             fclose($fp);
             $dbm->insert('tplsource', ' (tpl_id, tpl_source) VALUES (' . $newtplid . ", '" . addslashes($tplsource) . "')");
         }
         // Admin templates
-        if ($fp = fopen('../modules/system/templates/admin/' . $tplfile['file'], 'r')) {
+        if ($fp = fopen(XOOPS_ROOT_PATH . '/modules/system/templates/admin/' . $tplfile['file'], 'r')) {
             $newtplid = $dbm->insert('tplfile', " VALUES (0, 1, 'system', 'default', '" . addslashes($tplfile['file']) . "', '" . addslashes($tplfile['description']) . "', " . $time . ', ' . $time . ", 'admin')");
             // $newtplid = $xoopsDB->getInsertId();
-            $tplsource = fread($fp, filesize('../modules/system/templates/admin/' . $tplfile['file']));
+            $tplsource = fread($fp, filesize(XOOPS_ROOT_PATH . '/modules/system/templates/admin/' . $tplfile['file']));
             fclose($fp);
             $dbm->insert('tplsource', ' (tpl_id, tpl_source) VALUES (' . $newtplid . ", '" . addslashes($tplsource) . "')");
         }
     }
 
     foreach ($modversion['blocks'] as $func_num => $newblock) {
-        if ($fp = fopen('../modules/system/templates/blocks/' . $newblock['template'], 'r')) {
+        if ($fp = fopen(XOOPS_ROOT_PATH . '/modules/system/templates/blocks/' . $newblock['template'], 'r')) {
             $visible = 0;
             if (in_array($newblock['template'], array('system_block_user.tpl', 'system_block_login.tpl', 'system_block_mainmenu.tpl'))) {
                 $visible = 1;
@@ -137,7 +136,7 @@ function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $
             // $newbid = $xoopsDB->getInsertId();
             $newtplid = $dbm->insert('tplfile', ' VALUES (0, ' . $newbid . ", 'system', 'default', '" . addslashes($newblock['template']) . "', '" . addslashes($newblock['description']) . "', " . $time . ', ' . $time . ", 'block')");
             // $newtplid = $xoopsDB->getInsertId();
-            $tplsource = fread($fp, filesize('../modules/system/templates/blocks/' . $newblock['template']));
+            $tplsource = fread($fp, filesize(XOOPS_ROOT_PATH . '/modules/system/templates/blocks/' . $newblock['template']));
             fclose($fp);
             $dbm->insert('tplsource', ' (tpl_id, tpl_source) VALUES (' . $newtplid . ", '" . addslashes($tplsource) . "')");
             $dbm->insert('group_permission', ' VALUES (0, ' . $groups['XOOPS_GROUP_ADMIN'] . ', ' . $newbid . ", 1, 'block_read')");
@@ -312,8 +311,8 @@ function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $
 
     $dbm->insert('config', " VALUES (134, 0, 1, 'redirect_message_ajax', '_MD_AM_CUSTOM_REDIRECT', '1', '_MD_AM_CUSTOM_REDIRECT_DESC', 'yesno', 'int', 12)");
 
-    require_once __DIR__ . '/../class/xoopslists.php';
-    $editors = XoopsLists::getDirListAsArray('../class/xoopseditor');
+    require_once XOOPS_ROOT_PATH . '/class/xoopslists.php';
+    $editors = XoopsLists::getDirListAsArray(XOOPS_ROOT_PATH . '/class/xoopseditor');
     $conf    = 36;
     foreach ($editors as $dir) {
         $dbm->insert('configoption', ' VALUES (' . $conf . ", '" . $dir . "', '" . $dir . "', 126)");
@@ -327,17 +326,17 @@ function make_data(&$dbm, $adminname, $hashedAdminPass, $adminmail, $language, $
         $dbm->insert('configoption', ' VALUES (' . $conf . ", '" . $dir . "', '" . $dir . "', 128)");
         ++$conf;
     }
-    $icons = XoopsLists::getDirListAsArray('../modules/system/images/icons');
+    $icons = XoopsLists::getDirListAsArray(XOOPS_ROOT_PATH . '/modules/system/images/icons');
     foreach ($icons as $dir) {
         $dbm->insert('configoption', ' VALUES (' . $conf . ", '" . $dir . "', '" . $dir . "', 98)");
         ++$conf;
     }
-    $breadcrumb = XoopsLists::getDirListAsArray('../modules/system/images/breadcrumb');
+    $breadcrumb = XoopsLists::getDirListAsArray(XOOPS_ROOT_PATH . '/modules/system/images/breadcrumb');
     foreach ($breadcrumb as $dir) {
         $dbm->insert('configoption', ' VALUES (' . $conf . ", '" . $dir . "', '" . $dir . "', 99)");
         ++$conf;
     }
-    $jqueryui = XoopsLists::getDirListAsArray('../modules/system/css/ui');
+    $jqueryui = XoopsLists::getDirListAsArray(XOOPS_ROOT_PATH . '/modules/system/css/ui');
     foreach ($jqueryui as $dir) {
         $dbm->insert('configoption', ' VALUES (' . $conf . ", '" . $dir . "', '" . $dir . "', 133)");
         ++$conf;

--- a/htdocs/install/page_configsite.php
+++ b/htdocs/install/page_configsite.php
@@ -55,7 +55,7 @@ $criteria->add($criteria2);
 $criteria->setSort('conf_catid ASC, conf_order ASC');
 $configs = $config_handler->getConfigs($criteria);
 
-include __DIR__ . '/include/createconfigform.php';
+require __DIR__ . '/include/createconfigform.php';
 $wizard->form = createConfigform($configs);
 $content      = $wizard->CreateForm();
 include __DIR__ . '/include/install_tpl.php';

--- a/htdocs/install/page_siteinit.php
+++ b/htdocs/install/page_siteinit.php
@@ -67,7 +67,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         return 302;
     }
 } else {
-    include_once __DIR__ . '/class/dbmanager.php';
+    require_once __DIR__ . '/class/dbmanager.php';
     $dbm = new Db_manager();
 
     if (!$dbm->isConnectable()) {

--- a/htdocs/install/page_tablescreate.php
+++ b/htdocs/install/page_tablescreate.php
@@ -33,8 +33,8 @@ $pageHasHelp = false;
 
 $vars =& $_SESSION['settings'];
 
-include_once __DIR__ . '/../mainfile.php';
-include_once __DIR__ . '/class/dbmanager.php';
+require_once __DIR__ . '/../mainfile.php';
+require_once __DIR__ . '/class/dbmanager.php';
 $dbm = new Db_manager();
 
 if (!$dbm->isConnectable()) {

--- a/htdocs/install/page_tablesfill.php
+++ b/htdocs/install/page_tablesfill.php
@@ -33,14 +33,25 @@ $pageHasHelp = false;
 
 $vars =& $_SESSION['settings'];
 
-include_once __DIR__ . '/../mainfile.php';
-include_once __DIR__ . '/class/dbmanager.php';
+require_once __DIR__ . '/../mainfile.php';
+require_once __DIR__ . '/class/dbmanager.php';
+if (!defined('_XOOPS_FATAL_MESSAGE')) {
+    include_once (XOOPS_ROOT_PATH . '/include/defines.php');
+}
+if (!defined('_DB_QUERY_ERROR')) {
+    if (file_exists(XOOPS_ROOT_PATH . "/language/{$language}/english/global.php")) {
+        include_once (XOOPS_ROOT_PATH . "/language/{$language}/english/global.php");
+    } else {
+        include_once (XOOPS_ROOT_PATH . '/language/english/global.php');
+    }
+}
 $dbm = new Db_manager();
 
 if (!$dbm->isConnectable()) {
     $wizard->redirectToPage('dbsettings');
     exit();
 }
+
 $sql = 'SELECT COUNT(*) FROM ' . $dbm->db->prefix('users');
 $result = $dbm->query($sql);
 if (!$dbm->db->isResultSet($result)) {
@@ -60,8 +71,8 @@ $update  = false;
 
 extract($_SESSION['siteconfig'], EXTR_SKIP);
 
-include_once __DIR__ . '/include/makedata.php';
-//$cm = 'dummy';
+require_once __DIR__ . '/include/makedata.php';
+
 $wizard->loadLangFile('install2');
 
 $licenseFile = XOOPS_VAR_PATH . '/data/license.php';

--- a/htdocs/install/page_theme.php
+++ b/htdocs/install/page_theme.php
@@ -55,7 +55,7 @@ $criteria->add(new Criteria('conf_name', 'theme_set'));
 
 $tempConfig = $config_handler->getConfigs($criteria);
 $config = array_pop($tempConfig);
-include __DIR__ . '/includecreateconfigform.php';
+include __DIR__ . '/include/createconfigform.php';
 $wizard->form = createThemeform($config);
 $content      = $wizard->CreateForm();
 

--- a/upgrade/class/control.php
+++ b/upgrade/class/control.php
@@ -69,10 +69,10 @@ class UpgradeControl
 
         $language = (null === $language) ? $this->upgradeLanguage : $language;
 
-        if (file_exists(__DIR__ . "/language/{$language}/{$domain}.php")) {
-            include_once __DIR__ . "/language/{$language}/{$domain}.php";
-        } elseif (file_exists(__DIR__ . "/language/english/{$domain}.php")) {
-            include_once __DIR__ . "/language/english/{$domain}.php";
+        if (file_exists(__DIR__ . "/../language/{$language}/{$domain}.php")) {
+            include_once __DIR__ . "/../language/{$language}/{$domain}.php";
+        } elseif (file_exists(__DIR__ . "/../language/english/{$domain}.php")) {
+            include_once __DIR__ . "/../language/english/{$domain}.php";
         }
 
 


### PR DESCRIPTION
Correct errors in the path declarations in install and update

Some of the  changes in #1344 had issues where relative paths that were specified originally (which were based on current working directory in the PHP process) were replaced with incorrect PHP `__DIR__` paths, which are relative to the current PHP file. It can be confusing ;)
