### PR TITLE
fix(pm): filter recipients by PM module access permission (#831)

### DIFF
--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -123,7 +123,12 @@ class XoopsFormSelectUser extends XoopsFormElementTray
             }
         }
 
-        // merge with selected
+        // Filter pre-selected users by allowed groups to prevent disallowed
+        // recipients from appearing when a value is prefilled via URL params
+        if (!empty($allowedGroups) && !empty($selectedUsers)) {
+            $allowedUids = $member_handler->getUsersByGroupLink($allowedGroups, new Criteria('uid', '(' . implode(',', array_keys($selectedUsers)) . ')', 'IN'), false);
+            $selectedUsers = array_intersect_key($selectedUsers, array_flip($allowedUids));
+        }
         $users = $selectedUsers + $queryCache[$cachekey];
 
         $select_element->addOptionArray($users);

--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -40,6 +40,8 @@ class XoopsFormSelectUser extends XoopsFormElementTray
      *                                 members of that item
      * @param int    $size             Number of rows. "1" makes a drop-down-list.
      * @param bool   $multiple         Allow multiple selections?
+     * @param array  $allowedGroups    Group IDs to restrict users to; empty means no restriction.
+     * @param array  $extraQuery       Extra query parameters appended to the findusers.php popup URL.
      */
     public function __construct($caption, $name, $includeAnonymous = false, $value = null, $size = 1, $multiple = false, array $allowedGroups = [], array $extraQuery = [])
     {
@@ -169,11 +171,11 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         $removeUsers->setExtra(' onclick="var sel = xoopsGetElementById(\'' . $name . '\');for (var i = sel.options.length-1; i >= 0; i--) {if (!sel.options[i].selected) {sel.options[i] = null;}}; return false;" ');
         $action_tray->addElement($removeUsers);
 
-        $searchUrl = XOOPS_URL . '/include/findusers.php?' . http_build_query(array_merge([
+        $searchUrl = XOOPS_URL . '/include/findusers.php?' . http_build_query([
             'target' => $name,
-            'multiple' => (int)$multiple,
+            'multiple' => (int) $multiple,
             'token' => $token,
-        ], $extraQuery), '', '&amp;');
+        ] + $extraQuery, '', '&amp;');
         $searchUsers = new XoopsFormButton('', 'srchusr_' . $name, _MA_USER_MORE, 'button');
         $searchUsers->setExtra(' onclick="openWithSelfMain(\'' . $searchUrl . '\', \'userselect\', 800, 600, null); return false;" ');
         $action_tray->addElement($searchUsers);

--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -28,6 +28,108 @@ xoops_load('XoopsFormSelect');
  */
 class XoopsFormSelectUser extends XoopsFormElementTray
 {
+    /** @var int Maximum users to show in the dropdown */
+    private static $limit = 200;
+
+    /** @var string Cache TTL interpreted by strtotime() */
+    private static $cacheTtl = '+5 minutes';
+
+    /**
+     * Sanitize allowed group IDs to strict positive integers.
+     *
+     * Rejects non-digit values entirely (intval('1foo') would silently become 1).
+     * Fails closed with [0] (impossible group) when a non-empty input sanitizes to empty.
+     *
+     * @param array $allowedGroups Raw group ID values
+     *
+     * @return array Sanitized group IDs, sorted
+     */
+    private static function normalizeAllowedGroups(array $allowedGroups): array
+    {
+        $hadGroups = !empty($allowedGroups);
+        $allowedGroups = array_values(array_unique(array_filter(
+            array_map(
+                static function ($v) { return ctype_digit((string) $v) ? (int) $v : 0; },
+                $allowedGroups
+            ),
+            static function ($groupId) { return $groupId > 0; }
+        )));
+        if ($hadGroups && empty($allowedGroups)) {
+            $allowedGroups = [0]; // impossible group — matches no users
+        }
+        sort($allowedGroups);
+
+        return $allowedGroups;
+    }
+
+    /**
+     * Build the user option list, using cache when available.
+     *
+     * @param XoopsMemberHandler $memberHandler Member handler
+     * @param array              $allowedGroups Sanitized group IDs (empty = no restriction)
+     * @param string             $cachekey      Cache key for this group set
+     * @param array              $queryCache    Reference to static query cache
+     *
+     * @return array uid => uname pairs
+     */
+    private static function getUserOptions(XoopsMemberHandler $memberHandler, array $allowedGroups, string $cachekey, array &$queryCache): array
+    {
+        if (!array_key_exists($cachekey, $queryCache)) {
+            XoopsLoad::load('XoopsCache');
+            $queryCache[$cachekey] = XoopsCache::read($cachekey);
+            if (!is_array($queryCache[$cachekey])) {
+                $criteria = new CriteriaCompo();
+                $userCount = !empty($allowedGroups)
+                    ? $memberHandler->getUserCountByGroupLink($allowedGroups)
+                    : $memberHandler->getUserCount();
+                if (self::$limit <= $userCount) {
+                    $criteria->setLimit(self::$limit);
+                    $criteria->setSort('last_login');
+                    $criteria->setOrder('DESC');
+                } else {
+                    $criteria->setSort('uname');
+                    $criteria->setOrder('ASC');
+                }
+                if (!empty($allowedGroups)) {
+                    $filteredUsers = $memberHandler->getUsersByGroupLink($allowedGroups, $criteria, true, true);
+                    $queryCache[$cachekey] = [];
+                    foreach ($filteredUsers as $uid => $user) {
+                        $queryCache[$cachekey][$uid] = $user->getVar('uname');
+                    }
+                } else {
+                    $queryCache[$cachekey] = $memberHandler->getUserList($criteria);
+                }
+                asort($queryCache[$cachekey]);
+                XoopsCache::write($cachekey, $queryCache[$cachekey], self::$cacheTtl);
+            }
+        }
+
+        return $queryCache[$cachekey];
+    }
+
+    /**
+     * Filter pre-selected values to only include users in allowed groups.
+     *
+     * @param array              $selectedUsers uid => uname of pre-selected users
+     * @param array              $allowedGroups Sanitized group IDs
+     * @param XoopsMemberHandler $memberHandler Member handler
+     *
+     * @return array Filtered uid => uname pairs
+     */
+    private static function filterSelectedByGroups(array $selectedUsers, array $allowedGroups, XoopsMemberHandler $memberHandler): array
+    {
+        if (empty($allowedGroups) || empty($selectedUsers)) {
+            return $selectedUsers;
+        }
+        $allowedUids = $memberHandler->getUsersByGroupLink(
+            $allowedGroups,
+            new Criteria('uid', '(' . implode(',', array_keys($selectedUsers)) . ')', 'IN'),
+            false
+        );
+
+        return array_intersect_key($selectedUsers, array_flip($allowedUids));
+    }
+
     /**
      * Constructor
      *
@@ -54,35 +156,7 @@ class XoopsFormSelectUser extends XoopsFormElementTray
          */
         static $queryCache = [];
 
-        /**
-         * @var int - limit to this many rows
-         */
-        $limit = 200;
-
-        /**
-         * @var string - cache time to live - will be interpreted by strtotime()
-         */
-        $cachettl = '+5 minutes';
-
-        /**
-         * @var string - cache key
-         */
-        // Strictly filter to valid positive integer group IDs.
-        // Reject non-digit values entirely (intval('1foo') would silently become 1).
-        // If caller passed a non-empty list that sanitizes to empty, fail closed
-        // with an impossible group ID so no users are shown.
-        $hadGroups = !empty($allowedGroups);
-        $allowedGroups = array_values(array_unique(array_filter(
-            array_map(
-                static function ($v) { return ctype_digit((string) $v) ? (int) $v : 0; },
-                $allowedGroups
-            ),
-            static function ($groupId) { return $groupId > 0; }
-        )));
-        if ($hadGroups && empty($allowedGroups)) {
-            $allowedGroups = [0]; // impossible group — matches no users
-        }
-        sort($allowedGroups);
+        $allowedGroups = self::normalizeAllowedGroups($allowedGroups);
         $cachekey = 'formselectuser';
         if (!empty($allowedGroups)) {
             $cachekey .= '_' . md5(implode(',', $allowedGroups));
@@ -97,56 +171,18 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         $value          = is_array($value) ? $value : (empty($value) ? [] : [$value]);
         $selectedUsers = [];
         if (count($value) > 0) {
-            // fetch the set of uids in $value
             $criteria = new Criteria('uid', '(' . implode(',', $value) . ')', 'IN');
             $criteria->setSort('uname');
             $criteria->setOrder('ASC');
             $selectedUsers = $member_handler->getUserList($criteria);
         }
 
-        // get the full selection list
-        // we will always cache this version to reduce expense
-        if (!array_key_exists($cachekey, $queryCache)) {
-            XoopsLoad::load('XoopsCache');
-            $queryCache[$cachekey] = XoopsCache::read($cachekey);
-            if (!is_array($queryCache[$cachekey])) {
-                $criteria = new CriteriaCompo();
-                $userCount = !empty($allowedGroups)
-                    ? $member_handler->getUserCountByGroupLink($allowedGroups)
-                    : $member_handler->getUserCount();
-                if ($limit <= $userCount) {
-                    // if we have more than $limit users, we will select who to show based on last_login
-                    $criteria->setLimit($limit);
-                    $criteria->setSort('last_login');
-                    $criteria->setOrder('DESC');
-                } else {
-                    $criteria->setSort('uname');
-                    $criteria->setOrder('ASC');
-                }
-                if (!empty($allowedGroups)) {
-                    $filteredUsers = $member_handler->getUsersByGroupLink($allowedGroups, $criteria, true, true);
-                    $queryCache[$cachekey] = [];
-                    foreach ($filteredUsers as $uid => $user) {
-                        $queryCache[$cachekey][$uid] = $user->getVar('uname');
-                    }
-                } else {
-                    $queryCache[$cachekey] = $member_handler->getUserList($criteria);
-                }
-                asort($queryCache[$cachekey]);
-                XoopsCache::write($cachekey, $queryCache[$cachekey], $cachettl); // won't do anything different if write fails
-            }
-        }
-
-        // Filter pre-selected users by allowed groups to prevent disallowed
-        // recipients from appearing when a value is prefilled via URL params
-        if (!empty($allowedGroups) && !empty($selectedUsers)) {
-            $allowedUids = $member_handler->getUsersByGroupLink($allowedGroups, new Criteria('uid', '(' . implode(',', array_keys($selectedUsers)) . ')', 'IN'), false);
-            $selectedUsers = array_intersect_key($selectedUsers, array_flip($allowedUids));
-        }
-        $users = $selectedUsers + $queryCache[$cachekey];
+        $options = self::getUserOptions($member_handler, $allowedGroups, $cachekey, $queryCache);
+        $selectedUsers = self::filterSelectedByGroups($selectedUsers, $allowedGroups, $member_handler);
+        $users = $selectedUsers + $options;
 
         $select_element->addOptionArray($users);
-        if ($limit > count($users)) {
+        if (self::$limit > count($users)) {
             parent::__construct($caption, '', $name);
             $this->addElement($select_element);
 

--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -95,7 +95,7 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         if (!array_key_exists($cachekey, $queryCache)) {
             XoopsLoad::load('XoopsCache');
             $queryCache[$cachekey] = XoopsCache::read($cachekey);
-            if ($queryCache[$cachekey] === false) {
+            if (!is_array($queryCache[$cachekey])) {
                 $criteria = new CriteriaCompo();
                 $userCount = !empty($allowedGroups)
                     ? $member_handler->getUserCountByGroupLink($allowedGroups)

--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -41,16 +41,16 @@ class XoopsFormSelectUser extends XoopsFormElementTray
      * @param int    $size             Number of rows. "1" makes a drop-down-list.
      * @param bool   $multiple         Allow multiple selections?
      */
-    public function __construct($caption, $name, $includeAnonymous = false, $value = null, $size = 1, $multiple = false)
+    public function __construct($caption, $name, $includeAnonymous = false, $value = null, $size = 1, $multiple = false, array $allowedGroups = [], array $extraQuery = [])
     {
         /**
-         * @var mixed array|false - cache any result for this session.
+         * @var array - cache any result for this session.
          *            Some modules use multiple copies of this element on a single page, so this call will
          *            be made multiple times. This is only used when $value is null.
          * @todo this should be replaced with better interface, with autocomplete style search
          * and user specific MRU cache
          */
-        static $queryCache = false;
+        static $queryCache = [];
 
         /**
          * @var int - limit to this many rows
@@ -65,7 +65,12 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         /**
          * @var string - cache key
          */
+        $allowedGroups = array_values(array_unique(array_filter(array_map('intval', $allowedGroups))));
+        sort($allowedGroups);
         $cachekey = 'formselectuser';
+        if (!empty($allowedGroups)) {
+            $cachekey .= '_' . md5(implode(',', $allowedGroups));
+        }
 
         $select_element = new XoopsFormSelect('', $name, $value, $size, $multiple);
         if ($includeAnonymous) {
@@ -85,12 +90,15 @@ class XoopsFormSelectUser extends XoopsFormElementTray
 
         // get the full selection list
         // we will always cache this version to reduce expense
-        if (empty($queryCache)) {
+        if (!array_key_exists($cachekey, $queryCache)) {
             XoopsLoad::load('XoopsCache');
-            $queryCache = XoopsCache::read($cachekey);
-            if ($queryCache === false) {
+            $queryCache[$cachekey] = XoopsCache::read($cachekey);
+            if ($queryCache[$cachekey] === false) {
                 $criteria = new CriteriaCompo();
-                if ($limit <= $member_handler->getUserCount()) {
+                $userCount = !empty($allowedGroups)
+                    ? $member_handler->getUserCountByGroupLink($allowedGroups)
+                    : $member_handler->getUserCount();
+                if ($limit <= $userCount) {
                     // if we have more than $limit users, we will select who to show based on last_login
                     $criteria->setLimit($limit);
                     $criteria->setSort('last_login');
@@ -99,14 +107,22 @@ class XoopsFormSelectUser extends XoopsFormElementTray
                     $criteria->setSort('uname');
                     $criteria->setOrder('ASC');
                 }
-                $queryCache = $member_handler->getUserList($criteria);
-                asort($queryCache);
-                XoopsCache::write($cachekey, $queryCache, $cachettl); // won't do anything different if write fails
+                if (!empty($allowedGroups)) {
+                    $filteredUsers = $member_handler->getUsersByGroupLink($allowedGroups, $criteria, true, true);
+                    $queryCache[$cachekey] = [];
+                    foreach ($filteredUsers as $uid => $user) {
+                        $queryCache[$cachekey][$uid] = $user->getVar('uname');
+                    }
+                } else {
+                    $queryCache[$cachekey] = $member_handler->getUserList($criteria);
+                }
+                asort($queryCache[$cachekey]);
+                XoopsCache::write($cachekey, $queryCache[$cachekey], $cachettl); // won't do anything different if write fails
             }
         }
 
         // merge with selected
-        $users = $selectedUsers + $queryCache;
+        $users = $selectedUsers + $queryCache[$cachekey];
 
         $select_element->addOptionArray($users);
         if ($limit > count($users)) {
@@ -153,8 +169,13 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         $removeUsers->setExtra(' onclick="var sel = xoopsGetElementById(\'' . $name . '\');for (var i = sel.options.length-1; i >= 0; i--) {if (!sel.options[i].selected) {sel.options[i] = null;}}; return false;" ');
         $action_tray->addElement($removeUsers);
 
+        $searchUrl = XOOPS_URL . '/include/findusers.php?' . http_build_query(array_merge([
+            'target' => $name,
+            'multiple' => (int)$multiple,
+            'token' => $token,
+        ], $extraQuery), '', '&amp;');
         $searchUsers = new XoopsFormButton('', 'srchusr_' . $name, _MA_USER_MORE, 'button');
-        $searchUsers->setExtra(' onclick="openWithSelfMain(\'' . XOOPS_URL . '/include/findusers.php?target=' . $name . '&amp;multiple=' . $multiple . '&amp;token=' . $token . '\', \'userselect\', 800, 600, null); return false;" ');
+        $searchUsers->setExtra(' onclick="openWithSelfMain(\'' . $searchUrl . '\', \'userselect\', 800, 600, null); return false;" ');
         $action_tray->addElement($searchUsers);
 
          if (isset($GLOBALS['xoTheme']) && is_object($GLOBALS['xoTheme'])) {

--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -67,7 +67,17 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         /**
          * @var string - cache key
          */
-        $allowedGroups = array_values(array_unique(array_filter(array_map('intval', $allowedGroups))));
+        // Filter to valid positive integer group IDs; reject non-numeric values.
+        // If caller passed a non-empty list that sanitizes to empty, fail closed
+        // with an impossible group ID so no users are shown.
+        $hadGroups = !empty($allowedGroups);
+        $allowedGroups = array_values(array_unique(array_filter(
+            array_map('intval', $allowedGroups),
+            static function ($v) { return $v > 0; }
+        )));
+        if ($hadGroups && empty($allowedGroups)) {
+            $allowedGroups = [0]; // impossible group — matches no users
+        }
         sort($allowedGroups);
         $cachekey = 'formselectuser';
         if (!empty($allowedGroups)) {

--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -67,12 +67,16 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         /**
          * @var string - cache key
          */
-        // Filter to valid positive integer group IDs; reject non-numeric values.
+        // Strictly filter to valid positive integer group IDs.
+        // Reject non-digit values entirely (intval('1foo') would silently become 1).
         // If caller passed a non-empty list that sanitizes to empty, fail closed
         // with an impossible group ID so no users are shown.
         $hadGroups = !empty($allowedGroups);
         $allowedGroups = array_values(array_unique(array_filter(
-            array_map('intval', $allowedGroups),
+            array_map(
+                static function ($v) { return ctype_digit((string) $v) ? (int) $v : 0; },
+                $allowedGroups
+            ),
             static function ($groupId) { return $groupId > 0; }
         )));
         if ($hadGroups && empty($allowedGroups)) {

--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -73,7 +73,7 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         $hadGroups = !empty($allowedGroups);
         $allowedGroups = array_values(array_unique(array_filter(
             array_map('intval', $allowedGroups),
-            static function ($v) { return $v > 0; }
+            static function ($groupId) { return $groupId > 0; }
         )));
         if ($hadGroups && empty($allowedGroups)) {
             $allowedGroups = [0]; // impossible group — matches no users

--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -643,7 +643,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
     $criteria->setLimit($limit);
     $criteria->setStart($start);
     if (!isset($foundusers)) {
-        $foundusers = $user_handler->getAll($criteria, Request::getArray('groups', [], 'POST'));
+        $foundusers = $user_handler->getAll($criteria, !empty($searchGroups) ? $searchGroups : Request::getArray('groups', [], 'POST'));
     }
 
     echo $js_adduser = '

--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -324,6 +324,7 @@ class XoUserHandler extends XoopsObjectHandler
 
 $rank_handler = new XoopsRankHandler($xoopsDB);
 $user_handler = new XoUserHandler($xoopsDB);
+/** @var XoopsMemberHandler $member_handler */
 $member_handler = xoops_getHandler('member');
 $moduleReadDirname = Request::getCmd('module_read', '', 'GET');
 if ($moduleReadDirname === '') {
@@ -332,9 +333,11 @@ if ($moduleReadDirname === '') {
 $moduleReadGroups = [];
 $moduleReadFailClosed = false;
 if ($moduleReadDirname !== '') {
+    /** @var XoopsModuleHandler $module_handler */
     $module_handler = xoops_getHandler('module');
     $module         = $module_handler->getByDirname($moduleReadDirname);
     if ($module instanceof XoopsModule) {
+        /** @var XoopsGroupPermHandler $moduleperm_handler */
         $moduleperm_handler = xoops_getHandler('groupperm');
         $moduleReadGroups   = array_values(array_unique(array_map('intval', $moduleperm_handler->getGroupIds('module_read', $module->getVar('mid')))));
         if (!in_array(XOOPS_GROUP_ADMIN, $moduleReadGroups, true)) {

--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -325,9 +325,9 @@ class XoUserHandler extends XoopsObjectHandler
 $rank_handler = new XoopsRankHandler($xoopsDB);
 $user_handler = new XoUserHandler($xoopsDB);
 $member_handler = xoops_getHandler('member');
-$moduleReadDirname = Request::getString('module_read', '', 'GET');
+$moduleReadDirname = Request::getCmd('module_read', '', 'GET');
 if ($moduleReadDirname === '') {
-    $moduleReadDirname = Request::getString('module_read', '', 'POST');
+    $moduleReadDirname = Request::getCmd('module_read', '', 'POST');
 }
 $moduleReadGroups = [];
 if ($moduleReadDirname !== '') {
@@ -501,7 +501,14 @@ if (!Request::hasVar('user_submit', 'POST')) {
         if ($mode == $_mode) {
             continue;
         }
-        $modes_switch[] = "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', ''), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '&amp;module_read=' . htmlspecialchars($moduleReadDirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . "&amp;mode={$_mode}'>{$title}</a>";
+        $modeSwitchUrl = 'findusers.php?' . http_build_query([
+            'target'      => Request::getString('target', ''),
+            'multiple'    => (int) $multiple,
+            'token'       => $token,
+            'module_read' => $moduleReadDirname,
+            'mode'        => $_mode,
+        ]);
+        $modes_switch[] = "<a href='" . htmlspecialchars($modeSwitchUrl, ENT_QUOTES | ENT_HTML5, 'UTF-8') . "'>{$title}</a>";
     }
     echo '<h4>' . implode(' | ', $modes_switch) . '</h4>';
     echo '(' . sprintf(_MA_USER_ACTUS, "<span style='color:#ff0000;'>$acttotal</span>") . ' ' . sprintf(_MA_USER_INACTUS, "<span style='color:#ff0000;'>$inacttotal</span>") . ')';
@@ -680,7 +687,13 @@ if (!Request::hasVar('user_submit', 'POST')) {
     ';
 
     echo '</html><body>';
-    echo "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', '', 'POST'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '&amp;module_read=' . htmlspecialchars($moduleReadDirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . "'>" . _MA_USER_FINDUS . "</a>&nbsp;<span style='font-weight:bold;'>&raquo;</span>&nbsp;" . _MA_USER_RESULTS . '<br><br>';
+    $breadcrumbUrl = 'findusers.php?' . http_build_query([
+        'target'      => Request::getString('target', '', 'POST'),
+        'multiple'    => (int) $multiple,
+        'token'       => $token,
+        'module_read' => $moduleReadDirname,
+    ]);
+    echo "<a href='" . htmlspecialchars($breadcrumbUrl, ENT_QUOTES | ENT_HTML5, 'UTF-8') . "'>" . _MA_USER_FINDUS . "</a>&nbsp;<span style='font-weight:bold;'>&raquo;</span>&nbsp;" . _MA_USER_RESULTS . '<br><br>';
     if (empty($start) && empty($foundusers)) {
         echo '<h4>' . _MA_USER_NOFOUND, '</h4>';
         $hiddenform = "<form name='findnext' action='findusers.php' method='post'>";

--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -324,6 +324,28 @@ class XoUserHandler extends XoopsObjectHandler
 
 $rank_handler = new XoopsRankHandler($xoopsDB);
 $user_handler = new XoUserHandler($xoopsDB);
+$member_handler = xoops_getHandler('member');
+$moduleReadDirname = Request::getString('module_read', '', 'GET');
+if ($moduleReadDirname === '') {
+    $moduleReadDirname = Request::getString('module_read', '', 'POST');
+}
+$moduleReadGroups = [];
+$moduleReadUserIds = [];
+if ($moduleReadDirname !== '') {
+    $module_handler = xoops_getHandler('module');
+    $module         = $module_handler->getByDirname($moduleReadDirname);
+    if ($module instanceof XoopsModule) {
+        $moduleperm_handler = xoops_getHandler('groupperm');
+        $moduleReadGroups   = array_values(array_unique(array_map('intval', $moduleperm_handler->getGroupIds('module_read', $module->getVar('mid')))));
+        if (!in_array(XOOPS_GROUP_ADMIN, $moduleReadGroups, true)) {
+            $moduleReadGroups[] = XOOPS_GROUP_ADMIN;
+        }
+        $moduleReadUserIds = array_values(array_unique(array_map('intval', $member_handler->getUsersByGroupLink($moduleReadGroups, null, false))));
+    } else {
+        // Keep the filter active but force an empty result set for unknown modules.
+        $moduleReadGroups = [0];
+    }
+}
 
 $items_match = [
     'uname'     => _MA_USER_UNAME,
@@ -405,8 +427,6 @@ if (!Request::hasVar('user_submit', 'POST')) {
         ];
         $level_radio->addOptionArray($levels);
 
-        /** @var XoopsMemberHandler $member_handler */
-        $member_handler = xoops_getHandler('member');
         $groups         = $member_handler->getGroupList();
         $groups[0]      = _ALL;
         $group_select   = new XoopsFormSelect(_MA_USER_GROUP, 'groups', Request::getInt('groups', 0), 3, true);
@@ -463,10 +483,25 @@ if (!Request::hasVar('user_submit', 'POST')) {
     $form->addElement(new XoopsFormHidden('target', Request::getString('target', '', 'POST')));
     $form->addElement(new XoopsFormHidden('multiple', $multiple));
     $form->addElement(new XoopsFormHidden('token', $token));
+    $form->addElement(new XoopsFormHidden('module_read', $moduleReadDirname));
     $form->addElement(new XoopsFormButton('', 'user_submit', _SUBMIT, 'submit'));
 
-    $acttotal   = $user_handler->getCount(new Criteria('level', 0, '>'));
-    $inacttotal = $user_handler->getCount(new Criteria('level', 0, '<='));
+    if ($moduleReadDirname !== '') {
+        if (empty($moduleReadUserIds)) {
+            $acttotal = $inacttotal = 0;
+        } else {
+            $actCriteria = new CriteriaCompo(new Criteria('uid', '(' . implode(',', $moduleReadUserIds) . ')', 'IN'));
+            $actCriteria->add(new Criteria('level', 0, '>'));
+            $acttotal = $user_handler->getCount($actCriteria);
+
+            $inactCriteria = new CriteriaCompo(new Criteria('uid', '(' . implode(',', $moduleReadUserIds) . ')', 'IN'));
+            $inactCriteria->add(new Criteria('level', 0, '<='));
+            $inacttotal = $user_handler->getCount($inactCriteria);
+        }
+    } else {
+        $acttotal   = $user_handler->getCount(new Criteria('level', 0, '>'));
+        $inacttotal = $user_handler->getCount(new Criteria('level', 0, '<='));
+    }
     echo '</html><body>';
     echo "<h2 style='text-align:left;'>" . _MA_USER_FINDUS . ' - ' . $modes[$mode] . '</h2>';
     $modes_switch = [];
@@ -474,7 +509,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
         if ($mode == $_mode) {
             continue;
         }
-        $modes_switch[] = "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', ''), ENT_QUOTES | ENT_HTML5) . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5) . "&amp;mode={$_mode}'>{$title}</a>";
+        $modes_switch[] = "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', ''), ENT_QUOTES | ENT_HTML5) . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5) . '&amp;module_read=' . htmlspecialchars($moduleReadDirname, ENT_QUOTES | ENT_HTML5) . "&amp;mode={$_mode}'>{$title}</a>";
     }
     echo '<h4>' . implode(' | ', $modes_switch) . '</h4>';
     echo '(' . sprintf(_MA_USER_ACTUS, "<span style='color:#ff0000;'>$acttotal</span>") . ' ' . sprintf(_MA_USER_INACTUS, "<span style='color:#ff0000;'>$inacttotal</span>") . ')';
@@ -582,7 +617,17 @@ if (!Request::hasVar('user_submit', 'POST')) {
             }
         }
     }
-    $total     = $user_handler->getCount($criteria, Request::getArray('groups', [], 'POST'));
+    if ($moduleReadDirname !== '') {
+        if (empty($moduleReadUserIds)) {
+            $total = 0;
+            $foundusers = [];
+        } else {
+            $criteria->add(new Criteria('uid', '(' . implode(',', $moduleReadUserIds) . ')', 'IN'));
+        }
+    }
+    if (!isset($total)) {
+        $total = $user_handler->getCount($criteria, Request::getArray('groups', [], 'POST'));
+    }
     $validsort = [
         'uname',
         'email',
@@ -599,7 +644,9 @@ if (!Request::hasVar('user_submit', 'POST')) {
     $criteria->setOrder($order);
     $criteria->setLimit($limit);
     $criteria->setStart($start);
-    $foundusers = $user_handler->getAll($criteria, Request::getArray('groups', [], 'POST'));
+    if (!isset($foundusers)) {
+        $foundusers = $user_handler->getAll($criteria, Request::getArray('groups', [], 'POST'));
+    }
 
     echo $js_adduser = '
         <script type="text/javascript">
@@ -635,7 +682,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
     ';
 
     echo '</html><body>';
-    echo "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', '', 'POST'), ENT_QUOTES | ENT_HTML5) . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5) . "'>" . _MA_USER_FINDUS . "</a>&nbsp;<span style='font-weight:bold;'>&raquo;</span>&nbsp;" . _MA_USER_RESULTS . '<br><br>';
+    echo "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', '', 'POST'), ENT_QUOTES | ENT_HTML5) . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5) . '&amp;module_read=' . htmlspecialchars($moduleReadDirname, ENT_QUOTES | ENT_HTML5) . "'>" . _MA_USER_FINDUS . "</a>&nbsp;<span style='font-weight:bold;'>&raquo;</span>&nbsp;" . _MA_USER_RESULTS . '<br><br>';
     if (empty($start) && empty($foundusers)) {
         echo '<h4>' . _MA_USER_NOFOUND, '</h4>';
         $hiddenform = "<form name='findnext' action='findusers.php' method='post'>";

--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -330,6 +330,7 @@ if ($moduleReadDirname === '') {
     $moduleReadDirname = Request::getCmd('module_read', '', 'POST');
 }
 $moduleReadGroups = [];
+$moduleReadFailClosed = false;
 if ($moduleReadDirname !== '') {
     $module_handler = xoops_getHandler('module');
     $module         = $module_handler->getByDirname($moduleReadDirname);
@@ -340,8 +341,8 @@ if ($moduleReadDirname !== '') {
             $moduleReadGroups[] = XOOPS_GROUP_ADMIN;
         }
     } else {
-        // Keep the filter active but force an empty result set for unknown modules.
-        $moduleReadGroups = [0];
+        // Unknown module: fail closed — no users should be shown
+        $moduleReadFailClosed = true;
     }
 }
 
@@ -484,7 +485,9 @@ if (!Request::hasVar('user_submit', 'POST')) {
     $form->addElement(new XoopsFormHidden('module_read', $moduleReadDirname));
     $form->addElement(new XoopsFormButton('', 'user_submit', _SUBMIT, 'submit'));
 
-    if (!empty($moduleReadGroups)) {
+    if ($moduleReadFailClosed) {
+        $acttotal = $inacttotal = 0;
+    } elseif (!empty($moduleReadGroups)) {
         $actCriteria = new Criteria('level', 0, '>');
         $acttotal = $member_handler->getUserCountByGroupLink($moduleReadGroups, $actCriteria);
 
@@ -616,12 +619,15 @@ if (!Request::hasVar('user_submit', 'POST')) {
             }
         }
     }
-    // Merge module-read groups with any explicitly selected groups
-    $searchGroups = Request::getArray('groups', [], 'POST');
-    if (!empty($moduleReadGroups)) {
-        // If specific groups were also selected, intersect with allowed groups
-        if (!empty($searchGroups)) {
-            $searchGroups = array_values(array_intersect(array_map('intval', $searchGroups), $moduleReadGroups));
+    // Normalize posted groups: strip the UI "All groups" sentinel (0)
+    $postedGroups = array_filter(array_map('intval', Request::getArray('groups', [], 'POST')), static function ($v) { return $v > 0; });
+    if ($moduleReadFailClosed) {
+        $total = 0;
+        $foundusers = [];
+    } elseif (!empty($moduleReadGroups)) {
+        // Intersect user-selected groups with module-permitted groups
+        if (!empty($postedGroups)) {
+            $searchGroups = array_values(array_intersect($postedGroups, $moduleReadGroups));
         } else {
             $searchGroups = $moduleReadGroups;
         }
@@ -629,9 +635,11 @@ if (!Request::hasVar('user_submit', 'POST')) {
             $total = 0;
             $foundusers = [];
         }
+    } else {
+        $searchGroups = $postedGroups;
     }
     if (!isset($total)) {
-        $total = $user_handler->getCount($criteria, $searchGroups);
+        $total = $user_handler->getCount($criteria, !empty($searchGroups) ? $searchGroups : []);
     }
     $validsort = [
         'uname',
@@ -650,7 +658,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
     $criteria->setLimit($limit);
     $criteria->setStart($start);
     if (!isset($foundusers)) {
-        $foundusers = $user_handler->getAll($criteria, !empty($searchGroups) ? $searchGroups : Request::getArray('groups', [], 'POST'));
+        $foundusers = $user_handler->getAll($criteria, !empty($searchGroups) ? $searchGroups : []);
     }
 
     echo $js_adduser = '

--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -330,7 +330,6 @@ if ($moduleReadDirname === '') {
     $moduleReadDirname = Request::getString('module_read', '', 'POST');
 }
 $moduleReadGroups = [];
-$moduleReadUserIds = [];
 if ($moduleReadDirname !== '') {
     $module_handler = xoops_getHandler('module');
     $module         = $module_handler->getByDirname($moduleReadDirname);
@@ -340,7 +339,6 @@ if ($moduleReadDirname !== '') {
         if (!in_array(XOOPS_GROUP_ADMIN, $moduleReadGroups, true)) {
             $moduleReadGroups[] = XOOPS_GROUP_ADMIN;
         }
-        $moduleReadUserIds = array_values(array_unique(array_map('intval', $member_handler->getUsersByGroupLink($moduleReadGroups, null, false))));
     } else {
         // Keep the filter active but force an empty result set for unknown modules.
         $moduleReadGroups = [0];
@@ -486,18 +484,12 @@ if (!Request::hasVar('user_submit', 'POST')) {
     $form->addElement(new XoopsFormHidden('module_read', $moduleReadDirname));
     $form->addElement(new XoopsFormButton('', 'user_submit', _SUBMIT, 'submit'));
 
-    if ($moduleReadDirname !== '') {
-        if (empty($moduleReadUserIds)) {
-            $acttotal = $inacttotal = 0;
-        } else {
-            $actCriteria = new CriteriaCompo(new Criteria('uid', '(' . implode(',', $moduleReadUserIds) . ')', 'IN'));
-            $actCriteria->add(new Criteria('level', 0, '>'));
-            $acttotal = $user_handler->getCount($actCriteria);
+    if (!empty($moduleReadGroups)) {
+        $actCriteria = new Criteria('level', 0, '>');
+        $acttotal = $member_handler->getUserCountByGroupLink($moduleReadGroups, $actCriteria);
 
-            $inactCriteria = new CriteriaCompo(new Criteria('uid', '(' . implode(',', $moduleReadUserIds) . ')', 'IN'));
-            $inactCriteria->add(new Criteria('level', 0, '<='));
-            $inacttotal = $user_handler->getCount($inactCriteria);
-        }
+        $inactCriteria = new Criteria('level', 0, '<=');
+        $inacttotal = $member_handler->getUserCountByGroupLink($moduleReadGroups, $inactCriteria);
     } else {
         $acttotal   = $user_handler->getCount(new Criteria('level', 0, '>'));
         $inacttotal = $user_handler->getCount(new Criteria('level', 0, '<='));
@@ -509,7 +501,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
         if ($mode == $_mode) {
             continue;
         }
-        $modes_switch[] = "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', ''), ENT_QUOTES | ENT_HTML5) . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5) . '&amp;module_read=' . htmlspecialchars($moduleReadDirname, ENT_QUOTES | ENT_HTML5) . "&amp;mode={$_mode}'>{$title}</a>";
+        $modes_switch[] = "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', ''), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '&amp;module_read=' . htmlspecialchars($moduleReadDirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . "&amp;mode={$_mode}'>{$title}</a>";
     }
     echo '<h4>' . implode(' | ', $modes_switch) . '</h4>';
     echo '(' . sprintf(_MA_USER_ACTUS, "<span style='color:#ff0000;'>$acttotal</span>") . ' ' . sprintf(_MA_USER_INACTUS, "<span style='color:#ff0000;'>$inacttotal</span>") . ')';
@@ -617,16 +609,22 @@ if (!Request::hasVar('user_submit', 'POST')) {
             }
         }
     }
-    if ($moduleReadDirname !== '') {
-        if (empty($moduleReadUserIds)) {
+    // Merge module-read groups with any explicitly selected groups
+    $searchGroups = Request::getArray('groups', [], 'POST');
+    if (!empty($moduleReadGroups)) {
+        // If specific groups were also selected, intersect with allowed groups
+        if (!empty($searchGroups)) {
+            $searchGroups = array_values(array_intersect(array_map('intval', $searchGroups), $moduleReadGroups));
+        } else {
+            $searchGroups = $moduleReadGroups;
+        }
+        if (empty($searchGroups)) {
             $total = 0;
             $foundusers = [];
-        } else {
-            $criteria->add(new Criteria('uid', '(' . implode(',', $moduleReadUserIds) . ')', 'IN'));
         }
     }
     if (!isset($total)) {
-        $total = $user_handler->getCount($criteria, Request::getArray('groups', [], 'POST'));
+        $total = $user_handler->getCount($criteria, $searchGroups);
     }
     $validsort = [
         'uname',
@@ -682,7 +680,7 @@ if (!Request::hasVar('user_submit', 'POST')) {
     ';
 
     echo '</html><body>';
-    echo "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', '', 'POST'), ENT_QUOTES | ENT_HTML5) . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5) . '&amp;module_read=' . htmlspecialchars($moduleReadDirname, ENT_QUOTES | ENT_HTML5) . "'>" . _MA_USER_FINDUS . "</a>&nbsp;<span style='font-weight:bold;'>&raquo;</span>&nbsp;" . _MA_USER_RESULTS . '<br><br>';
+    echo "<a href='findusers.php?target=" . htmlspecialchars(Request::getString('target', '', 'POST'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '&amp;multiple=' . (string) $multiple . '&amp;token=' . htmlspecialchars($token, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '&amp;module_read=' . htmlspecialchars($moduleReadDirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . "'>" . _MA_USER_FINDUS . "</a>&nbsp;<span style='font-weight:bold;'>&raquo;</span>&nbsp;" . _MA_USER_RESULTS . '<br><br>';
     if (empty($start) && empty($foundusers)) {
         echo '<h4>' . _MA_USER_NOFOUND, '</h4>';
         $hiddenform = "<form name='findnext' action='findusers.php' method='post'>";

--- a/htdocs/modules/pm/language/english/main.php
+++ b/htdocs/modules/pm/language/english/main.php
@@ -20,6 +20,7 @@ define('_PM_SORRY', 'Sorry! You are not a registered user.');
 define('_PM_REGISTERNOW', 'Register Now!');
 define('_PM_GOBACK', 'Go Back');
 define('_PM_USERNOEXIST', "The selected user doesn't exist in the database.");
+define('_PM_USERNOPERM', 'The selected user cannot receive private messages.');
 define('_PM_PLZTRYAGAIN', 'Please check the name and try again.');
 define('_PM_MESSAGEPOSTED', 'Your message has been posted');
 define('_PM_CLICKHERE', 'You can click here to view your private messages');

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -99,19 +99,38 @@ function pmCanMessageUser(int $uid): bool
 }
 
 /**
+ * Safe fallbacks for PM language constants that may not be loaded.
+ */
+function pmSafeTryAgain(): string
+{
+    return defined('_PM_PLZTRYAGAIN') ? _PM_PLZTRYAGAIN : 'Please try again.';
+}
+
+function pmSafeGoBack(): string
+{
+    return defined('_PM_GOBACK') ? _PM_GOBACK : 'Go back';
+}
+
+/**
+ * Render the "user does not exist" error block.
+ */
+function pmRenderUserNotFound(): void
+{
+    echo '<br><br><div><h4>' . _PM_USERNOEXIST . '<br>';
+    echo pmSafeTryAgain() . '</h4><br>';
+    echo "[ <a href='javascript:history.go(-1)'>" . pmSafeGoBack() . '</a> ]</div>';
+}
+
+/**
  * Render the standard invalid-recipient message.
- *
- * @return void
  */
 function pmRenderInvalidRecipient(): void
 {
-    $noPermMsg  = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
-    $tryAgain   = defined('_PM_PLZTRYAGAIN') ? _PM_PLZTRYAGAIN : 'Please try again.';
-    $goBack     = defined('_PM_GOBACK') ? _PM_GOBACK : 'Go back';
+    $noPermMsg = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
 
     echo '<br><br><div><h4>' . $noPermMsg . '<br>';
-    echo $tryAgain . '</h4><br>';
-    echo "[ <a href='javascript:history.go(-1)'>" . $goBack . '</a> ]</div>';
+    echo pmSafeTryAgain() . '</h4><br>';
+    echo "[ <a href='javascript:history.go(-1)'>" . pmSafeGoBack() . '</a> ]</div>';
 }
 
 $op = XoopsRequest::getCmd('op', '', 'POST');
@@ -144,7 +163,7 @@ xoops_header();
 
 $myts = \MyTextSanitizer::getInstance();
 if ($op === 'submit') {
-    $recipientId = XoopsRequest::getInt('to_userid', 0, 'POST');
+    $recipientId = \Xmf\Request::getInt('to_userid', 0, 'POST');
     /** @var XoopsMemberHandler $member_handler */
     $member_handler = xoops_getHandler('member');
     $count          = $member_handler->getUserCount(new Criteria('uid', $recipientId));
@@ -215,12 +234,10 @@ if ($op === 'submit') {
         $pmform->addElement(new XoopsFormLabel(_PM_TO, $pm_uname));
         $pmform->addElement(new XoopsFormHidden('to_userid', $pm->getVar('from_userid')));
     } elseif ($sendmod == 1) {
-        $sendModRecipient = XoopsRequest::getInt('to_userid', 0, 'POST');
+        $sendModRecipient = \Xmf\Request::getInt('to_userid', 0, 'POST');
         $tmpUname = XoopsUser::getUnameFromId($sendModRecipient);
         if (empty($tmpUname)) {
-            echo '<br><br><div><h4>' . _PM_USERNOEXIST . '<br>';
-            echo (defined('_PM_PLZTRYAGAIN') ? _PM_PLZTRYAGAIN : 'Please try again.') . '</h4><br>';
-            echo "[ <a href='javascript:history.go(-1)'>" . (defined('_PM_GOBACK') ? _PM_GOBACK : 'Go back') . '</a> ]</div>';
+            pmRenderUserNotFound();
             xoops_footer();
             return;
         }
@@ -237,9 +254,7 @@ if ($op === 'submit') {
         if ($send2 == 1) {
             $tmpUname = XoopsUser::getUnameFromId($to_userid, false);
             if (empty($tmpUname)) {
-                echo '<br><br><div><h4>' . _PM_USERNOEXIST . '<br>';
-                echo (defined('_PM_PLZTRYAGAIN') ? _PM_PLZTRYAGAIN : 'Please try again.') . '</h4><br>';
-                echo "[ <a href='javascript:history.go(-1)'>" . (defined('_PM_GOBACK') ? _PM_GOBACK : 'Go back') . '</a> ]</div>';
+                pmRenderUserNotFound();
                 xoops_footer();
                 return;
             }

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -216,12 +216,19 @@ if ($op === 'submit') {
         $pmform->addElement(new XoopsFormHidden('to_userid', $pm->getVar('from_userid')));
     } elseif ($sendmod == 1) {
         $sendModRecipient = XoopsRequest::getInt('to_userid', 0, 'POST');
+        $tmpUname = XoopsUser::getUnameFromId($sendModRecipient);
+        if (empty($tmpUname)) {
+            echo '<br><br><div><h4>' . _PM_USERNOEXIST . '<br>';
+            echo (defined('_PM_PLZTRYAGAIN') ? _PM_PLZTRYAGAIN : 'Please try again.') . '</h4><br>';
+            echo "[ <a href='javascript:history.go(-1)'>" . (defined('_PM_GOBACK') ? _PM_GOBACK : 'Go back') . '</a> ]</div>';
+            xoops_footer();
+            return;
+        }
         if (!pmCanMessageUser($sendModRecipient)) {
             pmRenderInvalidRecipient();
             xoops_footer();
             return;
         }
-        $tmpUname = XoopsUser::getUnameFromId($sendModRecipient);
         $pmform->addElement(new XoopsFormHidden('to_userid', $sendModRecipient));
         $pmform->addElement(new XoopsFormLabel(_PM_TO, $tmpUname));
         $subject = $myts->htmlSpecialChars(XoopsRequest::getString('subject', '', 'POST'));

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -28,6 +28,87 @@ XoopsLoad::load('XoopsRequest');
 
 $subject_icons = XoopsLists::getSubjectsList();
 
+/**
+ * Resolve the PM module object once per request.
+ *
+ * @return XoopsModule|false
+ */
+function pmGetModule()
+{
+    static $pmModule = null;
+    if ($pmModule === null) {
+        $moduleHandler = xoops_getHandler('module');
+        $module        = $moduleHandler->getByDirname('pm');
+        $pmModule      = ($module instanceof XoopsModule) ? $module : false;
+    }
+
+    return $pmModule;
+}
+
+/**
+ * Groups allowed to use the PM module.
+ *
+ * Mirrors module_read checks by always allowing the admin group.
+ *
+ * @return array
+ */
+function pmGetAllowedRecipientGroups()
+{
+    static $groups = null;
+    if ($groups === null) {
+        $groups = [];
+        $module = pmGetModule();
+        if ($module instanceof XoopsModule) {
+            $grouppermHandler = xoops_getHandler('groupperm');
+            $groups           = array_values(array_unique(array_map('intval', $grouppermHandler->getGroupIds('module_read', $module->getVar('mid')))));
+            if (!in_array(XOOPS_GROUP_ADMIN, $groups, true)) {
+                $groups[] = XOOPS_GROUP_ADMIN;
+            }
+        }
+    }
+
+    return $groups;
+}
+
+/**
+ * Check whether a user can access the PM module and receive PMs.
+ *
+ * @param int $uid
+ *
+ * @return bool
+ */
+function pmCanMessageUser($uid)
+{
+    $uid = (int) $uid;
+    if ($uid <= 0) {
+        return false;
+    }
+    $module = pmGetModule();
+    if (!$module instanceof XoopsModule) {
+        return false;
+    }
+    $memberHandler = xoops_getHandler('member');
+    $userGroups    = $memberHandler->getGroupsByUser($uid);
+    if (empty($userGroups)) {
+        return false;
+    }
+    $grouppermHandler = xoops_getHandler('groupperm');
+
+    return $grouppermHandler->checkRight('module_read', $module->getVar('mid'), $userGroups);
+}
+
+/**
+ * Render the standard invalid-recipient message.
+ *
+ * @return void
+ */
+function pmRenderInvalidRecipient()
+{
+    echo '<br><br><div><h4>' . _PM_USERNOPERM . '<br>';
+    echo _PM_PLZTRYAGAIN . '</h4><br>';
+    echo "[ <a href='javascript:history.go(-1)'>" . _PM_GOBACK . '</a> ]</div>';
+}
+
 $op = XoopsRequest::getCmd('op', '', 'POST');
 
 $reply     = XoopsRequest::getBool('reply', 0, 'GET');
@@ -58,13 +139,16 @@ xoops_header();
 
 $myts = \MyTextSanitizer::getInstance();
 if ($op === 'submit') {
+    $recipientId = XoopsRequest::getInt('to_userid', 0, 'POST');
     /** @var XoopsMemberHandler $member_handler */
     $member_handler = xoops_getHandler('member');
-    $count          = $member_handler->getUserCount(new Criteria('uid', XoopsRequest::getInt('to_userid', 0, 'POST')));
+    $count          = $member_handler->getUserCount(new Criteria('uid', $recipientId));
     if ($count != 1) {
         echo '<br><br><div><h4>' . _PM_USERNOEXIST . '<br>';
         echo _PM_PLZTRYAGAIN . '</h4><br>';
         echo "[ <a href='javascript:history.go(-1)'>" . _PM_GOBACK . '</a> ]</div>';
+    } elseif (!pmCanMessageUser($recipientId)) {
+        pmRenderInvalidRecipient();
     } elseif ($GLOBALS['xoopsSecurity']->check()) {
         $pm_handler = xoops_getModuleHandler('message', 'pm');
         $pm         = $pm_handler->create();
@@ -75,7 +159,7 @@ if ($op === 'submit') {
         }
         $pm->setVar('subject', XoopsRequest::getString('subject', null, 'POST'));
         $pm->setVar('msg_text', XoopsRequest::getString('message', null, 'POST'));
-        $pm->setVar('to_userid', XoopsRequest::getInt('to_userid', 0, 'POST'));
+        $pm->setVar('to_userid', $recipientId);
         $pm->setVar('from_userid', $GLOBALS['xoopsUser']->getVar('uid'));
         if (XoopsRequest::getBool('savecopy', 0)) {
             //PMs are by default not saved in outbox
@@ -104,6 +188,11 @@ if ($op === 'submit') {
             $message  = "[quote]\n";
             $message .= sprintf(_PM_USERWROTE, $pm_uname);
             $message .= "\n" . $pm->getVar('msg_text', 'E') . "\n[/quote]";
+            if (!pmCanMessageUser($pm->getVar('from_userid'))) {
+                pmRenderInvalidRecipient();
+                xoops_footer();
+                return;
+            }
         } else {
             unset($pm);
             $reply = $send2 = 0;
@@ -121,18 +210,29 @@ if ($op === 'submit') {
         $pmform->addElement(new XoopsFormLabel(_PM_TO, $pm_uname));
         $pmform->addElement(new XoopsFormHidden('to_userid', $pm->getVar('from_userid')));
     } elseif ($sendmod == 1) {
-        $tmpUname = XoopsUser::getUnameFromId(XoopsRequest::getInt('to_userid', 0, 'POST'));
+        $sendModRecipient = XoopsRequest::getInt('to_userid', 0, 'POST');
+        if (!pmCanMessageUser($sendModRecipient)) {
+            pmRenderInvalidRecipient();
+            xoops_footer();
+            return;
+        }
+        $tmpUname = XoopsUser::getUnameFromId($sendModRecipient);
         $pmform->addElement(new XoopsFormHidden('to_userid', XoopsRequest::getInt('to_userid', 0, 'POST')));
         $pmform->addElement(new XoopsFormLabel(_PM_TO, $tmpUname));
         $subject = $myts->htmlSpecialChars(XoopsRequest::getString('subject', '', 'POST'));
         $message = $myts->htmlSpecialChars(XoopsRequest::getString('message', '', 'POST'));
     } else {
         if ($send2 == 1) {
+            if (!pmCanMessageUser($to_userid)) {
+                pmRenderInvalidRecipient();
+                xoops_footer();
+                return;
+            }
             $tmpUname = XoopsUser::getUnameFromId($to_userid, false);
             $pmform->addElement(new XoopsFormLabel(_PM_TO, $tmpUname));
             $pmform->addElement(new XoopsFormHidden('to_userid', $to_userid));
         } else {
-            $to_username = new XoopsFormSelectUser(_PM_TO, 'to_userid');
+            $to_username = new XoopsFormSelectUser(_PM_TO, 'to_userid', false, null, 1, false, pmGetAllowedRecipientGroups(), ['module_read' => 'pm']);
             $pmform->addElement($to_username);
         }
     }

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -79,9 +79,8 @@ function pmGetAllowedRecipientGroups(): array
  *
  * @return bool
  */
-function pmCanMessageUser($uid)
+function pmCanMessageUser(int $uid): bool
 {
-    $uid = (int) $uid;
     if ($uid <= 0) {
         return false;
     }
@@ -229,12 +228,19 @@ if ($op === 'submit') {
         $message = $myts->htmlSpecialChars(XoopsRequest::getString('message', '', 'POST'));
     } else {
         if ($send2 == 1) {
+            $tmpUname = XoopsUser::getUnameFromId($to_userid, false);
+            if (empty($tmpUname)) {
+                echo '<br><br><div><h4>' . _PM_USERNOEXIST . '<br>';
+                echo (defined('_PM_PLZTRYAGAIN') ? _PM_PLZTRYAGAIN : 'Please try again.') . '</h4><br>';
+                echo "[ <a href='javascript:history.go(-1)'>" . (defined('_PM_GOBACK') ? _PM_GOBACK : 'Go back') . '</a> ]</div>';
+                xoops_footer();
+                return;
+            }
             if (!pmCanMessageUser($to_userid)) {
                 pmRenderInvalidRecipient();
                 xoops_footer();
                 return;
             }
-            $tmpUname = XoopsUser::getUnameFromId($to_userid, false);
             $pmform->addElement(new XoopsFormLabel(_PM_TO, $tmpUname));
             $pmform->addElement(new XoopsFormHidden('to_userid', $to_userid));
         } else {

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -33,7 +33,7 @@ $subject_icons = XoopsLists::getSubjectsList();
  *
  * @return XoopsModule|false
  */
-function pmGetModule()
+function pmGetModule(): XoopsModule|false
 {
     static $pmModule = null;
     if ($pmModule === null) {

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -64,8 +64,8 @@ function pmGetAllowedRecipientGroups(): array
                 $groups[] = XOOPS_GROUP_ADMIN;
             }
         } else {
-            // Fail closed: only admin can send if PM module lookup fails
-            $groups = [defined('XOOPS_GROUP_ADMIN') ? (int) XOOPS_GROUP_ADMIN : 1];
+            // Fail closed: no users shown — matches pmCanMessageUser which rejects all
+            $groups = [0];
         }
     }
 

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -37,6 +37,7 @@ function pmGetModule(): XoopsModule|false
 {
     static $pmModule = null;
     if ($pmModule === null) {
+        /** @var XoopsModuleHandler $moduleHandler */
         $moduleHandler = xoops_getHandler('module');
         $module        = $moduleHandler->getByDirname('pm');
         $pmModule      = ($module instanceof XoopsModule) ? $module : false;
@@ -58,6 +59,7 @@ function pmGetAllowedRecipientGroups(): array
     if ($groups === null) {
         $module = pmGetModule();
         if ($module instanceof XoopsModule) {
+            /** @var XoopsGroupPermHandler $grouppermHandler */
             $grouppermHandler = xoops_getHandler('groupperm');
             $groups           = array_values(array_unique(array_map('intval', $grouppermHandler->getGroupIds('module_read', $module->getVar('mid')))));
             if (!in_array(XOOPS_GROUP_ADMIN, $groups, true)) {
@@ -88,11 +90,13 @@ function pmCanMessageUser(int $uid): bool
     if (!$module instanceof XoopsModule) {
         return false;
     }
+    /** @var XoopsMemberHandler $memberHandler */
     $memberHandler = xoops_getHandler('member');
     $userGroups    = $memberHandler->getGroupsByUser($uid);
     if (empty($userGroups)) {
         return false;
     }
+    /** @var XoopsGroupPermHandler $grouppermHandler */
     $grouppermHandler = xoops_getHandler('groupperm');
 
     return $grouppermHandler->checkRight('module_read', $module->getVar('mid'), $userGroups);
@@ -177,15 +181,15 @@ if ($op === 'submit') {
         $pm_handler = xoops_getModuleHandler('message', 'pm');
         $pm         = $pm_handler->create();
         $pm->setVar('msg_time', time());
-        $msg_image = XoopsRequest::getString('msg_image', null, 'POST');
+        $msg_image = \Xmf\Request::getString('msg_image', '', 'POST');
         if (in_array($msg_image, $subject_icons)) {
             $pm->setVar('msg_image', $msg_image);
         }
-        $pm->setVar('subject', XoopsRequest::getString('subject', null, 'POST'));
-        $pm->setVar('msg_text', XoopsRequest::getString('message', null, 'POST'));
+        $pm->setVar('subject', \Xmf\Request::getString('subject', '', 'POST'));
+        $pm->setVar('msg_text', \Xmf\Request::getString('message', '', 'POST'));
         $pm->setVar('to_userid', $recipientId);
         $pm->setVar('from_userid', $GLOBALS['xoopsUser']->getVar('uid'));
-        if (XoopsRequest::getBool('savecopy', 0)) {
+        if (\Xmf\Request::getBool('savecopy', false, 'POST')) {
             //PMs are by default not saved in outbox
             $pm->setVar('from_delete', 0);
         }
@@ -248,8 +252,8 @@ if ($op === 'submit') {
         }
         $pmform->addElement(new XoopsFormHidden('to_userid', $sendModRecipient));
         $pmform->addElement(new XoopsFormLabel(_PM_TO, $tmpUname));
-        $subject = $myts->htmlSpecialChars(XoopsRequest::getString('subject', '', 'POST'));
-        $message = $myts->htmlSpecialChars(XoopsRequest::getString('message', '', 'POST'));
+        $subject = $myts->htmlSpecialChars(\Xmf\Request::getString('subject', '', 'POST'));
+        $message = $myts->htmlSpecialChars(\Xmf\Request::getString('message', '', 'POST'));
     } else {
         if ($send2 == 1) {
             $tmpUname = XoopsUser::getUnameFromId($to_userid, false);

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -212,15 +212,15 @@ if ($op === 'submit') {
         $pm_handler = xoops_getModuleHandler('message', 'pm');
         $pm         = $pm_handler->get($msg_id);
         if ($pm->getVar('to_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
-            $pm_uname = XoopsUser::getUnameFromId($pm->getVar('from_userid'));
-            $message  = "[quote]\n";
-            $message .= sprintf(_PM_USERWROTE, $pm_uname);
-            $message .= "\n" . $pm->getVar('msg_text', 'E') . "\n[/quote]";
             if (!pmCanMessageUser($pm->getVar('from_userid'))) {
                 pmRenderInvalidRecipient();
                 xoops_footer();
                 return;
             }
+            $pm_uname = XoopsUser::getUnameFromId($pm->getVar('from_userid'));
+            $message  = "[quote]\n";
+            $message .= sprintf(_PM_USERWROTE, $pm_uname);
+            $message .= "\n" . $pm->getVar('msg_text', 'E') . "\n[/quote]";
         } else {
             unset($pm);
             $reply = $send2 = 0;

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -52,11 +52,10 @@ function pmGetModule()
  *
  * @return array
  */
-function pmGetAllowedRecipientGroups()
+function pmGetAllowedRecipientGroups(): array
 {
     static $groups = null;
     if ($groups === null) {
-        $groups = [];
         $module = pmGetModule();
         if ($module instanceof XoopsModule) {
             $grouppermHandler = xoops_getHandler('groupperm');
@@ -64,6 +63,9 @@ function pmGetAllowedRecipientGroups()
             if (!in_array(XOOPS_GROUP_ADMIN, $groups, true)) {
                 $groups[] = XOOPS_GROUP_ADMIN;
             }
+        } else {
+            // Fail closed: only admin can send if PM module lookup fails
+            $groups = [defined('XOOPS_GROUP_ADMIN') ? (int) XOOPS_GROUP_ADMIN : 1];
         }
     }
 

--- a/htdocs/modules/pm/pmlite.php
+++ b/htdocs/modules/pm/pmlite.php
@@ -104,11 +104,15 @@ function pmCanMessageUser($uid)
  *
  * @return void
  */
-function pmRenderInvalidRecipient()
+function pmRenderInvalidRecipient(): void
 {
-    echo '<br><br><div><h4>' . _PM_USERNOPERM . '<br>';
-    echo _PM_PLZTRYAGAIN . '</h4><br>';
-    echo "[ <a href='javascript:history.go(-1)'>" . _PM_GOBACK . '</a> ]</div>';
+    $noPermMsg  = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
+    $tryAgain   = defined('_PM_PLZTRYAGAIN') ? _PM_PLZTRYAGAIN : 'Please try again.';
+    $goBack     = defined('_PM_GOBACK') ? _PM_GOBACK : 'Go back';
+
+    echo '<br><br><div><h4>' . $noPermMsg . '<br>';
+    echo $tryAgain . '</h4><br>';
+    echo "[ <a href='javascript:history.go(-1)'>" . $goBack . '</a> ]</div>';
 }
 
 $op = XoopsRequest::getCmd('op', '', 'POST');
@@ -219,7 +223,7 @@ if ($op === 'submit') {
             return;
         }
         $tmpUname = XoopsUser::getUnameFromId($sendModRecipient);
-        $pmform->addElement(new XoopsFormHidden('to_userid', XoopsRequest::getInt('to_userid', 0, 'POST')));
+        $pmform->addElement(new XoopsFormHidden('to_userid', $sendModRecipient));
         $pmform->addElement(new XoopsFormLabel(_PM_TO, $tmpUname));
         $subject = $myts->htmlSpecialChars(XoopsRequest::getString('subject', '', 'POST'));
         $message = $myts->htmlSpecialChars(XoopsRequest::getString('message', '', 'POST'));

--- a/htdocs/pmlite.php
+++ b/htdocs/pmlite.php
@@ -66,9 +66,8 @@ if (!in_array($method, $safeMethods)) {
  *
  * @return bool
  */
-function corePmCanMessageUser($uid)
+function corePmCanMessageUser(int $uid): bool
 {
-    $uid = (int) $uid;
     if ($uid <= 0) {
         return false;
     }
@@ -92,13 +91,12 @@ function corePmCanMessageUser($uid)
  *
  * @return array
  */
-function corePmGetAllowedGroups()
+function corePmGetAllowedGroups(): array
 {
     static $groups = null;
     if ($groups !== null) {
         return $groups;
     }
-    $groups = [];
     $moduleHandler = xoops_getHandler('module');
     $pmModule = $moduleHandler->getByDirname('pm');
     if ($pmModule instanceof XoopsModule) {
@@ -107,6 +105,9 @@ function corePmGetAllowedGroups()
         if (!in_array(XOOPS_GROUP_ADMIN, $groups, true)) {
             $groups[] = XOOPS_GROUP_ADMIN;
         }
+    } else {
+        // Fail closed: only admin can send if PM module lookup fails
+        $groups = [defined('XOOPS_GROUP_ADMIN') ? (int) XOOPS_GROUP_ADMIN : 1];
     }
 
     return $groups;

--- a/htdocs/pmlite.php
+++ b/htdocs/pmlite.php
@@ -71,16 +71,19 @@ function corePmCanMessageUser(int $uid): bool
     if ($uid <= 0) {
         return false;
     }
+    /** @var XoopsModuleHandler $moduleHandler */
     $moduleHandler = xoops_getHandler('module');
     $pmModule = $moduleHandler->getByDirname('pm');
     if (!$pmModule instanceof XoopsModule) {
         return false; // Fail closed: PM module not found
     }
+    /** @var XoopsMemberHandler $memberHandler */
     $memberHandler = xoops_getHandler('member');
     $userGroups = $memberHandler->getGroupsByUser($uid);
     if (empty($userGroups)) {
         return false;
     }
+    /** @var XoopsGroupPermHandler $grouppermHandler */
     $grouppermHandler = xoops_getHandler('groupperm');
 
     return $grouppermHandler->checkRight('module_read', $pmModule->getVar('mid'), $userGroups);
@@ -111,9 +114,11 @@ function corePmGetAllowedGroups(): array
     if ($groups !== null) {
         return $groups;
     }
+    /** @var XoopsModuleHandler $moduleHandler */
     $moduleHandler = xoops_getHandler('module');
     $pmModule = $moduleHandler->getByDirname('pm');
     if ($pmModule instanceof XoopsModule) {
+        /** @var XoopsGroupPermHandler $grouppermHandler */
         $grouppermHandler = xoops_getHandler('groupperm');
         $groups = array_values(array_unique(array_map('intval', $grouppermHandler->getGroupIds('module_read', $pmModule->getVar('mid')))));
         if (!in_array(XOOPS_GROUP_ADMIN, $groups, true)) {

--- a/htdocs/pmlite.php
+++ b/htdocs/pmlite.php
@@ -188,17 +188,26 @@ if (is_object($xoopsUser)) {
                 $reply = $send2 = 0;
             }
         }
-        if (1 == $send2 && !corePmCanMessageUser($to_userid)) {
-            corePmRenderInvalidRecipient();
-            xoops_footer();
-            exit;
+        if (1 == $send2) {
+            $to_username = XoopsUser::getUnameFromId($to_userid);
+            if (empty($to_username)) {
+                echo '<br><br><div><h4>' . _PM_USERNOEXIST . '<br>';
+                echo _PM_PLZTRYAGAIN . '</h4><br>';
+                echo "[ <a href='javascript:history.go(-1)' title=''>" . _PM_GOBACK . '</a> ]</div>';
+                xoops_footer();
+                exit;
+            }
+            if (!corePmCanMessageUser($to_userid)) {
+                corePmRenderInvalidRecipient();
+                xoops_footer();
+                exit;
+            }
         }
         $pmform = new XoopsThemeForm('', 'coolsus', 'pmlite.php', 'post', true);
         if (1 == $reply) {
             $pmform->addElement(new XoopsFormLabel(_PM_TO, $pm_uname));
             $pmform->addElement(new XoopsFormHidden('to_userid', $pm->getVar('from_userid')));
         } elseif (1 == $send2) {
-            $to_username = XoopsUser::getUnameFromId($to_userid);
             $pmform->addElement(new XoopsFormHidden('to_userid', $to_userid));
             $pmform->addElement(new XoopsFormLabel(_PM_TO, $to_username));
         } else {

--- a/htdocs/pmlite.php
+++ b/htdocs/pmlite.php
@@ -74,7 +74,7 @@ function corePmCanMessageUser(int $uid): bool
     $moduleHandler = xoops_getHandler('module');
     $pmModule = $moduleHandler->getByDirname('pm');
     if (!$pmModule instanceof XoopsModule) {
-        return true; // PM module not installed — no filtering possible
+        return false; // Fail closed: PM module not found
     }
     $memberHandler = xoops_getHandler('member');
     $userGroups = $memberHandler->getGroupsByUser($uid);
@@ -117,7 +117,7 @@ if (is_object($xoopsUser)) {
     $myts = \MyTextSanitizer::getInstance();
     if ('submit' === $op) {
         $recipientId = Request::getInt('to_userid', 0, 'POST');
-        $sql = 'SELECT COUNT(*) FROM ' . $xoopsDB->prefix('users') . ' WHERE uid=' . $recipientId;
+        $sql = 'SELECT COUNT(*) FROM ' . $xoopsDB->prefix('users') . ' WHERE uid=' . $xoopsDB->quote($recipientId);
         $result = $xoopsDB->query($sql);
         if (!$xoopsDB->isResultSet($result)) {
             throw new \RuntimeException(
@@ -200,7 +200,7 @@ if (is_object($xoopsUser)) {
             $pmform->addElement(new XoopsFormHidden('to_userid', $to_userid));
             $pmform->addElement(new XoopsFormLabel(_PM_TO, $to_username));
         } else {
-            $pmform->addElement(new XoopsFormSelectUser(_PM_TO, 'to_userid', false, $to_userid, 1, false, corePmGetAllowedGroups()));
+            $pmform->addElement(new XoopsFormSelectUser(_PM_TO, 'to_userid', false, $to_userid, 1, false, corePmGetAllowedGroups(), ['module_read' => 'pm']));
         }
 
         if (1 == $reply) {

--- a/htdocs/pmlite.php
+++ b/htdocs/pmlite.php
@@ -87,6 +87,20 @@ function corePmCanMessageUser(int $uid): bool
 }
 
 /**
+ * Render the invalid-recipient error message for the core PM entry point.
+ */
+function corePmRenderInvalidRecipient(): void
+{
+    xoops_loadLanguage('main', 'pm');
+    $noPermMsg = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
+    $tryAgain  = defined('_PM_PLZTRYAGAIN') ? _PM_PLZTRYAGAIN : 'Please try again.';
+    $goBack    = defined('_PM_GOBACK') ? _PM_GOBACK : 'Go back';
+    echo '<br><br><div><h4>' . $noPermMsg . '<br>';
+    echo $tryAgain . '</h4><br>';
+    echo "[ <a href='javascript:history.go(-1)' title=''>" . $goBack . '</a> ]</div>';
+}
+
+/**
  * Get group IDs allowed to use the PM module (for filtering the user selector).
  *
  * @return array
@@ -131,11 +145,7 @@ if (is_object($xoopsUser)) {
             echo _PM_PLZTRYAGAIN . '</h4><br>';
             echo "[ <a href='javascript:history.go(-1)' title=''>" . _PM_GOBACK . '</a> ]</div>';
         } elseif (!corePmCanMessageUser($recipientId)) {
-            xoops_loadLanguage('main', 'pm');
-            $noPermMsg = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
-            echo '<br><br><div><h4>' . $noPermMsg . '<br>';
-            echo _PM_PLZTRYAGAIN . '</h4><br>';
-            echo "[ <a href='javascript:history.go(-1)' title=''>" . _PM_GOBACK . '</a> ]</div>';
+            corePmRenderInvalidRecipient();
         } else {
             $pm_handler = xoops_getHandler('privmessage');
             $pm         = $pm_handler->create();
@@ -165,11 +175,7 @@ if (is_object($xoopsUser)) {
             $pm         = $pm_handler->get($msg_id);
             if ($pm->getVar('to_userid') == $xoopsUser->getVar('uid')) {
                 if (!corePmCanMessageUser($pm->getVar('from_userid'))) {
-                    xoops_loadLanguage('main', 'pm');
-                    $noPermMsg = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
-                    echo '<br><br><div><h4>' . $noPermMsg . '<br>';
-                    echo _PM_PLZTRYAGAIN . '</h4><br>';
-                    echo "[ <a href='javascript:history.go(-1)' title=''>" . _PM_GOBACK . '</a> ]</div>';
+                    corePmRenderInvalidRecipient();
                     xoops_footer();
                     exit;
                 }
@@ -183,11 +189,7 @@ if (is_object($xoopsUser)) {
             }
         }
         if (1 == $send2 && !corePmCanMessageUser($to_userid)) {
-            xoops_loadLanguage('main', 'pm');
-            $noPermMsg = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
-            echo '<br><br><div><h4>' . $noPermMsg . '<br>';
-            echo _PM_PLZTRYAGAIN . '</h4><br>';
-            echo "[ <a href='javascript:history.go(-1)' title=''>" . _PM_GOBACK . '</a> ]</div>';
+            corePmRenderInvalidRecipient();
             xoops_footer();
             exit;
         }

--- a/htdocs/pmlite.php
+++ b/htdocs/pmlite.php
@@ -145,7 +145,7 @@ if (is_object($xoopsUser)) {
             }
             $pm->setVar('subject', Request::getString('subject', null, 'POST'));
             $pm->setVar('msg_text', Request::getString('message', null, 'POST'));
-            $pm->setVar('to_userid', Request::getInt('to_userid', 0, 'POST'));
+            $pm->setVar('to_userid', $recipientId);
             $pm->setVar('from_userid', $xoopsUser->getVar('uid'));
             if (!$pm_handler->insert($pm)) {
                 echo $pm->getHtmlErrors();

--- a/htdocs/pmlite.php
+++ b/htdocs/pmlite.php
@@ -59,10 +59,64 @@ if (!in_array($method, $safeMethods)) {
     }
 }
 
+/**
+ * Check if a user has PM module access (for the core pmlite entry point).
+ *
+ * @param int $uid
+ *
+ * @return bool
+ */
+function corePmCanMessageUser($uid)
+{
+    $uid = (int) $uid;
+    if ($uid <= 0) {
+        return false;
+    }
+    $moduleHandler = xoops_getHandler('module');
+    $pmModule = $moduleHandler->getByDirname('pm');
+    if (!$pmModule instanceof XoopsModule) {
+        return true; // PM module not installed — no filtering possible
+    }
+    $memberHandler = xoops_getHandler('member');
+    $userGroups = $memberHandler->getGroupsByUser($uid);
+    if (empty($userGroups)) {
+        return false;
+    }
+    $grouppermHandler = xoops_getHandler('groupperm');
+
+    return $grouppermHandler->checkRight('module_read', $pmModule->getVar('mid'), $userGroups);
+}
+
+/**
+ * Get group IDs allowed to use the PM module (for filtering the user selector).
+ *
+ * @return array
+ */
+function corePmGetAllowedGroups()
+{
+    static $groups = null;
+    if ($groups !== null) {
+        return $groups;
+    }
+    $groups = [];
+    $moduleHandler = xoops_getHandler('module');
+    $pmModule = $moduleHandler->getByDirname('pm');
+    if ($pmModule instanceof XoopsModule) {
+        $grouppermHandler = xoops_getHandler('groupperm');
+        $groups = array_values(array_unique(array_map('intval', $grouppermHandler->getGroupIds('module_read', $pmModule->getVar('mid')))));
+        if (!in_array(XOOPS_GROUP_ADMIN, $groups, true)) {
+            $groups[] = XOOPS_GROUP_ADMIN;
+        }
+    }
+
+    return $groups;
+}
+
 if (is_object($xoopsUser)) {
     $myts = \MyTextSanitizer::getInstance();
     if ('submit' === $op) {
-        $sql = 'SELECT COUNT(*) FROM ' . $xoopsDB->prefix('users') . ' WHERE uid=' . Request::getInt('to_userid', 0, 'POST') . '';
+        $recipientId = Request::getInt('to_userid', 0, 'POST');
+        $sql = 'SELECT COUNT(*) FROM ' . $xoopsDB->prefix('users') . ' WHERE uid=' . $recipientId;
         $result = $xoopsDB->query($sql);
         if (!$xoopsDB->isResultSet($result)) {
             throw new \RuntimeException(
@@ -73,6 +127,12 @@ if (is_object($xoopsUser)) {
         [$count] = $xoopsDB->fetchRow($result);
         if (1 != $count) {
             echo '<br><br><div><h4>' . _PM_USERNOEXIST . '<br>';
+            echo _PM_PLZTRYAGAIN . '</h4><br>';
+            echo "[ <a href='javascript:history.go(-1)' title=''>" . _PM_GOBACK . '</a> ]</div>';
+        } elseif (!corePmCanMessageUser($recipientId)) {
+            xoops_loadLanguage('main', 'pm');
+            $noPermMsg = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
+            echo '<br><br><div><h4>' . $noPermMsg . '<br>';
             echo _PM_PLZTRYAGAIN . '</h4><br>';
             echo "[ <a href='javascript:history.go(-1)' title=''>" . _PM_GOBACK . '</a> ]</div>';
         } else {
@@ -103,6 +163,15 @@ if (is_object($xoopsUser)) {
             $pm_handler = xoops_getHandler('privmessage');
             $pm         = $pm_handler->get($msg_id);
             if ($pm->getVar('to_userid') == $xoopsUser->getVar('uid')) {
+                if (!corePmCanMessageUser($pm->getVar('from_userid'))) {
+                    xoops_loadLanguage('main', 'pm');
+                    $noPermMsg = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
+                    echo '<br><br><div><h4>' . $noPermMsg . '<br>';
+                    echo _PM_PLZTRYAGAIN . '</h4><br>';
+                    echo "[ <a href='javascript:history.go(-1)' title=''>" . _PM_GOBACK . '</a> ]</div>';
+                    xoops_footer();
+                    exit;
+                }
                 $pm_uname = XoopsUser::getUnameFromId($pm->getVar('from_userid'));
                 $message  = "[quote]\n";
                 $message .= sprintf(_PM_USERWROTE, $pm_uname);
@@ -111,6 +180,15 @@ if (is_object($xoopsUser)) {
                 unset($pm);
                 $reply = $send2 = 0;
             }
+        }
+        if (1 == $send2 && !corePmCanMessageUser($to_userid)) {
+            xoops_loadLanguage('main', 'pm');
+            $noPermMsg = defined('_PM_USERNOPERM') ? _PM_USERNOPERM : 'The selected user cannot receive private messages.';
+            echo '<br><br><div><h4>' . $noPermMsg . '<br>';
+            echo _PM_PLZTRYAGAIN . '</h4><br>';
+            echo "[ <a href='javascript:history.go(-1)' title=''>" . _PM_GOBACK . '</a> ]</div>';
+            xoops_footer();
+            exit;
         }
         $pmform = new XoopsThemeForm('', 'coolsus', 'pmlite.php', 'post', true);
         if (1 == $reply) {
@@ -121,7 +199,7 @@ if (is_object($xoopsUser)) {
             $pmform->addElement(new XoopsFormHidden('to_userid', $to_userid));
             $pmform->addElement(new XoopsFormLabel(_PM_TO, $to_username));
         } else {
-            $pmform->addElement(new XoopsFormSelectUser(_PM_TO, 'to_userid', $to_userid));
+            $pmform->addElement(new XoopsFormSelectUser(_PM_TO, 'to_userid', false, $to_userid, 1, false, corePmGetAllowedGroups()));
         }
 
         if (1 == $reply) {

--- a/htdocs/pmlite.php
+++ b/htdocs/pmlite.php
@@ -120,8 +120,8 @@ function corePmGetAllowedGroups(): array
             $groups[] = XOOPS_GROUP_ADMIN;
         }
     } else {
-        // Fail closed: only admin can send if PM module lookup fails
-        $groups = [defined('XOOPS_GROUP_ADMIN') ? (int) XOOPS_GROUP_ADMIN : 1];
+        // Fail closed: no users shown — matches corePmCanMessageUser which rejects all
+        $groups = [0];
     }
 
     return $groups;


### PR DESCRIPTION
  Users without PM module access appeared in the compose recipient
  list and could receive messages via direct URL. Compose form, popup
  user finder, and submit handler now check module_read permission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User picker/search now scopes results to module/group context, filters preselected users accordingly, and preserves context when opening the “more users” dialog (accepts extra query parameters).

* **Bug Fixes**
  * Find-users results and totals honor module-level read permissions (fail-closed when module unknown) and avoid returning disallowed users.
  * Private messaging now consistently validates recipient permissions across send/reply/display flows and blocks disallowed deliveries with a clear UI.

* **Localization**
  * Added English message for denied private-message recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->