### PR TITLE
Fix undefined $module in install_ok case

### DIFF
--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -353,7 +353,7 @@ switch ($op) {
         $module     = trim(Request::getString('module', '', 'POST'));
         $moduleDirs = XoopsLists::getModulesList();
         if (!in_array($module, $moduleDirs, true)) {
-            redirect_header('admin.php?fct=modulesadmin', 3, 'Invalid module install request.');
+            redirect_header('admin.php?fct=modulesadmin', 3, sprintf(_AM_SYSTEM_MODULES_FAILINS, $module));
         }
         $ret   = [];
         $ret[] = xoops_module_install($module);
@@ -416,7 +416,7 @@ switch ($op) {
         /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         if (!is_object($module_handler->getByDirname($module))) {
-            redirect_header('admin.php?fct=modulesadmin', 3, 'Invalid module uninstall request.');
+            redirect_header('admin.php?fct=modulesadmin', 3, sprintf(_AM_SYSTEM_MODULES_DELETE_ERROR, $module));
         }
         $ret   = [];
         $ret[] = xoops_module_uninstall($module);
@@ -478,7 +478,7 @@ switch ($op) {
         /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         if (!is_object($module_handler->getByDirname($module))) {
-            redirect_header('admin.php?fct=modulesadmin', 3, 'Invalid module update request.');
+            redirect_header('admin.php?fct=modulesadmin', 3, sprintf(_AM_SYSTEM_MODULES_UPDATE_ERROR, $module));
         }
         $ret   = [];
         $ret[] = xoops_module_update($module);


### PR DESCRIPTION
## Summary

- Adds missing `$module = Request::getString('module', '')` initialization in the `install_ok` case of `modulesadmin/main.php`
- The `uninstall_ok` and `update_ok` cases already have this line; `install_ok` was the only one missing it
- Without this fix, installing any module triggers `Undefined variable $module` (PHP 8 Fatal Error)

## Test plan

- [ ] Install a module (e.g. Debugbar) via System > Modules admin — should complete without errors
- [ ] Verify uninstall and update still work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for module install requests to prevent invalid operations and display a clear warning when a module isn’t installable.
  * Added the same validation and warning for module uninstall requests.
  * Added the same validation and warning for module update requests, avoiding unintended processing when a module is not installable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->