### PR TITLE
Fix unserialize() extra data warning in Protector

### DIFF
--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -427,7 +427,7 @@ class Protector
         if (is_array($filepath4badips) && isset($filepath4badips[0])) {
             [$bad_ips_serialized] = $filepath4badips;
         }
-        $bad_ips = empty($bad_ips_serialized) ? [] : @unserialize($bad_ips_serialized, ['allowed_classes' => false]);
+        $bad_ips = empty($bad_ips_serialized) ? [] : @unserialize(trim($bad_ips_serialized), ['allowed_classes' => false]);
         if (!is_array($bad_ips) || isset($bad_ips[0])) {
             $bad_ips = [];
         }
@@ -478,7 +478,7 @@ class Protector
                     [$group1_ips_serialized] = $filepath4group1ips;
                 }
 
-                $group1_ips = empty($group1_ips_serialized) ? [] : @unserialize($group1_ips_serialized, ['allowed_classes' => false]);
+                $group1_ips = empty($group1_ips_serialized) ? [] : @unserialize(trim($group1_ips_serialized), ['allowed_classes' => false]);
                 if (!is_array($group1_ips)) {
                     $group1_ips = [];
                 }


### PR DESCRIPTION
file() returns lines with trailing newlines, so serialized data like "a:0:{}\n" triggers "Extra data starting at offset 6 of 7 bytes" on PHP 8.x. Add trim() before unserialize() in get_bad_ips() and get_group1_ips() to strip the trailing newline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where IP list processing could fail due to leading or trailing whitespace in configuration data. This improvement ensures proper parsing and handling of IP blocking rules and IP group configurations, improving overall reliability of IP-based access controls and preventing potential data processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->