### PR TITLE
load modinfo language in /system/xoops_version.php, after upgrade

### DIFF
--- a/htdocs/modules/system/xoops_version.php
+++ b/htdocs/modules/system/xoops_version.php
@@ -16,6 +16,7 @@
  * @since
  * @author       XOOPS Development Team, Kazumi Ono (AKA onokazu)
  */
+xoops_loadLanguage('modinfo', 'system');
 
 $modversion['name']        = _MI_SYSTEM_NAME;
 $modversion['version']     = '2.1.7-Stable';


### PR DESCRIPTION
I've experienced it today on two websites that I was upgrading: after the upgrade finished, and was going to update the System module, I've got fatal error that XOOPS couldn't find ```_MI_SYSTEM_NAME``` in xoops_version.php :
``` $modversion['name']        = _MI_SYSTEM_NAME;```

I don't know why, and right now don't have time to investigate. After I added the line, it worked. 