### PR TITLE
http is default

### DIFF
--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -30,7 +30,7 @@ if (!defined('XOOPS_MAINFILE_INCLUDED')) {
     define('XOOPS_TRUST_PATH', XOOPS_PATH);
 
     // URL Association for SSL and Protocol Compatibility
-    $http = 'https://';
+    $http = 'http://';
     if (!empty($_SERVER['HTTPS'])) {
         $http = ($_SERVER['HTTPS'] === 'on') ? 'https://' : 'http://';
     }


### PR DESCRIPTION
$_SERVER['HTTPS'] is set only when HTTPS protocol (as described on php.net) 
So `$http` was never set to `$http='http://'`
Cookie session was created with secure=true even with `http` connection and it was not working with Safari browser.