### PR TITLE
consistency in dealing with deprecated in PHP 8.2 utf8_encode() and utf8_decode()

### DIFF
--- a/htdocs/class/auth/auth_ldap.php
+++ b/htdocs/class/auth/auth_ldap.php
@@ -196,7 +196,7 @@ class XoopsAuthLdap extends XoopsAuth
      */
     public function cp1252_to_utf8($str)
     {
-        return strtr(utf8_encode($str), $this->cp1252_map);
+        return strtr(xoops_utf8_encode($str), $this->cp1252_map);
     }
 
     /**

--- a/htdocs/class/auth/auth_provisionning.php
+++ b/htdocs/class/auth/auth_provisionning.php
@@ -140,7 +140,7 @@ class XoopsAuthProvisionning
         foreach ($tab_mapping as $mapping) {
             $fields = explode('=', trim($mapping));
             if ($fields[0] && $fields[1]) {
-                $newuser->setVar(trim($fields[0]), utf8_decode($datas[trim($fields[1])][0]));
+                $newuser->setVar(trim($fields[0]), xoops_utf8_decode($datas[trim($fields[1])][0]));
             }
         }
         if ($member_handler->insertUser($newuser)) {
@@ -176,7 +176,7 @@ class XoopsAuthProvisionning
         foreach ($tab_mapping as $mapping) {
             $fields = explode('=', trim($mapping));
             if ($fields[0] && $fields[1]) {
-                $xoopsUser->setVar(trim($fields[0]), utf8_decode($datas[trim($fields[1])][0]));
+                $xoopsUser->setVar(trim($fields[0]), xoops_utf8_decode($datas[trim($fields[1])][0]));
             }
         }
         if ($member_handler->insertUser($xoopsUser)) {

--- a/htdocs/class/xoopslocal.php
+++ b/htdocs/class/xoopslocal.php
@@ -46,7 +46,7 @@ class XoopsLocalAbstract
 
         return $str;
     }
-    // Each local language should define its own equalient utf8_encode
+    // Each local language should define its own equivalent utf8_encode
     /**
      * XoopsLocalAbstract::utf8_encode()
      *
@@ -62,6 +62,24 @@ class XoopsLocalAbstract
         }
 
         return utf8_encode($text);
+    }
+
+    // Each local language should define its own equivalent utf8_encode
+    /**
+     * XoopsLocalAbstract::utf8_decode()
+     *
+     * @param  mixed $text
+     * @return string
+     */
+    public static function utf8_decode($text)
+    {
+        if (XOOPS_USE_MULTIBYTES == 1) {
+            if (function_exists('mb_convert_encoding')) {
+                return mb_convert_encoding($text, 'ISO-8859-1', 'auto');
+            }
+        }
+
+        return utf8_decode($text);
     }
 
     /**

--- a/htdocs/class/xoopslocal.php
+++ b/htdocs/class/xoopslocal.php
@@ -92,26 +92,51 @@ class XoopsLocalAbstract
      */
     public static function convert_encoding($text, $to = 'utf-8', $from = '')
     {
+        // Early exit if the text is empty
         if (empty($text)) {
             return $text;
         }
+
+        // Set default $from encoding if not provided
         if (empty($from)) {
             $from = empty($GLOBALS['xlanguage']['charset_base']) ? _CHARSET : $GLOBALS['xlanguage']['charset_base'];
         }
+
+        // If $to and $from are the same, no conversion is needed
         if (empty($to) || !strcasecmp($to, $from)) {
             return $text;
         }
 
-        if (XOOPS_USE_MULTIBYTES && function_exists('mb_convert_encoding')) {
-            $converted_text = @mb_convert_encoding($text, $to, $from);
-        } elseif (function_exists('iconv')) {
-            $converted_text = @iconv($from, $to . '//TRANSLIT', $text);
-        } elseif ('utf-8' === $to) {
-            $converted_text = utf8_encode($text);
-        }
-        $text = empty($converted_text) ? $text : $converted_text;
+        // Initialize a variable to store the converted text
+        $convertedText = '';
 
+        // Try to use mb_convert_encoding if available
+        if (XOOPS_USE_MULTIBYTES && function_exists('mb_convert_encoding')) {
+            $convertedText = mb_convert_encoding($text, $to, $from);
+            if (false !== $convertedText) {
+                return $convertedText;
+            }
+        }
+
+        // Try to use iconv if available
+        if (function_exists('iconv')) {
+            $convertedText = iconv($from, $to . '//TRANSLIT', $text);
+            if (false !== $convertedText) {
+                return $convertedText;
+            }
+        }
+
+        // Try to use utf8_encode if target encoding is 'utf-8'
+        if ('utf-8' === $to) {
+            $convertedText = utf8_encode($text);
+            if (false !== $convertedText) {
+                return $convertedText;
+            }
+        }
+
+        // If all conversions fail, return the original text
         return $text;
+        
     }
 
     /**

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -1105,6 +1105,19 @@ function xoops_utf8_encode(&$text)
 }
 
 /**
+ * xoops_utf8_decode()
+ *
+ * @param mixed $text
+ * @return string
+ */
+function xoops_utf8_decode(&$text)
+{
+    xoops_load('XoopsLocal');
+
+    return XoopsLocal::utf8_decode($text);
+}
+
+/**
  * xoops_convert_encoding()
  *
  * @param mixed $text

--- a/htdocs/modules/system/admin/tplsets/main.php
+++ b/htdocs/modules/system/admin/tplsets/main.php
@@ -373,7 +373,8 @@ switch ($op) {
             // Save modif
             if (isset($_REQUEST['templates'])) {
                 $open = fopen('' . $path_file . '', 'w+');
-                if (!fwrite($open, utf8_encode(stripslashes($_REQUEST['templates'])))) {
+                $temp = stripslashes($_REQUEST['templates']);
+                if (!fwrite($open, xoops_utf8_encode($temp))) {
                     redirect_header('admin.php?fct=tplsets', 2, _AM_SYSTEM_TEMPLATES_ERROR);
                 }
                 fclose($open);


### PR DESCRIPTION
something to consider?
In modules, I'll be changing all utf8_encode() and uf8_decode() to mb_convert_encoding()