### PR TITLE
Fix Scrutinizer issues in XoopsCache

### DIFF
--- a/htdocs/class/cache/xoopscache.php
+++ b/htdocs/class/cache/xoopscache.php
@@ -296,9 +296,9 @@ class XoopsCache
      * @return bool True on success, false on failure
      * @access public
      */
-    public function engine(string $name = 'file', array $settings = []): bool
+    public function engine(?string $name = 'file', array $settings = []): bool
     {
-        if ($name === '') {
+        if ($name === null || $name === '') {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- **Fix init() on null**: Add explicit null guards in `prepareEngine()` and `config()` before calling `init()` on engine instances, resolving the static analysis "method on null" error
- **Remove redundant type checks**: Add `string` and `array` type hints to `engine()` and `config()` parameters, eliminating always-true `is_string($name)` and `is_array($settings)` checks
- **Remove premature @deprecated tag**: The `XoopsCacheEngineInterface` is actively used throughout the codebase; the `@deprecated` annotation triggered false positives in Scrutinizer

Resolves all 5 Scrutinizer issues reported on `htdocs/class/cache/xoopscache.php`.

## Test plan
- [x] Verify cache read/write operations still work correctly
- [x] Verify Scrutinizer no longer reports these 5 issues
- [x] Run existing `XoopsCacheEngineTest` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)