### PR TITLE
Reverse adding more entropy (image_name field size in DB is too small

### DIFF
--- a/htdocs/class/captcha/image/scripts/image.php
+++ b/htdocs/class/captcha/image/scripts/image.php
@@ -69,7 +69,7 @@ class XoopsCaptchaImageHandler
             $this->config['num_chars'] = 4;
             $this->code                = mt_rand(pow(10, $this->config['num_chars'] - 1), (int)str_pad('9', $this->config['num_chars'], '9'));
         } else {
-            $raw_code = md5(uniqid(mt_rand(), 1));
+            $raw_code = md5(uniqid(mt_rand(), true));
             if (!empty($this->config['skip_characters'])) {
                 $valid_code = str_replace($this->config['skip_characters'], '', $raw_code);
                 $this->code = substr($valid_code, 0, $this->config['num_chars']);

--- a/htdocs/class/uploader.php
+++ b/htdocs/class/uploader.php
@@ -234,7 +234,7 @@ class XoopsMediaUploader
             $index           = (int)$index;
             $this->mediaName = @get_magic_quotes_gpc() ? stripslashes($_FILES[$media_name]['name'][$index]) : $_FILES[$media_name]['name'][$index];
             if ($this->randomFilename) {
-                $unique          = uniqid('', true);
+                $unique          = uniqid();
                 $this->targetFileName = '' . $unique . '--' . $this->mediaName;
             }
             $this->mediaType    = $_FILES[$media_name]['type'][$index];
@@ -249,7 +249,7 @@ class XoopsMediaUploader
             $media_name      =& $_FILES[$media_name];
             $this->mediaName = @get_magic_quotes_gpc() ? stripslashes($media_name['name']) : $media_name['name'];
             if ($this->randomFilename) {
-                $unique          = uniqid('', true);
+                $unique          = uniqid();
                 $this->targetFileName = '' . $unique . '--' . $this->mediaName;
             }
             $this->mediaType    = $media_name['type'];
@@ -465,7 +465,7 @@ class XoopsMediaUploader
         if (isset($this->targetFileName)) {
             $this->savedFileName = $this->targetFileName;
         } elseif (isset($this->prefix)) {
-            $this->savedFileName = uniqid($this->prefix, true) . '.' . strtolower($matched[1]);
+            $this->savedFileName = uniqid($this->prefix, false) . '.' . strtolower($matched[1]); //TODO: for true, need to increase size of image_name field in image table
         } else {
             $this->savedFileName = strtolower($this->mediaName);
         }


### PR DESCRIPTION
originally XOOPS created this name:
images/img64eb5c3654644.jpg
By adding "true" to uniqid(), XOOPS creates longer name, which doesn't fit into the DB, as the field size is only 30:
'images/img65596d11ac6014.17681140.jpg