### PR TITLE
Fix #1215: Replace removed money_format() with NumberFormatter

### DIFF
--- a/htdocs/language/english/locale.php
+++ b/htdocs/language/english/locale.php
@@ -63,14 +63,25 @@ class XoopsLocal extends XoopsLocalAbstract
     /**
      * Money Format
      *
-     * @param  string    $format  sprintf-style format (ignored, kept for BC)
+     * @param  string    $format  legacy money_format()-style format string (ignored, kept for BC)
      * @param  int|float $number
      * @return string
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function money_format($format, $number)
     {
-        $fmt = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
+        if (!extension_loaded('intl')) {
+            return '$' . number_format((float)$number, 2, '.', ',');
+        }
 
-        return $fmt->formatCurrency((float)$number, 'USD');
+        static $fmt = null;
+        if (null === $fmt) {
+            $fmt = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
+        }
+
+        $result = $fmt->formatCurrency((float)$number, 'USD');
+
+        return $result !== false ? $result : '$' . number_format((float)$number, 2, '.', ',');
     }
 }


### PR DESCRIPTION
## Summary
- Replaces the deprecated/removed `money_format()` PHP function (removed in PHP 8.0) with `NumberFormatter::formatCurrency()` from the `intl` extension in the English locale class
- The `$format` parameter is retained for backward compatibility but is no longer used, as `NumberFormatter` handles locale-specific formatting internally
- `setlocale(LC_MONETARY)` call removed as it is not needed by `NumberFormatter`

## Test plan
- [ ] Verify currency formatting still works in any XOOPS page that calls `XoopsLocal::money_format()`
- [ ] Confirm no PHP deprecation/error on PHP 8.0+

Fixes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved currency formatting to use a more reliable, modern approach with graceful fallback when advanced locale support isn't available. Preserves the existing public API and behavior, ensures consistent USD formatting, and reduces errors in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->