### PR TITLE
fix for xoopsutility

### DIFF
--- a/htdocs/class/utility/xoopsutility.php
+++ b/htdocs/class/utility/xoopsutility.php
@@ -48,12 +48,12 @@ class XoopsUtility
                 return self::recursive($handler, $item);
             }, $data);
         }
+        if (null === $data) {
+            return $data;
+        }
         // single function
         if (is_string($handler)) {
-            if (null === $data) {
-                return $data;
-            }
-            return function_exists((string) $handler) ? $handler($data) : $data;
+            return function_exists($handler) ? $handler($data) : $data;
         }
         // Method of a class
         if (is_array($handler)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an early guard to skip processing when input data is null, preventing erroneous handling.
  * Removed an unnecessary type coercion in single-handler paths to avoid redundant conversions.
  * Preserved existing behavior for array- and object-based handlers; short-circuiting now occurs before invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->