### PR TITLE
Fixing paths in Protector

### DIFF
--- a/htdocs/xoops_lib/modules/protector/admin/about.php
+++ b/htdocs/xoops_lib/modules/protector/admin/about.php
@@ -16,8 +16,8 @@
  * @author              Mage, Mamba
  **/
 
-include __DIR__ . '/../../../include/cp_header.php';
-include __DIR__ . '/../../../class/xoopsformloader.php';
+include XOOPS_ROOT_PATH . '/include/cp_header.php';
+include XOOPS_ROOT_PATH . '/class/xoopsformloader.php';
 include __DIR__ . '/admin_header.php';
 xoops_cp_header();
 

--- a/htdocs/xoops_lib/modules/protector/admin/admin_header.php
+++ b/htdocs/xoops_lib/modules/protector/admin/admin_header.php
@@ -22,14 +22,14 @@ include_once XOOPS_ROOT_PATH . '/mainfile.php';
 include_once XOOPS_ROOT_PATH . '/include/cp_header.php';
 include_once XOOPS_ROOT_PATH . '/include/cp_functions.php';
 
-//include __DIR__ . '/../../../include/cp_header.php';
+//include XOOPS_ROOT_PATH . '/include/cp_header.php';
 //require_once XOOPS_ROOT_PATH . '/modules/' . $GLOBALS['xoopsModule']->getVar('dirname') . '/include/functions.php';
 
 if (file_exists($GLOBALS['xoops']->path('/Frameworks/moduleclasses/moduleadmin/moduleadmin.php'))) {
     include_once $GLOBALS['xoops']->path('/Frameworks/moduleclasses/moduleadmin/moduleadmin.php');
     //return true;
 } else {
-    redirect_header('../../../admin.php', 5, _AM_MODULEADMIN_MISSING, false);
+    redirect_header(XOOPS_ROOT_PATH . '/admin.php', 5, _AM_MODULEADMIN_MISSING, false);
     //return false;
 }
 

--- a/htdocs/xoops_lib/modules/protector/admin/advisory.php
+++ b/htdocs/xoops_lib/modules/protector/admin/advisory.php
@@ -1,5 +1,5 @@
 <?php
-include __DIR__ . '/../../../include/cp_header.php';
+include XOOPS_ROOT_PATH . '/include/cp_header.php';
 include __DIR__ . '/admin_header.php';
 $db = XoopsDatabaseFactory::getDatabaseConnection();
 

--- a/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
+++ b/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
@@ -1,5 +1,5 @@
 <?php
-include __DIR__ . '/../../../include/cp_header.php';
+include XOOPS_ROOT_PATH . '/include/cp_header.php';
 include __DIR__ . '/admin_header.php';
 require_once dirname(__DIR__) . '/class/gtickets.php';
 $db = XoopsDatabaseFactory::getDatabaseConnection();


### PR DESCRIPTION
There was a conflict when the ` /xoops_lib` folder was outside of the document root