### PR TITLE
Fix for https://github.com/XOOPS/XoopsCore25/issues/1458

### DIFF
--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -367,9 +367,9 @@ class MyTextSanitizer
         $replacements[] = '<a href="\\2" rel="external" title="">\\3</a>';
         $patterns[]     = "/\[url=(['\"]?)([^'\"<>]*)\\1](.*)\[\/url\]/sU";
         $replacements[] = '<a href="http://\\2" rel="noopener external" title="">\\3</a>';
-        $patterns[]     = "/\[color=(['\"]?)([a-zA-Z0-9#]*)\\1](.*)\[\/color\]/sU";
-        $replacements[] = '<span style="color: \\2;">\\3</span>';
-        $patterns[]     = "/\[size=(['\"]?)([a-zA-Z0-9.#]*)\\1](.*)\[\/size\]/sU";
+        $patterns[]     = "/\[color=(['\"]?)([a-zA-Z0-9#]+)\\1?](.*)\[\/color\]/sU";
+        $replacements[] = '<span style="color: #\\2;">\\3</span>';
+        $patterns[]     = "/\[size=(['\"]?)([a-zA-Z0-9-]+)\\1?](.*)\[\/size\]/sU";
         $replacements[] = '<span style="font-size: \\2;">\\3</span>';
         $patterns[]     = "/\[font=(['\"]?)([^;<>\*\(\)\"']*)\\1](.*)\[\/font\]/sU";
         $replacements[] = '<span style="font-family: \\2;">\\3</span>';


### PR DESCRIPTION
**Color pattern:**
        **_Problem:_** The pattern ```/\[color=(['\"]?)([a-zA-Z0-9#]*)\\1](.*)\[\/color\]/sU``` is expecting the color value to be enclosed in either single quotes or double quotes, but the example ```[color=009900]``` doesn't have any quotes.
        **_Solution:_** We remove the quote capturing group and make it optional:  ```/\[color=(['\"]?)([a-zA-Z0-9#]+)\\1?](.*)\[\/color\]/sU```

**Size pattern:**
        **_Problem:_** The pattern ```/\[size=(['\"]?)([a-zA-Z0-9.#]*)\\1](.*)\[\/size\]/sU``` is allowing dot (```.```) and hash (```#```) characters in the size value, which are not valid for font sizes.
        **_Solution:_** We remove the dot  (```.```) and hash (```#```) characters from the size value capturing group: ```/\[size=(['\"]?)([a-zA-Z0-9-]+)\\1?](.*)\[\/size\]/sU```

The updated patterns make the quotes optional by using ```\\1?``` instead of ```\\1```. 
This allows the color and size values to be specified with or without quotes.