### PR TITLE
New path for composer files in install file

### DIFF
--- a/htdocs/install/include/common.inc.php
+++ b/htdocs/install/include/common.inc.php
@@ -86,7 +86,7 @@ include_once __DIR__ . '/../../include/version.php';
 require_once __DIR__ . '/../../include/xoopssetcookie.php';
 include_once __DIR__ . '/../include/functions.php';
 include_once __DIR__ . '/../../class/module.textsanitizer.php';
-include_once __DIR__ . '/../../class/libraries/vendor/autoload.php';
+include_once __DIR__ . '/../../xoops_lib/vendor/autoload.php';
 
 $pageHasHelp = false;
 $pageHasForm = false;


### PR DESCRIPTION
During installation, I got this error htdocs/install/include/../../class/libraries/vendor/autoload.php): Failed to open stream: No such file or directory in htdocs/install/include/common.inc.php on line 89
The installation stopped at /install/page_pathsettings.php
I set the new path for vendor/autoload.php in common.inc.php and I was able to install Xoops without errors