### PR TITLE
Updating versions, fix for versionCompare()

### DIFF
--- a/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
@@ -374,7 +374,7 @@ class ModuleAdmin
             // xoops version
             if ($this->_obj->getInfo('min_xoops')) {
                 $currentXoopsVersion = strtolower(str_replace('XOOPS ', '', XOOPS_VERSION));
-                if (version_compare($currentXoopsVersion, strtolower($this->_obj->getInfo('min_xoops')), '<')) {
+                if ($this->_obj->versionCompare($currentXoopsVersion, strtolower($this->_obj->getInfo('min_xoops')), '<')) {
                     $ret .= "<span style='color : red; font-weight : bold;'><img src='" . $path . "0.png' >" . sprintf(_AM_MODULEADMIN_CONFIG_XOOPS, $this->_obj->getInfo('min_xoops'), substr(XOOPS_VERSION, 6, strlen(XOOPS_VERSION) - 6)) . "</span>\n";
                 } else {
                     $ret .= "<span style='color : green;'><img src='" . $path . "1.png' >" . sprintf(_AM_MODULEADMIN_CONFIG_XOOPS, $this->_obj->getInfo('min_xoops'), substr(XOOPS_VERSION, 6)) . "</span>\n";

--- a/htdocs/include/version.php
+++ b/htdocs/include/version.php
@@ -29,4 +29,4 @@ defined('XOOPS_ROOT_PATH') || exit('Restricted access');
 /**
  *  Define XOOPS version
  */
-define('XOOPS_VERSION', 'XOOPS 2.5.11-RC3');
+define('XOOPS_VERSION', 'XOOPS 2.5.11-Stable');

--- a/htdocs/modules/pm/xoops_version.php
+++ b/htdocs/modules/pm/xoops_version.php
@@ -42,8 +42,8 @@ $modversion['icons32']        = '../../Frameworks/moduleclasses/icons/32';
 $modversion['release_date']        = '2019/02/18';
 $modversion['module_website_url']  = 'https://xoops.org/';
 $modversion['module_website_name'] = 'XOOPS';
-$modversion['min_php']             = '5.3.9';
-$modversion['min_xoops']           = '2.5.10';
+$modversion['min_php']             = '5.6.0';
+$modversion['min_xoops']           = '2.5.11';
 $modversion['min_admin']           = '1.2';
 $modversion['min_db']              = array('mysql'  => '5.0.7');
 

--- a/htdocs/modules/profile/xoops_version.php
+++ b/htdocs/modules/profile/xoops_version.php
@@ -41,7 +41,7 @@ $modversion['icons32']        = '../../Frameworks/moduleclasses/icons/32';
 $modversion['release_date']        = '2022/09/09';
 $modversion['module_website_url']  = 'https://xoops.org/';
 $modversion['module_website_name'] = 'XOOPS';
-$modversion['min_php']             = '5.3.9';
+$modversion['min_php']             = '5.6.0';
 $modversion['min_xoops']           = '2.5.11';
 $modversion['min_admin']           = '1.2';
 $modversion['min_db']              = array('mysql'  => '5.0.7');

--- a/htdocs/xoops_lib/modules/protector/xoops_version.php
+++ b/htdocs/xoops_lib/modules/protector/xoops_version.php
@@ -41,8 +41,8 @@ $modversion['icons32']        = 'Frameworks/moduleclasses/icons/32';
 $modversion['release_date']        = '2019/02/18';
 $modversion['module_website_url']  = 'https://xoops.org/';
 $modversion['module_website_name'] = 'XOOPS';
-$modversion['min_php']             = '5.3.9';
-$modversion['min_xoops']           = '2.5.10';
+$modversion['min_php']             = '5.6.0';
+$modversion['min_xoops']           = '2.5.11';
 
 // Any tables can't be touched by modulesadmin.
 $modversion['sqlfile'] = false;


### PR DESCRIPTION
@GregMage When I compared 'min_xoops" from a module as "2.5.11" to the XOOPS version as "2.5.11-Stable", the PHP version_compare() didn't work, telling me that I don't have the required minimum PHP version. 

Once I've changed it to  ```$this->_obj->versionCompare()```, it worked.

Can you check if this is correct? 