### PR TITLE
Fix tag.tpl always loading in modules/news

### DIFF
--- a/htdocs/themes/xbootstrap5/modules/news/news_article.tpl
+++ b/htdocs/themes/xbootstrap5/modules/news/news_article.tpl
@@ -50,7 +50,7 @@
     <{/if}>
 </div>
 
-<{if isset($tags)}>
+<{if isset($tags) and $tag == true}>
     <{include file="db:tag_bar.tpl"}>
 <{/if}>
 


### PR DESCRIPTION
In article.php, tags smarty var is always set (with true or false)
But news_article.tpl only check if var isset, so it always try to load the db:tag_bar.tpl