### PR TITLE
Fix function_exists() type strictness in XoopsUtility

### DIFF
--- a/htdocs/class/utility/xoopsutility.php
+++ b/htdocs/class/utility/xoopsutility.php
@@ -50,7 +50,7 @@ class XoopsUtility
         }
         // single function
         if (is_string($handler)) {
-            return function_exists($handler) ? $handler($data) : $data;
+            return function_exists((string) $handler) ? $handler($data) : $data;
         }
         // Method of a class
         if (is_array($handler)) {


### PR DESCRIPTION
## Summary

- Adds explicit `(string)` cast to `function_exists()` call in `XoopsUtility::recursive()` to satisfy PHP 8 strict type checking and static analyzers (PHPStan/Scrutinizer)
- The `is_string($handler)` guard already ensures the value is a string at runtime, but analyzers cannot infer the narrowed type through the branch

## Test plan

- [ ] Verify no regressions in modules that use `XoopsUtility::recursive()` (e.g. text sanitizer filters)
- [ ] Confirm PHPStan/Scrutinizer no longer flags `function_exists()` parameter type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor internal code normalization with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->