### PR TITLE
Fix #1134: Increase image_name field from varchar(30) to varchar(191)

### DIFF
--- a/htdocs/class/uploader.php
+++ b/htdocs/class/uploader.php
@@ -476,7 +476,7 @@ class XoopsMediaUploader
         if (isset($this->targetFileName)) {
             $this->savedFileName = $this->targetFileName;
         } elseif (isset($this->prefix)) {
-            $this->savedFileName = uniqid($this->prefix, false) . '.' . strtolower($matched[1]); //TODO: for true, need to increase size of image_name field in image table
+            $this->savedFileName = uniqid($this->prefix, true) . '.' . strtolower($matched[1]);
         } else {
             $this->savedFileName = strtolower($this->mediaName);
         }

--- a/htdocs/install/sql/mysql.structure.sql
+++ b/htdocs/install/sql/mysql.structure.sql
@@ -252,7 +252,7 @@ CREATE TABLE groups_users_link (
 
 CREATE TABLE image (
   image_id mediumint(8) unsigned NOT NULL auto_increment,
-  image_name varchar(30) NOT NULL default '',
+  image_name varchar(191) NOT NULL default '',
   image_nicename varchar(255) NOT NULL default '',
   image_mimetype varchar(30) NOT NULL default '',
   image_created int(10) unsigned NOT NULL default '0',

--- a/htdocs/kernel/image.php
+++ b/htdocs/kernel/image.php
@@ -46,7 +46,7 @@ class XoopsImage extends XoopsObject
     {
         parent::__construct();
         $this->initVar('image_id', XOBJ_DTYPE_INT, null, false);
-        $this->initVar('image_name', XOBJ_DTYPE_OTHER, null, false, 30);
+        $this->initVar('image_name', XOBJ_DTYPE_OTHER, null, false, 191);
         $this->initVar('image_nicename', XOBJ_DTYPE_TXTBOX, null, true, 100);
         $this->initVar('image_mimetype', XOBJ_DTYPE_OTHER, null, false);
         $this->initVar('image_created', XOBJ_DTYPE_INT, null, false);


### PR DESCRIPTION
## Summary
- **`install/sql/mysql.structure.sql`**: `image_name varchar(30)` → `varchar(191)` (191 is the max safe length for a utf8mb4 column used in a MySQL index)
- **`kernel/image.php`**: `initVar` max length `30` → `191`  
- **`class/uploader.php`**: Enable `uniqid($prefix, true)` (more entropy) — this was intentionally blocked by a `//TODO` comment since 2021 pending this field size increase

> **Note for existing installations:** Run the following migration:
> ```sql
> ALTER TABLE {prefix}_image MODIFY image_name varchar(191) NOT NULL DEFAULT '';
> ```

## Test plan
- [ ] Fresh install: upload an image with a long filename → saves correctly
- [ ] Verify `uniqid($prefix, true)` generates filenames that fit within 191 chars

Fixes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)