### PR TITLE
Feature #529: Add $secure parameter to formatURL()

### DIFF
--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -674,15 +674,16 @@ function checkEmail($email, $antispam = false)
 /**
  * formatURL()
  *
- * @param mixed $url
- * @return mixed|string
+ * @param string $url    URL to format
+ * @param bool   $secure When true, use https:// instead of http:// as the default scheme
+ * @return string
  */
-function formatURL($url)
+function formatURL($url, $secure = false)
 {
     $url = trim($url);
     if ($url != '') {
         if ((!preg_match('/^http[s]*:\/\//i', $url)) && (!preg_match('/^ftp*:\/\//i', $url)) && (!preg_match('/^ed2k*:\/\//i', $url))) {
-            $url = 'http://' . $url;
+            $url = ($secure ? 'https://' : 'http://') . $url;
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds an optional `bool $secure = false` parameter to `formatURL()`
- When `$secure` is `true`, scheme-less URLs are prefixed with `https://` instead of `http://`
- All existing call sites are unaffected (parameter defaults to `false`)

## Test plan
- [ ] `formatURL('example.com')` → `'http://example.com'` (unchanged behaviour)
- [ ] `formatURL('example.com', true)` → `'https://example.com'`
- [ ] `formatURL('https://example.com', true)` → `'https://example.com'` (already has scheme, unchanged)
- [ ] `formatURL('http://example.com', true)` → `'http://example.com'` (already has scheme, unchanged)

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HTTPS protocol in URL formatting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->