### PR TITLE
fix(pm): delete confirmation UX, centered popups, xbootstrap5 templates

### DIFF
--- a/htdocs/include/xoops.js
+++ b/htdocs/include/xoops.js
@@ -46,11 +46,11 @@ function justReturn() {
 }
 
 function openWithSelfMain(url, name, width, height, returnwindow) {
-    var left = Math.max(0, Math.round((screen.width - width) / 2));
-    var top = Math.max(0, Math.round((screen.height - height) / 2));
-    var options = "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top + ",toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no";
+    const left = Math.max(0, Math.round((screen.width - width) / 2));
+    const top = Math.max(0, Math.round((screen.height - height) / 2));
+    const options = "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top + ",toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no";
 
-    var new_window = window.open(url, name, options);
+    const new_window = window.open(url, name, options);
     window.self.name = "main";
     new_window.focus();
     return (returnwindow != null ? new_window : void(0));

--- a/htdocs/include/xoops.js
+++ b/htdocs/include/xoops.js
@@ -46,11 +46,11 @@ function justReturn() {
 }
 
 function openWithSelfMain(url, name, width, height, returnwindow) {
-    var left = Math.max(0, Math.round((screen.width - width) / 2));
-    var top = Math.max(0, Math.round((screen.height - height) / 2));
-    var options = "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top + ",toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no";
+    const left = Math.max(0, Math.round((screen.width - width) / 2));
+    const top = Math.max(0, Math.round((screen.height - height) / 2));
+    const options = "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top + ",toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no";
 
-    var new_window = window.open(url, name, options);
+    const new_window = window.open(url, name, options);
     if (new_window) {
         window.self.name = "main";
         new_window.focus();

--- a/htdocs/include/xoops.js
+++ b/htdocs/include/xoops.js
@@ -46,7 +46,9 @@ function justReturn() {
 }
 
 function openWithSelfMain(url, name, width, height, returnwindow) {
-    var options = "width=" + width + ",height=" + height + ",toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no";
+    var left = Math.max(0, Math.round((screen.width - width) / 2));
+    var top = Math.max(0, Math.round((screen.height - height) / 2));
+    var options = "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top + ",toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no";
 
     var new_window = window.open(url, name, options);
     window.self.name = "main";

--- a/htdocs/include/xoops.js
+++ b/htdocs/include/xoops.js
@@ -51,8 +51,10 @@ function openWithSelfMain(url, name, width, height, returnwindow) {
     const options = "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top + ",toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no";
 
     const new_window = window.open(url, name, options);
-    window.self.name = "main";
-    new_window.focus();
+    if (new_window) {
+        window.self.name = "main";
+        new_window.focus();
+    }
     return (returnwindow != null ? new_window : void(0));
 }
 

--- a/htdocs/include/xoops.js
+++ b/htdocs/include/xoops.js
@@ -46,11 +46,11 @@ function justReturn() {
 }
 
 function openWithSelfMain(url, name, width, height, returnwindow) {
-    const left = Math.max(0, Math.round((screen.width - width) / 2));
-    const top = Math.max(0, Math.round((screen.height - height) / 2));
-    const options = "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top + ",toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no";
+    var left = Math.max(0, Math.round((screen.width - width) / 2));
+    var top = Math.max(0, Math.round((screen.height - height) / 2));
+    var options = "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top + ",toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no";
 
-    const new_window = window.open(url, name, options);
+    var new_window = window.open(url, name, options);
     if (new_window) {
         window.self.name = "main";
         new_window.focus();

--- a/htdocs/modules/pm/viewpmsg.php
+++ b/htdocs/modules/pm/viewpmsg.php
@@ -44,16 +44,18 @@ if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'PO
     } elseif (Request::getInt('ok', 0, 'POST') === 0) {
         $postedIds  = array_map('intval', Request::getArray('msg_id', [], 'POST'));
         $currentUid = (int) $xoopsUser->getVar('uid');
-        // Build confirmation list and filter to IDs the current user actually owns
-        $confirmMsg     = _PM_SURE_TO_DELETE;
-        $allowedIds     = [];
+        // Bulk-fetch selected PMs in one query instead of N+1
+        $confirmMsg = _PM_SURE_TO_DELETE;
+        $allowedIds = [];
         if (!empty($postedIds)) {
+            $criteria = new Criteria('msg_id', '(' . implode(',', $postedIds) . ')', 'IN');
+            $pmObjects = $pm_handler->getObjects($criteria, true);
             $confirmMsg .= '<ul>';
             foreach ($postedIds as $delId) {
-                $delPm = $pm_handler->get($delId);
-                if (!is_object($delPm)) {
+                if (!isset($pmObjects[$delId])) {
                     continue;
                 }
+                $delPm   = $pmObjects[$delId];
                 $toUid   = (int) $delPm->getVar('to_userid');
                 $fromUid = (int) $delPm->getVar('from_userid');
                 if ($toUid !== $currentUid && $fromUid !== $currentUid) {

--- a/htdocs/modules/pm/viewpmsg.php
+++ b/htdocs/modules/pm/viewpmsg.php
@@ -42,26 +42,27 @@ if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'PO
     if (!$GLOBALS['xoopsSecurity']->check()) {
         $GLOBALS['xoopsTpl']->assign('errormsg', implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
     } elseif (Request::getInt('ok', 0, 'POST') === 0) {
-        $deleteIds = array_map('intval', Request::getArray('msg_id', [], 'POST'));
-        // Build confirmation message listing the selected message subjects
-        $confirmMsg = _PM_SURE_TO_DELETE;
+        $postedIds  = array_map('intval', Request::getArray('msg_id', [], 'POST'));
         $currentUid = (int) $xoopsUser->getVar('uid');
-        if (!empty($deleteIds)) {
+        // Build confirmation list and filter to IDs the current user actually owns
+        $confirmMsg     = _PM_SURE_TO_DELETE;
+        $allowedIds     = [];
+        if (!empty($postedIds)) {
             $confirmMsg .= '<ul>';
-            foreach ($deleteIds as $delId) {
+            foreach ($postedIds as $delId) {
                 $delPm = $pm_handler->get($delId);
                 if (!is_object($delPm)) {
                     continue;
                 }
                 $toUid   = (int) $delPm->getVar('to_userid');
                 $fromUid = (int) $delPm->getVar('from_userid');
-                // Allow if current user is recipient or sender (inbox, outbox, savebox)
                 if ($toUid !== $currentUid && $fromUid !== $currentUid) {
                     continue;
                 }
-                // Show the counterpart user
+                $allowedIds[] = $delId;
                 $otherUid  = ($toUid === $currentUid) ? $fromUid : $toUid;
-                $otherName = htmlspecialchars((string) XoopsUser::getUnameFromId($otherUid), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                // getUnameFromId() already escapes — do not double-escape
+                $otherName = XoopsUser::getUnameFromId($otherUid);
                 $subject   = htmlspecialchars($delPm->getVar('subject', 'n'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
                 $confirmMsg .= '<li>' . $subject . ' — <em>' . $otherName . '</em></li>';
             }
@@ -72,7 +73,7 @@ if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'PO
                 'ok'              => 1,
                 'delete_messages' => 1,
                 'op'              => $op,
-                'msg_ids'         => json_encode($deleteIds),
+                'msg_ids'         => json_encode($allowedIds),
             ],
             $_SERVER['REQUEST_URI'],
             $confirmMsg,

--- a/htdocs/modules/pm/viewpmsg.php
+++ b/htdocs/modules/pm/viewpmsg.php
@@ -83,17 +83,17 @@ if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'PO
         include $GLOBALS['xoops']->path('footer.php');
         exit();
     } else {
-        $clean_msg_id = json_decode(Request::getString('msg_ids', '', 'POST'), true, 2);
-        if (!empty($clean_msg_id)) {
-            $clean_msg_id = array_map('intval', $clean_msg_id);
-        }
-        $size = count($clean_msg_id);
-        $msg  = & $clean_msg_id;
-        for ($i = 0; $i < $size; ++$i) {
-            $pm = $pm_handler->get($msg[$i]);
-            if ($pm->getVar('to_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
+        $decoded = json_decode(Request::getString('msg_ids', '', 'POST'), true, 2);
+        $clean_msg_id = is_array($decoded) ? array_map('intval', $decoded) : [];
+        $currentUid = (int) $GLOBALS['xoopsUser']->getVar('uid');
+        foreach ($clean_msg_id as $msgId) {
+            $pm = $pm_handler->get($msgId);
+            if (!is_object($pm)) {
+                continue;
+            }
+            if ((int) $pm->getVar('to_userid') === $currentUid) {
                 $pm_handler->setTodelete($pm);
-            } elseif ($pm->getVar('from_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
+            } elseif ((int) $pm->getVar('from_userid') === $currentUid) {
                 $pm_handler->setFromdelete($pm);
             }
             unset($pm);

--- a/htdocs/modules/pm/viewpmsg.php
+++ b/htdocs/modules/pm/viewpmsg.php
@@ -42,7 +42,7 @@ if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'PO
     if (!$GLOBALS['xoopsSecurity']->check()) {
         $GLOBALS['xoopsTpl']->assign('errormsg', implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
     } elseif (Request::getInt('ok', 0, 'POST') === 0) {
-        $postedIds  = array_map('intval', Request::getArray('msg_id', [], 'POST'));
+        $postedIds  = array_values(array_unique(array_map('intval', Request::getArray('msg_id', [], 'POST'))));
         $currentUid = (int) $xoopsUser->getVar('uid');
         // Bulk-fetch selected PMs in one query instead of N+1
         $confirmMsg = _PM_SURE_TO_DELETE;

--- a/htdocs/modules/pm/viewpmsg.php
+++ b/htdocs/modules/pm/viewpmsg.php
@@ -42,15 +42,29 @@ if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'PO
     if (!$GLOBALS['xoopsSecurity']->check()) {
         $GLOBALS['xoopsTpl']->assign('errormsg', implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
     } elseif (Request::getInt('ok', 0, 'POST') === 0) {
+        $deleteIds = array_map('intval', Request::getArray('msg_id', [], 'POST'));
+        // Build confirmation message listing the selected message subjects
+        $confirmMsg = _PM_SURE_TO_DELETE;
+        if (!empty($deleteIds)) {
+            $confirmMsg .= '<ul>';
+            foreach ($deleteIds as $delId) {
+                $delPm = $pm_handler->get($delId);
+                if (is_object($delPm) && $delPm->getVar('to_userid') == $xoopsUser->getVar('uid')) {
+                    $confirmMsg .= '<li>' . htmlspecialchars($delPm->getVar('subject', 'n'), ENT_QUOTES | ENT_HTML5)
+                        . ' — <em>' . XoopsUser::getUnameFromId($delPm->getVar('from_userid')) . '</em></li>';
+                }
+            }
+            $confirmMsg .= '</ul>';
+        }
         xoops_confirm(
             [
                 'ok'              => 1,
                 'delete_messages' => 1,
                 'op'              => $op,
-                'msg_ids'         => json_encode(array_map('intval', Request::getArray('msg_id', [], 'POST'))),
+                'msg_ids'         => json_encode($deleteIds),
             ],
             $_SERVER['REQUEST_URI'],
-            _PM_SURE_TO_DELETE,
+            $confirmMsg,
         );
         include $GLOBALS['xoops']->path('footer.php');
         exit();

--- a/htdocs/modules/pm/viewpmsg.php
+++ b/htdocs/modules/pm/viewpmsg.php
@@ -45,14 +45,25 @@ if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'PO
         $deleteIds = array_map('intval', Request::getArray('msg_id', [], 'POST'));
         // Build confirmation message listing the selected message subjects
         $confirmMsg = _PM_SURE_TO_DELETE;
+        $currentUid = (int) $xoopsUser->getVar('uid');
         if (!empty($deleteIds)) {
             $confirmMsg .= '<ul>';
             foreach ($deleteIds as $delId) {
                 $delPm = $pm_handler->get($delId);
-                if (is_object($delPm) && $delPm->getVar('to_userid') == $xoopsUser->getVar('uid')) {
-                    $confirmMsg .= '<li>' . htmlspecialchars($delPm->getVar('subject', 'n'), ENT_QUOTES | ENT_HTML5)
-                        . ' — <em>' . XoopsUser::getUnameFromId($delPm->getVar('from_userid')) . '</em></li>';
+                if (!is_object($delPm)) {
+                    continue;
                 }
+                $toUid   = (int) $delPm->getVar('to_userid');
+                $fromUid = (int) $delPm->getVar('from_userid');
+                // Allow if current user is recipient or sender (inbox, outbox, savebox)
+                if ($toUid !== $currentUid && $fromUid !== $currentUid) {
+                    continue;
+                }
+                // Show the counterpart user
+                $otherUid  = ($toUid === $currentUid) ? $fromUid : $toUid;
+                $otherName = htmlspecialchars((string) XoopsUser::getUnameFromId($otherUid), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $subject   = htmlspecialchars($delPm->getVar('subject', 'n'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $confirmMsg .= '<li>' . $subject . ' — <em>' . $otherName . '</em></li>';
             }
             $confirmMsg .= '</ul>';
         }

--- a/htdocs/themes/xbootstrap5/css/modules/pm.css
+++ b/htdocs/themes/xbootstrap5/css/modules/pm.css
@@ -26,3 +26,25 @@
 .message-current-tab div.alert {
     padding: 10px 30px 10px 10px;
 }
+
+/* PM action buttons — styled via name attribute for renderer independence */
+.pm-actions [name="move_messages"],
+.pm-actions [name="empty_messages"] {
+    background-color: transparent;
+    border-color: var(--bs-secondary);
+    color: var(--bs-secondary);
+}
+.pm-actions [name="move_messages"]:hover,
+.pm-actions [name="empty_messages"]:hover {
+    background-color: var(--bs-secondary);
+    color: #fff;
+}
+.pm-actions [name="delete_messages"] {
+    background-color: transparent;
+    border-color: var(--bs-danger);
+    color: var(--bs-danger);
+}
+.pm-actions [name="delete_messages"]:hover {
+    background-color: var(--bs-danger);
+    color: #fff;
+}

--- a/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
+++ b/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
@@ -106,10 +106,10 @@
     </table>
 
     <{if $display|default:false}>
-    <div class="d-flex gap-2 mt-2">
-        <{$pmform.elements.move_messages.body|replace:'btn btn-secondary':'btn btn-outline-secondary'}>
-        <{$pmform.elements.delete_messages.body|replace:'btn btn-secondary':'btn btn-outline-danger'}>
-        <{$pmform.elements.empty_messages.body|replace:'btn btn-secondary':'btn btn-outline-secondary'}>
+    <div class="d-flex gap-2 mt-2 pm-actions">
+        <{$pmform.elements.move_messages.body}>
+        <{$pmform.elements.delete_messages.body}>
+        <{$pmform.elements.empty_messages.body}>
     </div>
     <{/if}>
 

--- a/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
+++ b/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
@@ -38,7 +38,7 @@
         <thead class="table-light">
             <tr>
                 <th class="text-center" style="width: 3rem;">
-                    <input name="allbox" id="allbox" onclick='xoopsCheckAll("<{$pmform.name}>", "allbox");' type="checkbox" value="Check All" class="form-check-input" aria-label="<{$smarty.const.THEME_SELECT_ALL|default:'Select all'|escape:'htmlall':'UTF-8'}>">
+                    <input name="allbox" id="allbox" onclick='xoopsCheckAll("<{$pmform.name}>", "allbox");' type="checkbox" value="Check All" class="form-check-input" aria-label="<{$smarty.const._ALL|escape:'htmlall':'UTF-8'}>">
                 </th>
                 <th class="text-center d-none d-sm-table-cell" style="width: 2.5rem;">
                     <span class="fa-solid fa-envelope text-primary"></span>
@@ -73,7 +73,7 @@
                     </td>
                     <td class="align-middle">
                         <{if $message.postername|default:'' != ''}>
-                            <a href="<{$xoops_url}>/userinfo.php?uid=<{$message.posteruid}>"><{$message.postername}></a>
+                            <a href="<{$xoops_url}>/userinfo.php?uid=<{$message.posteruid}>"><{$message.postername|escape:'htmlall':'UTF-8'}></a>
                         <{else}>
                             <{$anonymous}>
                         <{/if}>

--- a/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
+++ b/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
@@ -48,7 +48,7 @@
         <thead class="table-light">
             <tr>
                 <th class="text-center" style="width: 3rem;">
-                    <input name="allbox" id="allbox" onclick='xoopsCheckAll("<{$pmform.name}>", "allbox");' type="checkbox" value="Check All" class="form-check-input">
+                    <input name="allbox" id="allbox" onclick='xoopsCheckAll("<{$pmform.name}>", "allbox");' type="checkbox" value="Check All" class="form-check-input" aria-label="Select all messages">
                 </th>
                 <th class="text-center d-none d-sm-table-cell" style="width: 2.5rem;">
                     <span class="fa-solid fa-envelope text-primary"></span>
@@ -107,9 +107,9 @@
 
     <{if $display|default:false}>
     <div class="d-flex gap-2 mt-2">
-        <{$pmform.elements.move_messages.body|replace:'formButton':'btn btn-outline-secondary'}>
-        <{$pmform.elements.delete_messages.body|replace:'formButton':'btn btn-outline-danger'}>
-        <{$pmform.elements.empty_messages.body|replace:'formButton':'btn btn-outline-secondary'}>
+        <{$pmform.elements.move_messages.body|replace:'btn btn-secondary':'btn btn-outline-secondary'}>
+        <{$pmform.elements.delete_messages.body|replace:'btn btn-secondary':'btn btn-outline-danger'}>
+        <{$pmform.elements.empty_messages.body|replace:'btn btn-secondary':'btn btn-outline-secondary'}>
     </div>
     <{/if}>
 

--- a/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
+++ b/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
@@ -14,7 +14,7 @@
     </div>
 <{/if}>
 
-<{if isset($pmform)}>
+<{if $pmform|default:false}>
 
 <{if $pagenav|default:false}>
     <div class="mb-2 text-end"><{$pagenav}></div>
@@ -105,7 +105,7 @@
         </tbody>
     </table>
 
-    <{if isset($display)}>
+    <{if $display|default:false}>
     <div class="d-flex gap-2 mt-2">
         <{$pmform.elements.move_messages.body|replace:'formButton':'btn btn-outline-secondary'}>
         <{$pmform.elements.delete_messages.body|replace:'formButton':'btn btn-outline-danger'}>
@@ -124,4 +124,4 @@
     <div class="mt-2 text-end"><{$pagenav}></div>
 <{/if}>
 
-<{/if}><{* /isset($pmform) *}>
+<{/if}><{* /$pmform *}>

--- a/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
+++ b/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
@@ -2,14 +2,14 @@
 
 <{if $msg|default:''}>
     <div class="alert alert-success alert-dismissible fade show">
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="<{$smarty.const._CLOSE|escape:'htmlall':'UTF-8'}>"></button>
         <strong><{$msg}></strong>
     </div>
 <{/if}>
 
 <{if $errormsg|default:''}>
     <div class="alert alert-danger alert-dismissible fade show">
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="<{$smarty.const._CLOSE|escape:'htmlall':'UTF-8'}>"></button>
         <strong><{$errormsg}></strong>
     </div>
 <{/if}>
@@ -38,7 +38,7 @@
         <thead class="table-light">
             <tr>
                 <th class="text-center" style="width: 3rem;">
-                    <input name="allbox" id="allbox" onclick='xoopsCheckAll("<{$pmform.name}>", "allbox");' type="checkbox" value="Check All" class="form-check-input" aria-label="<{$smarty.const.THEME_SELECT_ALL|default:'Select all'}>">
+                    <input name="allbox" id="allbox" onclick='xoopsCheckAll("<{$pmform.name}>", "allbox");' type="checkbox" value="Check All" class="form-check-input" aria-label="<{$smarty.const.THEME_SELECT_ALL|default:'Select all'|escape:'htmlall':'UTF-8'}>">
                 </th>
                 <th class="text-center d-none d-sm-table-cell" style="width: 2.5rem;">
                     <span class="fa-solid fa-envelope text-primary"></span>

--- a/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
+++ b/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
@@ -1,147 +1,127 @@
 <h4><{$smarty.const._PM_PRIVATEMESSAGE}></h4>
-<div class="current-tab">
-    <div class="row">
-        <{if $op == "out"}>
-            <div class="col-6 col-md-6">
-                <a class="btn btn-info w-100" href="viewpmsg.php?op=in" title="<{$smarty.const._PM_INBOX}>"><{$smarty.const._PM_INBOX}></a>
-            </div>
-            <div class="col-6 col-md-6">
-                <a class="btn btn-info w-100" href="viewpmsg.php?op=save" title="<{$smarty.const._PM_SAVEBOX}>"><{$smarty.const._PM_SAVEBOX}></a>
-            </div>
-        <{elseif $op == "save"}>
-            <div class="col-6 col-md-6">
-                <a class="btn btn-info w-100" href="viewpmsg.php?op=in" title="<{$smarty.const._PM_INBOX}>"><{$smarty.const._PM_INBOX}></a>
-            </div>
-            <div class="col-6 col-md-6">
-                <a class="btn btn-info w-100" href="viewpmsg.php?op=out" title="<{$smarty.const._PM_OUTBOX}>"><{$smarty.const._PM_OUTBOX}></a>
-            </div>
-        <{elseif $op == "in"}>
-            <div class="col-6 col-md-6">
-                <a class="btn btn-info w-100" href="viewpmsg.php?op=out" title="<{$smarty.const._PM_OUTBOX}>"><{$smarty.const._PM_OUTBOX}></a>
-            </div>
-            <div class="col-6 col-md-6">
-                <a class="btn btn-info w-100" href="viewpmsg.php?op=save" title="<{$smarty.const._PM_SAVEBOX}>"><{$smarty.const._PM_SAVEBOX}></a>
-            </div>
-        <{/if}>
-    </div>
-</div><!-- .current-tab -->
-
-<div class="message-current-tab">
-    <{if $op == "out"}>
-        <div class="alert alert-success alert-dismissable">
-            <button type="button" class="close" data-bs-dismiss="alert" aria-hidden="true">×</button>
-            <strong><{$smarty.const._PM_OUTBOX}></strong>
-        </div>
-    <{elseif $op == "save"}>
-        <div class="alert alert-success alert-dismissable">
-            <button type="button" class="close" data-bs-dismiss="alert" aria-hidden="true">×</button>
-            <strong><{$smarty.const._PM_SAVEBOX}></strong>
-        </div>
-    <{else}>
-        <div class="alert alert-success alert-dismissable">
-            <button type="button" class="close" data-bs-dismiss="alert" aria-hidden="true">×</button>
-            <strong><{$smarty.const._PM_INBOX}></strong>
-        </div>
-    <{/if}>
-</div><!-- .message-current-tab -->
 
 <{if $msg|default:''}>
-    <div class="alert alert-info alert-dismissable">
-        <button type="button" class="close" data-bs-dismiss="alert" aria-hidden="true">×</button>
+    <div class="alert alert-success alert-dismissible fade show">
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         <strong><{$msg}></strong>
     </div>
 <{/if}>
 
 <{if $errormsg|default:''}>
-    <div class="alert alert-danger alert-dismissable">
-        <button type="button" class="close" data-bs-dismiss="alert" aria-hidden="true">×</button>
+    <div class="alert alert-danger alert-dismissible fade show">
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         <strong><{$errormsg}></strong>
     </div>
 <{/if}>
 
+<{if isset($pmform)}>
+
 <{if $pagenav|default:false}>
-    <{$pagenav}>
+    <div class="mb-2 text-end"><{$pagenav}></div>
 <{/if}>
 
-<form name="<{$pmform.name}>" id="<{$pmform.name}>" action="<{$pmform.action}>" method="<{$pmform.method}>" <{$pmform.extra}>="">
-<div class="row xoops-message-list">
-<div class="xoops-message-header">
-<div class="col-3 col-md-2">
-<input name="allbox" id="allbox" onclick="xoopsCheckAll(&quot;<{$pmform.name}>&quot;, &quot;allbox&quot;);" type="checkbox" value="Check All">
-&nbsp;
-<span class="fa-solid fa-circle-down btn btn-sm btn-primary"></span>
-</div>
+<form name="<{$pmform.name}>" id="<{$pmform.name}>" action="<{$pmform.action}>" method="<{$pmform.method}>" <{$pmform.extra}>>
 
-<{if $op == "out"}>
-<div class="col-2 col-md-2"><strong><{$smarty.const._PM_TO}></strong></div>
-<{else}>
-<div class="col-2 col-md-2"><strong><{$smarty.const._PM_FROM}></strong></div>
-<{/if}>
+    <div class="mb-3">
+        <{$pmform.elements.send.body}>
+    </div>
 
-<div class="col-4 col-md-5"><strong><{$smarty.const._PM_SUBJECT}></strong></div>
-
-<div class="col-3 col-md-3"><strong><{$smarty.const._PM_DATE}></strong></div>
-
-</div><!-- .xoops-message-header -->
-
-<{if $total_messages == 0}>
-    <div class="col-md-12">
-        <div class="alert alert-warning">
-            <{$smarty.const._PM_YOUDONTHAVE}>
+    <div class="row mb-3">
+        <div class="col-12 btn-group" role="group">
+            <{if $op == "in" || (!($op == "out") && !($op == "save"))}>
+                <a class="btn btn-primary" href="viewpmsg.php?op=in"><span class="fa-solid fa-inbox fa-fw"></span> <{$smarty.const._PM_INBOX}></a>
+                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=out"><span class="fa-solid fa-paper-plane fa-fw"></span> <{$smarty.const._PM_OUTBOX}></a>
+                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=save"><span class="fa-solid fa-box-archive fa-fw"></span> <{$smarty.const._PM_SAVEBOX}></a>
+            <{elseif $op == "out"}>
+                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=in"><span class="fa-solid fa-inbox fa-fw"></span> <{$smarty.const._PM_INBOX}></a>
+                <a class="btn btn-primary" href="viewpmsg.php?op=out"><span class="fa-solid fa-paper-plane fa-fw"></span> <{$smarty.const._PM_OUTBOX}></a>
+                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=save"><span class="fa-solid fa-box-archive fa-fw"></span> <{$smarty.const._PM_SAVEBOX}></a>
+            <{elseif $op == "save"}>
+                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=in"><span class="fa-solid fa-inbox fa-fw"></span> <{$smarty.const._PM_INBOX}></a>
+                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=out"><span class="fa-solid fa-paper-plane fa-fw"></span> <{$smarty.const._PM_OUTBOX}></a>
+                <a class="btn btn-primary" href="viewpmsg.php?op=save"><span class="fa-solid fa-box-archive fa-fw"></span> <{$smarty.const._PM_SAVEBOX}></a>
+            <{/if}>
         </div>
     </div>
-<{/if}>
-</div><!-- .xoops-message-list -->
 
-<{foreach item=message from=$messages|default:null}>
-    <div class="row xoops-message-list xoops-message-loop">
-        <div class="col-3 col-md-2">
-            <input type="checkbox" id="msg_id_<{$message.msg_id}>" name="msg_id[]" value="<{$message.msg_id}>">
-            &nbsp;
-            <{if $message.read_msg == 1}>
-                <span class="fa-solid fa-check btn btn-sm btn-success"></span>
-            <{else}>
-                <span class="fa-solid fa-envelope btn btn-sm btn-warning" title="<{$smarty.const._PM_NOTREAD}>"></span>
+    <table class="table table-hover">
+        <thead class="table-light">
+            <tr>
+                <th class="text-center" style="width: 3rem;">
+                    <input name="allbox" id="allbox" onclick='xoopsCheckAll("<{$pmform.name}>", "allbox");' type="checkbox" value="Check All" class="form-check-input">
+                </th>
+                <th class="text-center d-none d-sm-table-cell" style="width: 2.5rem;">
+                    <span class="fa-solid fa-envelope text-primary"></span>
+                </th>
+                <{if $op == "out"}>
+                    <th><{$smarty.const._PM_TO}></th>
+                <{else}>
+                    <th><{$smarty.const._PM_FROM}></th>
+                <{/if}>
+                <th><{$smarty.const._PM_SUBJECT}></th>
+                <th class="d-none d-md-table-cell"><{$smarty.const._PM_DATE}></th>
+            </tr>
+        </thead>
+        <tbody>
+            <{if $total_messages == 0}>
+                <tr>
+                    <td colspan="5" class="text-center text-muted py-3"><{$smarty.const._PM_YOUDONTHAVE}></td>
+                </tr>
             <{/if}>
-            <{if $message.msg_image|default:'' != ''}>
-                <img src="<{$xoops_url}>/images/subject/<{$message.msg_image}>" alt="">
-            <{/if}>
-        </div>
-        <div class="col-2 col-md-2">
-            <{if $message.postername|default:'' != ''}>
-                <a href="<{$xoops_url}>/userinfo.php?uid=<{$message.posteruid}>" title=""><{$message.postername}></a>
-            <{else}>
-                <{$anonymous}>
-            <{/if}>
-        </div>
 
-        <div class="col-4 col-md-5">
-            <a href="readpmsg.php?msg_id=<{$message.msg_id}>&start=<{$message.msg_no}>&total_messages=<{$total_messages}>&op=<{$op}>" title="">
-                <{$message.subject}>
-            </a>
-        </div>
+            <{foreach item=message from=$messages|default:null}>
+                <tr>
+                    <td class="text-center align-middle">
+                        <input type="checkbox" id="msg_id_<{$message.msg_id}>" name="msg_id[]" value="<{$message.msg_id}>" class="form-check-input">
+                    </td>
+                    <td class="text-center align-middle d-none d-sm-table-cell">
+                        <{if $message.read_msg == 1}>
+                            <span class="fa-solid fa-envelope-open text-secondary"></span>
+                        <{else}>
+                            <span class="fa-solid fa-envelope text-primary"></span>
+                        <{/if}>
+                    </td>
+                    <td class="align-middle">
+                        <{if $message.postername|default:'' != ''}>
+                            <a href="<{$xoops_url}>/userinfo.php?uid=<{$message.posteruid}>"><{$message.postername}></a>
+                        <{else}>
+                            <{$anonymous}>
+                        <{/if}>
+                    </td>
+                    <td class="align-middle">
+                        <{if $message.msg_image|default:'' != ''}>
+                            <img src="<{$xoops_url}>/images/subject/<{$message.msg_image}>" alt="">
+                        <{/if}>
+                        <a href="readpmsg.php?msg_id=<{$message.msg_id}>&amp;start=<{$message.msg_no}>&amp;total_messages=<{$total_messages}>&amp;op=<{$op}>">
+                            <{$message.subject}>
+                        </a>
+                        <div class="d-md-none text-muted small"><{$message.msg_time}></div>
+                    </td>
+                    <td class="align-middle d-none d-md-table-cell">
+                        <{$message.msg_time}>
+                    </td>
+                </tr>
+            <{/foreach}>
+        </tbody>
+    </table>
 
-        <div class="col-3 col-md-3">
-            <{$message.msg_time}>
-        </div>
+    <{if isset($display)}>
+    <div class="d-flex gap-2 mt-2">
+        <{$pmform.elements.move_messages.body|replace:'formButton':'btn btn-outline-secondary'}>
+        <{$pmform.elements.delete_messages.body|replace:'formButton':'btn btn-outline-danger'}>
+        <{$pmform.elements.empty_messages.body|replace:'formButton':'btn btn-outline-secondary'}>
     </div>
-    <!-- .xoops-message-list -->
-<{/foreach}>
-
-<{$pmform.elements.send.body}>
-<{if isset($display)}>
-    <{$pmform.elements.move_messages.body}>
-    <{$pmform.elements.delete_messages.body}>
-    <{$pmform.elements.empty_messages.body}>
-<{/if}>
-
-<{foreach item=element from=$pmform.elements|default:null}>
-    <{if $element.hidden == 1}>
-        <{$element.body}>
     <{/if}>
-<{/foreach}>
+
+    <{foreach item=element from=$pmform.elements|default:null}>
+        <{if $element.hidden == 1}>
+            <{$element.body}>
+        <{/if}>
+    <{/foreach}>
 </form>
 
 <{if $pagenav|default:false}>
-    <{$pagenav}>
+    <div class="mt-2 text-end"><{$pagenav}></div>
 <{/if}>
+
+<{/if}><{* /isset($pmform) *}>

--- a/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
+++ b/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
@@ -28,19 +28,9 @@
 
     <div class="row mb-3">
         <div class="col-12 btn-group" role="group">
-            <{if $op == "in" || (!($op == "out") && !($op == "save"))}>
-                <a class="btn btn-primary" href="viewpmsg.php?op=in"><span class="fa-solid fa-inbox fa-fw"></span> <{$smarty.const._PM_INBOX}></a>
-                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=out"><span class="fa-solid fa-paper-plane fa-fw"></span> <{$smarty.const._PM_OUTBOX}></a>
-                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=save"><span class="fa-solid fa-box-archive fa-fw"></span> <{$smarty.const._PM_SAVEBOX}></a>
-            <{elseif $op == "out"}>
-                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=in"><span class="fa-solid fa-inbox fa-fw"></span> <{$smarty.const._PM_INBOX}></a>
-                <a class="btn btn-primary" href="viewpmsg.php?op=out"><span class="fa-solid fa-paper-plane fa-fw"></span> <{$smarty.const._PM_OUTBOX}></a>
-                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=save"><span class="fa-solid fa-box-archive fa-fw"></span> <{$smarty.const._PM_SAVEBOX}></a>
-            <{elseif $op == "save"}>
-                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=in"><span class="fa-solid fa-inbox fa-fw"></span> <{$smarty.const._PM_INBOX}></a>
-                <a class="btn btn-outline-secondary" href="viewpmsg.php?op=out"><span class="fa-solid fa-paper-plane fa-fw"></span> <{$smarty.const._PM_OUTBOX}></a>
-                <a class="btn btn-primary" href="viewpmsg.php?op=save"><span class="fa-solid fa-box-archive fa-fw"></span> <{$smarty.const._PM_SAVEBOX}></a>
-            <{/if}>
+            <a class="btn <{if $op == 'in' || ($op != 'out' && $op != 'save')}>btn-primary<{else}>btn-outline-secondary<{/if}>" href="viewpmsg.php?op=in"><span class="fa-solid fa-inbox fa-fw"></span> <{$smarty.const._PM_INBOX}></a>
+            <a class="btn <{if $op == 'out'}>btn-primary<{else}>btn-outline-secondary<{/if}>" href="viewpmsg.php?op=out"><span class="fa-solid fa-paper-plane fa-fw"></span> <{$smarty.const._PM_OUTBOX}></a>
+            <a class="btn <{if $op == 'save'}>btn-primary<{else}>btn-outline-secondary<{/if}>" href="viewpmsg.php?op=save"><span class="fa-solid fa-box-archive fa-fw"></span> <{$smarty.const._PM_SAVEBOX}></a>
         </div>
     </div>
 

--- a/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
+++ b/htdocs/themes/xbootstrap5/modules/pm/pm_viewpmsg.tpl
@@ -38,7 +38,7 @@
         <thead class="table-light">
             <tr>
                 <th class="text-center" style="width: 3rem;">
-                    <input name="allbox" id="allbox" onclick='xoopsCheckAll("<{$pmform.name}>", "allbox");' type="checkbox" value="Check All" class="form-check-input" aria-label="Select all messages">
+                    <input name="allbox" id="allbox" onclick='xoopsCheckAll("<{$pmform.name}>", "allbox");' type="checkbox" value="Check All" class="form-check-input" aria-label="<{$smarty.const.THEME_SELECT_ALL|default:'Select all'}>">
                 </th>
                 <th class="text-center d-none d-sm-table-cell" style="width: 2.5rem;">
                     <span class="fa-solid fa-envelope text-primary"></span>
@@ -62,7 +62,7 @@
             <{foreach item=message from=$messages|default:null}>
                 <tr>
                     <td class="text-center align-middle">
-                        <input type="checkbox" id="msg_id_<{$message.msg_id}>" name="msg_id[]" value="<{$message.msg_id}>" class="form-check-input">
+                        <input type="checkbox" id="msg_id_<{$message.msg_id}>" name="msg_id[]" value="<{$message.msg_id}>" class="form-check-input" aria-label="<{$message.subject|escape}>">
                     </td>
                     <td class="text-center align-middle d-none d-sm-table-cell">
                         <{if $message.read_msg == 1}>
@@ -83,7 +83,7 @@
                             <img src="<{$xoops_url}>/images/subject/<{$message.msg_image}>" alt="">
                         <{/if}>
                         <a href="readpmsg.php?msg_id=<{$message.msg_id}>&amp;start=<{$message.msg_no}>&amp;total_messages=<{$total_messages}>&amp;op=<{$op}>">
-                            <{$message.subject}>
+                            <{$message.subject|escape}>
                         </a>
                         <div class="d-md-none text-muted small"><{$message.msg_time}></div>
                     </td>

--- a/htdocs/themes/xbootstrap5/modules/system/system_confirm.tpl
+++ b/htdocs/themes/xbootstrap5/modules/system/system_confirm.tpl
@@ -1,0 +1,13 @@
+<div class="alert alert-primary" role="alert">
+    <div class="d-flex flex-wrap align-items-center gap-3">
+        <div class="flex-grow-1"><{$msg}></div>
+        <form class="d-inline-flex gap-2" method="post" action="<{$action}>">
+            <{$hiddens}>
+            <{if ($addtoken)}>
+                <{$token}>
+            <{/if}>
+            <input class="btn btn-primary" type="submit" name="confirm_submit" value="<{$submit}>" title="<{$submit}>">
+            <input class="btn btn-secondary" name="confirm_back" type="button" value="<{$smarty.const._CANCEL}>" onclick="history.go(-1);" title="<{$smarty.const._CANCEL}>">
+        </form>
+    </div>
+</div>


### PR DESCRIPTION
  Show selected message subjects and senders in the delete confirmation
  dialog. Center all popup windows (PM compose, smilies, user finder)
  via openWithSelfMain. Rewrite xbootstrap5 PM inbox template with
  proper table layout and separate action buttons. Add styled
  system_confirm.tpl for xbootstrap5 so confirmation dialogs match
  xswatch4 appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed deletion confirmation listing allowed messages (other participant and subject).
  * Added a Bootstrap‑5 styled confirmation form for POST actions.

* **Bug Fixes**
  * Popup windows now center reliably and avoid off‑screen placement; focus only applied when opened.
  * Deletion flow validates, de‑duplicates and restricts removals to messages the current user may delete; safer ID handling and defensive decoding.

* **Style**
  * Private messages UI refreshed with Bootstrap‑5 tables, updated alerts, responsive timestamps, improved pagination placement, accessible checkboxes, and restyled action buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->