### PR TITLE
Fix problem with admin save preference

### DIFF
--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -69,7 +69,8 @@ class XoopsSecurity
             'expire' => time() + (int) $timeout,
         ];
         $_SESSION[$name . '_SESSION'][] = $token_data;
-
+        // Force update of session in base
+        session_write_close();
         return md5($token_id . $_SERVER['HTTP_USER_AGENT'] . XOOPS_DB_PREFIX);
     }
 

--- a/htdocs/modules/system/themes/ComposerInfo.php
+++ b/htdocs/modules/system/themes/ComposerInfo.php
@@ -1,6 +1,6 @@
 <?php
 
-header('HTTP/1.0 404 Not Found');
+//header('HTTP/1.0 404 Not Found');
 
 class ComposerInfo
 {

--- a/htdocs/modules/system/themes/ComposerInfo.php
+++ b/htdocs/modules/system/themes/ComposerInfo.php
@@ -1,6 +1,10 @@
 <?php
 
-//header('HTTP/1.0 404 Not Found');
+// Prevent direct access
+if (basename($_SERVER['SCRIPT_FILENAME']) === 'ComposerInfo.php') {
+    header("HTTP/1.0 403 Forbidden");
+    exit('Access Denied');
+}
 
 class ComposerInfo
 {


### PR DESCRIPTION
Context :  My admin preferences (modules & main) was not always saved.

**htdocs/modules/system/themes/ComposerInfo.php**

I checked and found an error 404 in the browser network tab. It was from the file : htdocs/modules/system/themes/ComposerInfo.php  . I comment the line but it didn't resolve the problem. But I think it's better commented.

**htdocs/class/xoopssecurity.php**

I found that an invalid token was aborting the save with a redirection.
The token was not saved in the session (xoops_session table) but was set correctly in $_SESSION 
So I forced the updating of the session in database with add **`session_write_close();`**

**htdocs/kernel/session.php**

I had an SQL duplicate index error with an INSERT comment in xoops_session
The fault was this test ` if (!$this->db->getAffectedRows())` after and UPDATE  in the **`public function write($sessionId, $data)`**

If a row exist and is not updated (all same values), `getAffectedRows` return 0 and  the code will try to INSERT, which cause an error (duplicate index)