### PR TITLE
Fix: https://github.com/XOOPS/XoopsCore25/issues/1564

### DIFF
--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -846,8 +846,11 @@ class MyTextSanitizer
      */
     public function addSlashes($text)
     {
-        $GLOBALS['xoopsLogger']->addDeprecated(__METHOD__ . ' is deprecated');
-        return $text;
+        global $xoopsDB;
+        $GLOBALS['xoopsLogger']->addDeprecated(
+            __METHOD__ . ' is deprecated. Use $xoopsDB->escape() or $xoopsDB->quoteString().'
+        );
+        return $xoopsDB->escape($text);
     }
 
     /**


### PR DESCRIPTION
This change ensures backward compatibility while signaling to developers that they should migrate to safer, modern methods for SQL escaping.