### PR TITLE
fix for new bug from PR#1511

### DIFF
--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -70,7 +70,7 @@ class XoopsSecurity
         ];
         $_SESSION[$name . '_SESSION'][] = $token_data;
         // Force update of session in base
-        session_write_close();
+//        session_write_close();
         return md5($token_id . $_SERVER['HTTP_USER_AGENT'] . XOOPS_DB_PREFIX);
     }
 
@@ -85,6 +85,11 @@ class XoopsSecurity
      */
     public function validateToken($token = false, $clearIfValid = true, $name = 'XOOPS_TOKEN')
     {
+        // Optional: Ensure a session is active, keep this as a safeguard, but it’s likely unnecessary
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
         global $xoopsLogger;
         $token = ($token !== false) ? $token : ($_REQUEST[$name . '_REQUEST'] ?? '');
         if (empty($token) || empty($_SESSION[$name . '_SESSION'])) {


### PR DESCRIPTION
[PR#1511](https://github.com/XOOPS/XoopsCore25/pull/1511) introduced a new bug: 

when calling: `$GLOBALS['xoopsSecurity']->check()`, it was returning error:  'No valid token found' because by calling session_write_close() in createToken(), the session is closed prematurely. When the script continues execution (e.g., during token validation), the session is no longer active, and attempts to access or modify $_SESSION fail or start a new session, resulting in the token not being found.

Commenting out session_write_close() keeps the session open, so $_SESSION remains accessible, and validateToken() should find the token without needing to restart the session. 
As a safeguard, I've added in `validateToken()`:
```php
if (session_status() !== PHP_SESSION_ACTIVE) {
    session_start();
}
```