### PR TITLE
Fix Deprecated addSlashes

### DIFF
--- a/htdocs/class/xoopsstory.php
+++ b/htdocs/class/xoopsstory.php
@@ -218,14 +218,15 @@ class XoopsStory
      */
     public function store($approved = false)
     {
+        global $xoopsDB;
         //$newpost = 0;
         $myts     = \MyTextSanitizer::getInstance();
         $title    = $myts->censorString($this->title);
         $hometext = $myts->censorString($this->hometext);
         $bodytext = $myts->censorString($this->bodytext);
-        $title    = $myts->addSlashes($title);
-        $hometext = $myts->addSlashes($hometext);
-        $bodytext = $myts->addSlashes($bodytext);
+        $title    = $xoopsDB->escape($title);
+        $hometext = $xoopsDB->escape($hometext);
+        $bodytext = $xoopsDB->escape($bodytext);
         if (!isset($this->nohtml) || $this->nohtml != 1) {
             $this->nohtml = 0;
         }

--- a/htdocs/class/xoopstopic.php
+++ b/htdocs/class/xoopstopic.php
@@ -124,14 +124,14 @@ class XoopsTopic
      */
     public function store()
     {
-        $myts   = \MyTextSanitizer::getInstance();
+        global $xoopsDB;
         $title  = '';
         $imgurl = '';
         if (isset($this->topic_title) && $this->topic_title != '') {
-            $title = $myts->addSlashes($this->topic_title);
+            $title = $xoopsDB->escape($this->topic_title);
         }
         if (isset($this->topic_imgurl) && $this->topic_imgurl != '') {
-            $imgurl = $myts->addSlashes($this->topic_imgurl);
+            $imgurl = $xoopsDB->escape($this->topic_imgurl);
         }
         if (!isset($this->topic_pid) || !is_numeric($this->topic_pid)) {
             $this->topic_pid = 0;

--- a/htdocs/edituser.php
+++ b/htdocs/edituser.php
@@ -340,7 +340,7 @@ if ($op === 'avatarchoose') {
     /** @var \XoopsAvatarHandler $avt_handler */
     $avt_handler = xoops_getHandler('avatar');
     if (!empty($_POST['user_avatar'])) {
-        $user_avatar     = $myts->addSlashes(trim($_POST['user_avatar']));
+        $user_avatar     = $xoopsDB->escape(trim($_POST['user_avatar']));
         $criteria_avatar = new CriteriaCompo(new Criteria('avatar_file', $user_avatar));
         $criteria_avatar->add(new Criteria('avatar_type', 'S'));
         $avatars = $avt_handler->getObjects($criteria_avatar);

--- a/htdocs/lostpass.php
+++ b/htdocs/lostpass.php
@@ -34,7 +34,7 @@ if ($email == '') {
 $myts           = \MyTextSanitizer::getInstance();
 /** @var XoopsMemberHandler $member_handler */
 $member_handler = xoops_getHandler('member');
-$getuser        = $member_handler->getUsers(new Criteria('email', $myts->addSlashes($email)));
+$getuser        = $member_handler->getUsers(new Criteria('email', $xoopsDB->escape($email)));
 
 if (empty($getuser)) {
     $msg = _US_SORRYNOTFOUND;

--- a/htdocs/modules/profile/activate.php
+++ b/htdocs/modules/profile/activate.php
@@ -79,7 +79,7 @@ if (!empty($_GET['id']) && !empty($_GET['actkey'])) {
     $myts           = \MyTextSanitizer::getInstance();
     /** @var XoopsMemberHandler $member_handler */
     $member_handler = xoops_getHandler('member');
-    $getuser        = $member_handler->getUsers(new Criteria('email', $myts->addSlashes(trim($_REQUEST['email']))));
+    $getuser        = $member_handler->getUsers(new Criteria('email', $xoopsDB->escape(trim($_REQUEST['email']))));
     if (count($getuser) == 0) {
         redirect_header(XOOPS_URL, 2, _US_SORRYNOTFOUND);
     }

--- a/htdocs/modules/profile/edituser.php
+++ b/htdocs/modules/profile/edituser.php
@@ -218,7 +218,7 @@ if ($op === 'avatarchoose') {
     $user_avatar = '';
     $avt_handler = xoops_getHandler('avatar');
     if (!empty($_POST['user_avatar'])) {
-        $user_avatar     = $myts->addSlashes(trim($_POST['user_avatar']));
+        $user_avatar     = $xoopsDB->escape(trim($_POST['user_avatar']));
         $criteria_avatar = new CriteriaCompo(new Criteria('avatar_file', $user_avatar));
         $criteria_avatar->add(new Criteria('avatar_type', 'S'));
         $avatars = $avt_handler->getObjects($criteria_avatar);

--- a/htdocs/modules/profile/lostpass.php
+++ b/htdocs/modules/profile/lostpass.php
@@ -29,10 +29,9 @@ if ($email == '') {
     redirect_header('user.php', 2, _US_SORRYNOTFOUND, false);
 }
 
-$myts           = \MyTextSanitizer::getInstance();
 /** @var XoopsMemberHandler $member_handler */
 $member_handler = xoops_getHandler('member');
-[$user] = $member_handler->getUsers(new Criteria('email', $myts->addSlashes($email)));
+[$user] = $member_handler->getUsers(new Criteria('email', $xoopsDB->escape($email)));
 
 if (empty($user)) {
     $msg = _US_SORRYNOTFOUND;

--- a/htdocs/modules/profile/search.php
+++ b/htdocs/modules/profile/search.php
@@ -18,7 +18,6 @@
  */
 
 include __DIR__ . '/header.php';
-$myts = \MyTextSanitizer::getInstance();
 
 $limit_default    = 20;
 $op               = $_REQUEST['op'] ?? 'search';
@@ -235,7 +234,7 @@ switch ($op) {
         }
 
         if (isset($_REQUEST['email']) && $_REQUEST['email'] !== '') {
-            $string = $myts->addSlashes(trim($_REQUEST['email']));
+            $string = $xoopsDB->escape(trim($_REQUEST['email']));
             switch ($_REQUEST['email_match']) {
                 case XOOPS_MATCH_START:
                     $string .= '%';
@@ -355,7 +354,7 @@ switch ($op) {
                     case XOBJ_DTYPE_TXTBOX:
                     case XOBJ_DTYPE_TXTAREA:
                         if (isset($_REQUEST[$fieldname]) && $_REQUEST[$fieldname] !== '') {
-                            $value = $myts->addSlashes(trim($_REQUEST[$fieldname]));
+                            $value = $xoopsDB->escape(trim($_REQUEST[$fieldname]));
                             switch ($_REQUEST[$fieldname . '_match']) {
                                 case XOOPS_MATCH_START:
                                     $value .= '%';

--- a/htdocs/modules/system/admin/users/main.php
+++ b/htdocs/modules/system/admin/users/main.php
@@ -160,7 +160,7 @@ switch ($op) {
                 xoops_cp_header();
                 xoops_error(sprintf(_AM_SYSTEM_USERS_PSEUDO_ERROR, htmlspecialchars(Request::getString('uname'), ENT_QUOTES | ENT_HTML5)));
                 xoops_cp_footer();
-            } elseif ($edituser->getVar('email', 'n') != Request::getEmail('email') && $member_handler->getUserCount(new Criteria('email', $myts->addSlashes(Request::getEmail('email')))) > 0) {
+            } elseif ($edituser->getVar('email', 'n') != Request::getEmail('email') && $member_handler->getUserCount(new Criteria('email', $xoopsDB->escape(Request::getEmail('email')))) > 0) {
                 xoops_cp_header();
                 xoops_error(sprintf(_AM_SYSTEM_USERS_MAIL_ERROR, htmlspecialchars(Request::getEmail('email'), ENT_QUOTES | ENT_HTML5)));
                 xoops_cp_footer();

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -111,9 +111,9 @@ if ($action !== 'showallbyuser') {
         foreach ($temp_queries as $q) {
             $q = trim($q);
             if (strlen($q) >= $xoopsConfigSearch['keyword_min']) {
-                $queries[] = $myts->addSlashes($q);
+                $queries[] = $xoopsDB->escape($q);
             } else {
-                $ignored_queries[] = $myts->addSlashes($q);
+                $ignored_queries[] = $xoopsDB->escape($q);
             }
         }
         if (count($queries) == 0) {
@@ -124,7 +124,7 @@ if ($action !== 'showallbyuser') {
         if (strlen($query) < $xoopsConfigSearch['keyword_min']) {
             redirect_header('search.php', 2, sprintf(_SR_KEYTOOSHORT, $xoopsConfigSearch['keyword_min']));
         }
-        $queries = [$myts->addSlashes($query)];
+        $queries = [$xoopsDB->escape($query)];
     }
 }
 switch ($action) {


### PR DESCRIPTION
Related to this point:
https://github.com/XOOPS/XoopsCore25/issues/1564

Xoops should not use the deprecated ‘addSlashes’ function in its core.

This PR fixes this error.