### PR TITLE
New feature: menu icons for modules

### DIFF
--- a/htdocs/kernel/module.php
+++ b/htdocs/kernel/module.php
@@ -233,6 +233,9 @@ class XoopsModule extends XoopsObject
                 $ret[] = [
                     'name' => $submenu['name'],
                     'url'  => $submenu['url'],
+
+                    'icon' => $submenu['icon']?? '',
+
                 ];
             }
         }
@@ -490,6 +493,18 @@ class XoopsModule extends XoopsObject
 
         return $inst;
     }
+
+
+    /**
+     * Returns Class Base Variable icon
+     * @param  string $format
+     * @return mixed
+     */
+    public function icon($format = '')
+    {
+        return $this->getVar('icon', $format);
+    }
+
 
     ##################### Deprecated Methods ######################
 

--- a/htdocs/modules/pm/xoops_version.php
+++ b/htdocs/modules/pm/xoops_version.php
@@ -37,7 +37,7 @@ $modversion['dirname']        = 'pm';
 $modversion['dirmoduleadmin'] = '/Frameworks/moduleclasses/moduleadmin';
 $modversion['icons16']        = '../../Frameworks/moduleclasses/icons/16';
 $modversion['icons32']        = '../../Frameworks/moduleclasses/icons/32';
-
+$modversion['icon']           = 'fa-solid fa-message';
 //about
 $modversion['release_date']        = '2019/02/18';
 $modversion['module_website_url']  = 'https://xoops.org/';

--- a/htdocs/modules/profile/xoops_version.php
+++ b/htdocs/modules/profile/xoops_version.php
@@ -37,6 +37,9 @@ $modversion['dirmoduleadmin'] = '/Frameworks/moduleclasses/moduleadmin';
 $modversion['icons16']        = '../../Frameworks/moduleclasses/icons/16';
 $modversion['icons32']        = '../../Frameworks/moduleclasses/icons/32';
 
+$modversion['icon']           = 'fa-solid fa-user';
+
+
 //about
 $modversion['release_date']        = '2022/09/09';
 $modversion['module_website_url']  = 'https://xoops.org/';
@@ -68,6 +71,10 @@ if ($GLOBALS['xoopsUser']) {
     $modversion['sub'][2]['url']  = 'search.php';
     $modversion['sub'][3]['name'] = _PROFILE_MI_CHANGEPASS;
     $modversion['sub'][3]['url']  = 'changepass.php';
+
+    $modversion['sub'][1]['icon'] = 'fa-solid fa-wrench';
+    $modversion['sub'][2]['icon'] = 'fa-solid fa-magnifying-glass';
+    $modversion['sub'][3]['icon'] = 'fa-solid fa-key';
 }
 
 // Mysql file

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -130,6 +130,10 @@ function b_system_main_show()
         if (in_array($i, $read_allowed)) {
             $block['modules'][$i]['name']      = $modules[$i]->getVar('name');
             $block['modules'][$i]['directory'] = $modules[$i]->getVar('dirname');
+
+            $icon = $module_handler->getByDirname($modules[$i]->getVar('dirname'))->getInfo('icon');
+            $block['modules'][$i]['icon'] = $icon ? $icon : 'fa-solid fa-caret-right';
+
             $sublinks                          = $modules[$i]->subLink();
             if ((!empty($xoopsModule)) && ($i == $xoopsModule->getVar('mid'))) {
                 $block['modules'][$i]['highlight'] = true;
@@ -144,6 +148,8 @@ function b_system_main_show()
                     $block['modules'][$i]['sublinks'][] = [
                         'name' => $sublink['name'],
                         'url'  => XOOPS_URL . '/modules/' . $modules[$i]->getVar('dirname') . '/' . $sublink['url'],
+
+                        'icon' => $sublink['icon'] !== '' ? $sublink['icon'] : 'fa-solid fa-caret-right'
                     ];
                 }
             } else {

--- a/htdocs/themes/xbootstrap5/css/reset.css
+++ b/htdocs/themes/xbootstrap5/css/reset.css
@@ -5,3 +5,9 @@ a, a:hover, a:focus, a:link, a:visited{text-decoration:none;}
 .label-default a, .label-primary a, .label-success a, .label-info a, .label-warning a, .label-danger a{color: #ffffff;}
 .btn-primary a{color: inherit;
 }
+
+.no-bullets {
+    list-style-type: none !important; /* Ensures no markers are displayed */
+    padding-left: 40px; /* Removes default padding */
+    margin-left: 0; /* Removes default margin */
+}

--- a/htdocs/themes/xbootstrap5/modules/system/blocks/system_block_mainmenu.tpl
+++ b/htdocs/themes/xbootstrap5/modules/system/blocks/system_block_mainmenu.tpl
@@ -1,16 +1,16 @@
 <ul class="nav flex-column">
-    <li class="<{if !$block.nothome|default:''}>active<{/if}>"><a href="<{xoAppUrl ' '}>" title="<{$block.lang_home}>"><span
-                    class="fa-solid fa-home"></span> <{$block.lang_home}></a></li>
+    <li class="<{if !$block.nothome|default:''}>active<{/if}>"><a href="<{xoAppUrl ' '}>" title="<{$block.lang_home}>">
+            <span class="fa-solid fa-home"></span> <{$block.lang_home}></a></li>
     <!-- start module menu loop -->
     <{foreach item=module from=$block.modules|default:null}>
         <li class="nav-item<{if $module.highlight|default:false}> active<{/if}>">
-            <a class="nav-link" href="<{$xoops_url}>/modules/<{$module.directory}>/" title="<{$module.name}>"><span class="fa-solid fa-check"></span>
+            <a class="nav-link" href="<{$xoops_url}>/modules/<{$module.directory}>/" title="<{$module.name}>"><span class="<{$module.icon}>"></span>
                 <{$module.name}>
             </a>
-            <ul>
+            <ul class="no-bullets">
                 <{foreach item=sublink from=$module.sublinks|default:null}>
                     <li>
-                        <a class="dropdown" href="<{$sublink.url}>" title="<{$sublink.name}>"><{$sublink.name}></a>
+                        <a class="dropdown" href="<{$sublink.url}>" title="<{$sublink.name}>"><span class="<{$sublink.icon}>"></span> <{$sublink.name}></a>
                     </li>
                 <{/foreach}>
             </ul>

--- a/htdocs/themes/xbootstrap5/style.css
+++ b/htdocs/themes/xbootstrap5/style.css
@@ -881,3 +881,21 @@ body {
     width: 100%;
     overflow-x: hidden;
 }
+
+
+.nav-item ul {
+    background-color: transparent; /* Ensure submenus have no background color */
+}
+
+/* Highlight the active main menu item */
+.nav-item.active > a.nav-link {
+    font-weight: bold;
+    background-color: #f0f0f0; /* Set the desired background color */
+    color: #000; /* Optional: Adjust text color for better contrast */
+}
+
+/* Highlight the active submenu item */
+.no-bullets li a.dropdown.active {
+    background-color: #e0e0e0; /* Set the desired background color for submenus */
+    color: #000; /* Optional: Adjust text color for better contrast */
+}


### PR DESCRIPTION
By adding Font Awesome icons to module and submenu items in xoops_version.php:

![image](https://github.com/user-attachments/assets/40aa9fbf-5a84-4693-b01b-3a43412e3a17)

you can have now in xbootstrap5 theme individual icons for the menu items:
![image](https://github.com/user-attachments/assets/cfad7a86-75ff-4318-a839-ea1abd819ae5)


What do you think? 