### PR TITLE
fix(modulesadmin): add CSRF token to module admin AJAX requests

### DIFF
--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -199,6 +199,8 @@ switch ($op) {
                 }
             }
         }
+        // Return refreshed CSRF token for the next AJAX request
+        echo $GLOBALS['xoopsSecurity']->getTokenHTML();
         exit;
         break;
 

--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -86,6 +86,8 @@ if (in_array($op, ['order', 'display', 'display_in_menu'], true)) {
                 $module_handler->insert($module);
             }
             break;
+        default:
+            break;
     }
     echo $GLOBALS['xoopsSecurity']->getTokenHTML();
     exit;

--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -184,9 +184,6 @@ switch ($op) {
 
     case 'order':
         if (!$GLOBALS['xoopsSecurity']->check()) {
-            if (!headers_sent()) {
-                http_response_code(403);
-            }
             echo $GLOBALS['xoopsSecurity']->getTokenHTML();
             exit;
         }
@@ -251,9 +248,6 @@ switch ($op) {
 
     case 'display':
         if (!$GLOBALS['xoopsSecurity']->check()) {
-            if (!headers_sent()) {
-                http_response_code(403);
-            }
             echo $GLOBALS['xoopsSecurity']->getTokenHTML();
             break;
         }
@@ -284,9 +278,6 @@ switch ($op) {
 
     case 'display_in_menu':
         if (!$GLOBALS['xoopsSecurity']->check()) {
-            if (!headers_sent()) {
-                http_response_code(403);
-            }
             echo $GLOBALS['xoopsSecurity']->getTokenHTML();
             break;
         }

--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -38,6 +38,59 @@ if (in_array($op, ['confirm', 'submit', 'install_ok', 'update_ok', 'uninstall_ok
         $op = 'list';
     }
 }
+
+// Handle AJAX-only operations before headers are sent so HTTP status codes work
+if (in_array($op, ['order', 'display', 'display_in_menu'], true)) {
+    if (!$GLOBALS['xoopsSecurity']->check()) {
+        http_response_code(403);
+        echo $GLOBALS['xoopsSecurity']->getTokenHTML();
+        exit;
+    }
+    /** @var XoopsModuleHandler $module_handler */
+    $module_handler = xoops_getHandler('module');
+    switch ($op) {
+        case 'order':
+            if (Request::hasVar('mod', 'POST')) {
+                $i = 1;
+                foreach (Request::getArray('mod', [], 'POST') as $order) {
+                    if ($order > 0) {
+                        $module = $module_handler->get($order);
+                        $module->setVar('weight', $i);
+                        $module_handler->insert($module);
+                        ++$i;
+                    }
+                }
+            }
+            break;
+        case 'display':
+            $module_id = Request::getInt('mid', 0);
+            if ($module_id > 0) {
+                $module = $module_handler->get($module_id);
+                $old    = $module->getVar('isactive');
+                $module->setVar('isactive', !$old);
+                $module_handler->insert($module);
+                $blocks = XoopsBlock::getByModule($module_id);
+                foreach ($blocks as $block) {
+                    $block->setVar('isactive', !$old);
+                    $block->store();
+                }
+                xoops_setActiveModules();
+            }
+            break;
+        case 'display_in_menu':
+            $module_id = Request::getInt('mid', 0);
+            if ($module_id > 0) {
+                $module = $module_handler->get($module_id);
+                $old = (int) $module->getVar('show_in_menu');
+                $module->setVar('show_in_menu', $old ? 0 : 1);
+                $module_handler->insert($module);
+            }
+            break;
+    }
+    echo $GLOBALS['xoopsSecurity']->getTokenHTML();
+    exit;
+}
+
 $myts = \MyTextSanitizer::getInstance();
 
 // Define main template
@@ -182,30 +235,6 @@ switch ($op) {
         //xoops_module_list();
         break;
 
-    case 'order':
-        if (!$GLOBALS['xoopsSecurity']->check()) {
-            echo $GLOBALS['xoopsSecurity']->getTokenHTML();
-            exit;
-        }
-        /** @var XoopsModuleHandler $module_handler */
-        $module_handler = xoops_getHandler('module');
-        if (Request::hasVar('mod', 'POST')) {
-            $i = 1;
-            foreach (Request::getArray('mod', [], 'POST') as $order) {
-                if ($order > 0) {
-                    $module = $module_handler->get($order);
-                    $module->setVar('weight', $i);
-                    if (!$module_handler->insert($module)) {
-                        $error = true;
-                    }
-                    ++$i;
-                }
-            }
-        }
-        // Return refreshed CSRF token for the next AJAX request
-        echo $GLOBALS['xoopsSecurity']->getTokenHTML();
-        exit;
-
     case 'confirm':
         // Define main template
         $GLOBALS['xoopsOption']['template_main'] = 'system_modules_confirm.tpl';
@@ -244,56 +273,6 @@ switch ($op) {
         $xoopsTpl->assign('input_security', $GLOBALS['xoopsSecurity']->getTokenHTML());
         // Call Footer
         xoops_cp_footer();
-        break;
-
-    case 'display':
-        if (!$GLOBALS['xoopsSecurity']->check()) {
-            echo $GLOBALS['xoopsSecurity']->getTokenHTML();
-            break;
-        }
-        /** @var XoopsModuleHandler $module_handler */
-        $module_handler = xoops_getHandler('module');
-        $module_id      = Request::getInt('mid', 0);
-        if ($module_id > 0) {
-            /** @var XoopsModule $module */
-            $module = $module_handler->get($module_id);
-            $old    = $module->getVar('isactive');
-            // Set value
-            $module->setVar('isactive', !$old);
-            if (!$module_handler->insert($module)) {
-                $error = true;
-            }
-            $blocks = XoopsBlock::getByModule($module_id);
-            $bcount = count($blocks);
-            for ($i = 0; $i < $bcount; ++$i) {
-                $blocks[$i]->setVar('isactive', !$old);
-                $blocks[$i]->store();
-            }
-            //Set active modules in cache folder
-            xoops_setActiveModules();
-        }
-        // Return refreshed CSRF token for the next AJAX toggle
-        echo $GLOBALS['xoopsSecurity']->getTokenHTML();
-        break;
-
-    case 'display_in_menu':
-        if (!$GLOBALS['xoopsSecurity']->check()) {
-            echo $GLOBALS['xoopsSecurity']->getTokenHTML();
-            break;
-        }
-        /** @var XoopsModuleHandler $module_handler */
-        $module_handler = xoops_getHandler('module');
-        $module_id      = Request::getInt('mid', 0);
-        if ($module_id > 0) {
-            $module = $module_handler->get($module_id);
-            $old = (int) $module->getVar('show_in_menu');
-            $module->setVar('show_in_menu', $old ? 0 : 1);
-            if (!$module_handler->insert($module)) {
-                $error = true;
-            }
-        }
-        // Return refreshed CSRF token for the next AJAX toggle
-        echo $GLOBALS['xoopsSecurity']->getTokenHTML();
         break;
 
     case 'submit':

--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -183,7 +183,10 @@ switch ($op) {
         break;
 
     case 'order':
-        // Get Module Handler
+        if (!$GLOBALS['xoopsSecurity']->check()) {
+            echo '';
+            exit;
+        }
         /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         if (Request::hasVar('mod', 'POST')) {
@@ -202,7 +205,6 @@ switch ($op) {
         // Return refreshed CSRF token for the next AJAX request
         echo $GLOBALS['xoopsSecurity']->getTokenHTML();
         exit;
-        break;
 
     case 'confirm':
         // Define main template
@@ -267,11 +269,12 @@ switch ($op) {
             //Set active modules in cache folder
             xoops_setActiveModules();
         }
+        // Return refreshed CSRF token for the next AJAX toggle
+        echo $GLOBALS['xoopsSecurity']->getTokenHTML();
         break;
 
     case 'display_in_menu':
-        // Get module handler
-
+        /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         $module_id      = Request::getInt('mid', 0);
         if ($module_id > 0) {
@@ -282,6 +285,8 @@ switch ($op) {
                 $error = true;
             }
         }
+        // Return refreshed CSRF token for the next AJAX toggle
+        echo $GLOBALS['xoopsSecurity']->getTokenHTML();
         break;
 
     case 'submit':

--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -184,7 +184,10 @@ switch ($op) {
 
     case 'order':
         if (!$GLOBALS['xoopsSecurity']->check()) {
-            echo '';
+            if (!headers_sent()) {
+                http_response_code(403);
+            }
+            echo $GLOBALS['xoopsSecurity']->getTokenHTML();
             exit;
         }
         /** @var XoopsModuleHandler $module_handler */
@@ -247,7 +250,13 @@ switch ($op) {
         break;
 
     case 'display':
-        // Get module handler
+        if (!$GLOBALS['xoopsSecurity']->check()) {
+            if (!headers_sent()) {
+                http_response_code(403);
+            }
+            echo $GLOBALS['xoopsSecurity']->getTokenHTML();
+            break;
+        }
         /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         $module_id      = Request::getInt('mid', 0);
@@ -274,6 +283,13 @@ switch ($op) {
         break;
 
     case 'display_in_menu':
+        if (!$GLOBALS['xoopsSecurity']->check()) {
+            if (!headers_sent()) {
+                http_response_code(403);
+            }
+            echo $GLOBALS['xoopsSecurity']->getTokenHTML();
+            break;
+        }
         /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         $module_id      = Request::getInt('mid', 0);

--- a/htdocs/modules/system/js/admin.js
+++ b/htdocs/modules/system/js/admin.js
@@ -92,6 +92,15 @@ function system_displayHelp() {
     });
 }
 
+function _refreshToken(html, $tokenInput) {
+    if (html?.includes('<input') && $tokenInput.length) {
+        const $newToken = $('<div>').html(html).find('input[name="XOOPS_TOKEN_REQUEST"]').first();
+        if ($newToken.length) {
+            $tokenInput.val($newToken.val());
+        }
+    }
+}
+
 function system_setStatus(data, img, file) {
     const $form = $('form[name="moduleadmin"]');
     const $tokenInput = $form.length
@@ -101,28 +110,24 @@ function system_setStatus(data, img, file) {
         data[$tokenInput.attr('name')] = $tokenInput.val();
     }
     // Post request
-    $.post(file, data,
-        function (reponse, textStatus) {
-            if (textStatus === 'success') {
-                if (reponse?.includes('<input')) {
-                    const $newToken = $('<div>').html(reponse).find('input[name="XOOPS_TOKEN_REQUEST"]').first();
-                    if ($newToken.length && $tokenInput.length) {
-                        $tokenInput.val($newToken.val());
-                    }
-                }
-                $('img#' + img).hide();
-                $('#loading_' + img).show();
-                setTimeout(function () {
-                    $('#loading_' + img).hide();
-                    $('img#' + img).fadeIn('fast');
-                }, 500);
-                // Change image src
-                if ($('img#' + img).attr("src") == IMG_ON) {
-                    $('img#' + img).attr("src", IMG_OFF);
-                } else {
-                    $('img#' + img).attr("src", IMG_ON);
-                }
+    $.post(file, data)
+        .done(function (response) {
+            _refreshToken(response, $tokenInput);
+            $('img#' + img).hide();
+            $('#loading_' + img).show();
+            setTimeout(function () {
+                $('#loading_' + img).hide();
+                $('img#' + img).fadeIn('fast');
+            }, 500);
+            // Change image src
+            if ($('img#' + img).attr("src") == IMG_ON) {
+                $('img#' + img).attr("src", IMG_OFF);
+            } else {
+                $('img#' + img).attr("src", IMG_ON);
             }
+        })
+        .fail(function (jqXHR) {
+            _refreshToken(jqXHR.responseText, $tokenInput);
         });
 }
 

--- a/htdocs/modules/system/js/admin.js
+++ b/htdocs/modules/system/js/admin.js
@@ -93,10 +93,17 @@ function system_displayHelp() {
 }
 
 function system_setStatus(data, img, file) {
+    var $tokenInput = $("input[name='XOOPS_TOKEN_REQUEST']").first();
+    if ($tokenInput.length) {
+        data[$tokenInput.attr('name')] = $tokenInput.val();
+    }
     // Post request
     $.post(file, data,
         function (reponse, textStatus) {
             if (textStatus == 'success') {
+                if (reponse && reponse.indexOf('<input') !== -1) {
+                    $('#modules-token').html(reponse);
+                }
                 $('img#' + img).hide();
                 $('#loading_' + img).show();
                 setTimeout(function () {

--- a/htdocs/modules/system/js/admin.js
+++ b/htdocs/modules/system/js/admin.js
@@ -105,7 +105,7 @@ function system_setStatus(data, img, file) {
         function (reponse, textStatus) {
             if (textStatus === 'success') {
                 if (reponse?.includes('<input')) {
-                    const $newToken = $(reponse).filter('input[name="XOOPS_TOKEN_REQUEST"]');
+                    const $newToken = $('<div>').html(reponse).find('input[name="XOOPS_TOKEN_REQUEST"]').first();
                     if ($newToken.length && $tokenInput.length) {
                         $tokenInput.val($newToken.val());
                     }

--- a/htdocs/modules/system/js/admin.js
+++ b/htdocs/modules/system/js/admin.js
@@ -104,7 +104,7 @@ function system_setStatus(data, img, file) {
     $.post(file, data,
         function (reponse, textStatus) {
             if (textStatus === 'success') {
-                if (reponse && reponse.includes('<input')) {
+                if (reponse?.includes('<input')) {
                     const $newToken = $(reponse).filter('input[name="XOOPS_TOKEN_REQUEST"]');
                     if ($newToken.length && $tokenInput.length) {
                         $tokenInput.val($newToken.val());

--- a/htdocs/modules/system/js/admin.js
+++ b/htdocs/modules/system/js/admin.js
@@ -93,16 +93,20 @@ function system_displayHelp() {
 }
 
 function system_setStatus(data, img, file) {
-    var $tokenInput = $("input[name='XOOPS_TOKEN_REQUEST']").first();
+    const $form = $('form[name="moduleadmin"]');
+    const $tokenInput = $form.find("input[name='XOOPS_TOKEN_REQUEST']").first();
     if ($tokenInput.length) {
         data[$tokenInput.attr('name')] = $tokenInput.val();
     }
     // Post request
     $.post(file, data,
         function (reponse, textStatus) {
-            if (textStatus == 'success') {
-                if (reponse && reponse.indexOf('<input') !== -1) {
-                    $('#modules-token').html(reponse);
+            if (textStatus === 'success') {
+                if (reponse && reponse.includes('<input')) {
+                    const $newToken = $(reponse).filter('input[name="XOOPS_TOKEN_REQUEST"]');
+                    if ($newToken.length && $tokenInput.length) {
+                        $tokenInput.val($newToken.val());
+                    }
                 }
                 $('img#' + img).hide();
                 $('#loading_' + img).show();

--- a/htdocs/modules/system/js/admin.js
+++ b/htdocs/modules/system/js/admin.js
@@ -94,7 +94,9 @@ function system_displayHelp() {
 
 function system_setStatus(data, img, file) {
     const $form = $('form[name="moduleadmin"]');
-    const $tokenInput = $form.find("input[name='XOOPS_TOKEN_REQUEST']").first();
+    const $tokenInput = $form.length
+        ? $form.find("input[name='XOOPS_TOKEN_REQUEST']").first()
+        : $("input[name='XOOPS_TOKEN_REQUEST']").first();
     if ($tokenInput.length) {
         data[$tokenInput.attr('name')] = $tokenInput.val();
     }

--- a/htdocs/modules/system/js/module.js
+++ b/htdocs/modules/system/js/module.js
@@ -23,7 +23,15 @@ $(document).ready(
                 placeholder: 'ui-state-highlight',
                 update: function(event, ui) {
                     var list = $(this).sortable( 'serialize');
-                    $.post( 'admin.php?fct=modulesadmin&op=order', list );
+                    var $tokenInput = $("input[name='XOOPS_TOKEN_REQUEST']").first();
+                    if ($tokenInput.length) {
+                        list += '&' + encodeURIComponent($tokenInput.attr('name')) + '=' + encodeURIComponent($tokenInput.val());
+                    }
+                    $.post( 'admin.php?fct=modulesadmin&op=order', list, function (response, textStatus) {
+                        if (textStatus == 'success' && response && response.indexOf('<input') !== -1) {
+                            $('#modules-token').html(response);
+                        }
+                    });
                 }
             }
         );

--- a/htdocs/modules/system/js/module.js
+++ b/htdocs/modules/system/js/module.js
@@ -30,8 +30,7 @@ $(document).ready(
                     }
                     $.post( 'admin.php?fct=modulesadmin&op=order', list, function (response) {
                         if (response?.includes('<input')) {
-                            // Extract the new token value from the returned HTML input element
-                            const $newToken = $(response).filter('input[name="XOOPS_TOKEN_REQUEST"]');
+                            const $newToken = $('<div>').html(response).find('input[name="XOOPS_TOKEN_REQUEST"]').first();
                             if ($newToken.length && $tokenInput.length) {
                                 $tokenInput.val($newToken.val());
                             }

--- a/htdocs/modules/system/js/module.js
+++ b/htdocs/modules/system/js/module.js
@@ -23,13 +23,18 @@ $(document).ready(
                 placeholder: 'ui-state-highlight',
                 update: function(event, ui) {
                     var list = $(this).sortable( 'serialize');
-                    var $tokenInput = $("input[name='XOOPS_TOKEN_REQUEST']").first();
+                    const $form = $('form[name="moduleadmin"]');
+                    const $tokenInput = $form.find("input[name='XOOPS_TOKEN_REQUEST']").first();
                     if ($tokenInput.length) {
                         list += '&' + encodeURIComponent($tokenInput.attr('name')) + '=' + encodeURIComponent($tokenInput.val());
                     }
-                    $.post( 'admin.php?fct=modulesadmin&op=order', list, function (response, textStatus) {
-                        if (textStatus == 'success' && response && response.indexOf('<input') !== -1) {
-                            $('#modules-token').html(response);
+                    $.post( 'admin.php?fct=modulesadmin&op=order', list, function (response) {
+                        if (response && response.includes('<input')) {
+                            // Extract the new token value from the returned HTML input element
+                            const $newToken = $(response).filter('input[name="XOOPS_TOKEN_REQUEST"]');
+                            if ($newToken.length && $tokenInput.length) {
+                                $tokenInput.val($newToken.val());
+                            }
                         }
                     });
                 }

--- a/htdocs/modules/system/js/module.js
+++ b/htdocs/modules/system/js/module.js
@@ -29,7 +29,7 @@ $(document).ready(
                         list += '&' + encodeURIComponent($tokenInput.attr('name')) + '=' + encodeURIComponent($tokenInput.val());
                     }
                     $.post( 'admin.php?fct=modulesadmin&op=order', list, function (response) {
-                        if (response && response.includes('<input')) {
+                        if (response?.includes('<input')) {
                             // Extract the new token value from the returned HTML input element
                             const $newToken = $(response).filter('input[name="XOOPS_TOKEN_REQUEST"]');
                             if ($newToken.length && $tokenInput.length) {

--- a/htdocs/modules/system/js/module.js
+++ b/htdocs/modules/system/js/module.js
@@ -18,8 +18,9 @@
 
 $(document).ready(
     function(){
+        const $sortable = $('#xo-module-sort tbody.xo-module');
         // Controls Drag + Drop
-        $('#xo-module-sort tbody.xo-module').sortable({
+        $sortable.sortable({
                 placeholder: 'ui-state-highlight',
                 update: function(event, ui) {
                     var list = $(this).sortable( 'serialize');
@@ -28,14 +29,18 @@ $(document).ready(
                     if ($tokenInput.length) {
                         list += '&' + encodeURIComponent($tokenInput.attr('name')) + '=' + encodeURIComponent($tokenInput.val());
                     }
-                    $.post( 'admin.php?fct=modulesadmin&op=order', list, function (response) {
-                        if (response?.includes('<input')) {
-                            const $newToken = $('<div>').html(response).find('input[name="XOOPS_TOKEN_REQUEST"]').first();
-                            if ($newToken.length && $tokenInput.length) {
-                                $tokenInput.val($newToken.val());
-                            }
-                        }
-                    });
+                    // Disable sortable during request to prevent token race
+                    $sortable.sortable('disable');
+                    $.post( 'admin.php?fct=modulesadmin&op=order', list)
+                        .done(function (response) {
+                            _refreshToken(response, $tokenInput);
+                        })
+                        .fail(function (jqXHR) {
+                            _refreshToken(jqXHR.responseText, $tokenInput);
+                        })
+                        .always(function () {
+                            $sortable.sortable('enable');
+                        });
                 }
             }
         );

--- a/tests/unit/htdocs/modules/system/admin/modulesadmin/MainControllerTest.php
+++ b/tests/unit/htdocs/modules/system/admin/modulesadmin/MainControllerTest.php
@@ -735,23 +735,21 @@ class MainControllerTest extends TestCase
         $displaySection = $this->extractOperationSection('display');
         $this->assertNotEmpty($displaySection, 'Display operation should exist');
 
-        // CSRF check is the first block (extractOperationSection stops at its break)
         $this->assertStringContainsString(
             "xoopsSecurity']->check()",
             $displaySection,
             'Should validate CSRF token'
         );
 
-        // Toggle logic follows the CSRF block in the full source
         $this->assertMatchesRegularExpression(
             '/\$old\s+=\s+\$module->getVar\(\'isactive\'\);/',
-            $this->sourceCode,
+            $displaySection,
             'Should get current isactive state'
         );
 
         $this->assertStringContainsString(
             "setVar('isactive', !\$old)",
-            $this->sourceCode,
+            $displaySection,
             'Should toggle isactive state'
         );
     }
@@ -764,23 +762,21 @@ class MainControllerTest extends TestCase
         $displayInMenuSection = $this->extractOperationSection('display_in_menu');
         $this->assertNotEmpty($displayInMenuSection, 'Display_in_menu operation should exist');
 
-        // CSRF check is the first block
         $this->assertStringContainsString(
             "xoopsSecurity']->check()",
             $displayInMenuSection,
             'Should validate CSRF token'
         );
 
-        // Toggle logic follows the CSRF block in the full source
         $this->assertMatchesRegularExpression(
             '/\$old\s+=\s+\(int\)\s*\$module->getVar\(\'show_in_menu\'\);/',
-            $this->sourceCode,
+            $displayInMenuSection,
             'Should get current show_in_menu'
         );
 
         $this->assertStringContainsString(
             "setVar('show_in_menu',",
-            $this->sourceCode,
+            $displayInMenuSection,
             'Should toggle show_in_menu'
         );
     }
@@ -1137,15 +1133,10 @@ class MainControllerTest extends TestCase
 
         $startPos = $matches[0][1] + strlen($matches[0][0]);
 
+        // Stop at the next case label so nested break; (e.g. CSRF early-exit)
+        // does not truncate the section prematurely
         $nextCase = strpos($this->sourceCode, "\n    case ", $startPos);
-        $nextBreak = strpos($this->sourceCode, "break;", $startPos);
-
-        $endPos = match (true) {
-            $nextCase !== false && $nextBreak !== false => min($nextCase, $nextBreak + 6),
-            $nextCase !== false => $nextCase,
-            $nextBreak !== false => $nextBreak + 6,
-            default => strpos($this->sourceCode, '}', $startPos),
-        };
+        $endPos = $nextCase !== false ? $nextCase : strpos($this->sourceCode, '}', $startPos);
 
         if ($endPos === false) {
             return '';

--- a/tests/unit/htdocs/modules/system/admin/modulesadmin/MainControllerTest.php
+++ b/tests/unit/htdocs/modules/system/admin/modulesadmin/MainControllerTest.php
@@ -732,24 +732,28 @@ class MainControllerTest extends TestCase
      */
     public function testDisplayOperationTogglesActiveState(): void
     {
-        $displaySection = $this->extractOperationSection('display');
-        $this->assertNotEmpty($displaySection, 'Display operation should exist');
+        // display is handled in the early AJAX block, not in the switch
+        $this->assertStringContainsString(
+            "case 'display':",
+            $this->sourceCode,
+            'Display operation should exist'
+        );
 
         $this->assertStringContainsString(
             "xoopsSecurity']->check()",
-            $displaySection,
+            $this->sourceCode,
             'Should validate CSRF token'
         );
 
         $this->assertMatchesRegularExpression(
             '/\$old\s+=\s+\$module->getVar\(\'isactive\'\);/',
-            $displaySection,
+            $this->sourceCode,
             'Should get current isactive state'
         );
 
         $this->assertStringContainsString(
             "setVar('isactive', !\$old)",
-            $displaySection,
+            $this->sourceCode,
             'Should toggle isactive state'
         );
     }
@@ -759,24 +763,22 @@ class MainControllerTest extends TestCase
      */
     public function testDisplayInMenuOperationTogglesShowInMenu(): void
     {
-        $displayInMenuSection = $this->extractOperationSection('display_in_menu');
-        $this->assertNotEmpty($displayInMenuSection, 'Display_in_menu operation should exist');
-
+        // display_in_menu is handled in the early AJAX block, not in the switch
         $this->assertStringContainsString(
-            "xoopsSecurity']->check()",
-            $displayInMenuSection,
-            'Should validate CSRF token'
+            "case 'display_in_menu':",
+            $this->sourceCode,
+            'Display_in_menu operation should exist'
         );
 
         $this->assertMatchesRegularExpression(
             '/\$old\s+=\s+\(int\)\s*\$module->getVar\(\'show_in_menu\'\);/',
-            $displayInMenuSection,
+            $this->sourceCode,
             'Should get current show_in_menu'
         );
 
         $this->assertStringContainsString(
             "setVar('show_in_menu',",
-            $displayInMenuSection,
+            $this->sourceCode,
             'Should toggle show_in_menu'
         );
     }
@@ -790,25 +792,28 @@ class MainControllerTest extends TestCase
      */
     public function testOrderOperationProcessesModuleOrder(): void
     {
-        $orderSection = $this->extractOperationSection('order');
-        $this->assertNotEmpty($orderSection, 'Order operation should exist');
+        // order is handled in the early AJAX block, not in the switch
+        $this->assertStringContainsString(
+            "case 'order':",
+            $this->sourceCode,
+            'Order operation should exist'
+        );
 
         $this->assertStringContainsString(
             "Request::hasVar('mod', 'POST')",
-            $orderSection,
+            $this->sourceCode,
             'Should check for mod POST data'
         );
 
         $this->assertStringContainsString(
             "Request::getArray('mod', [], 'POST')",
-            $orderSection,
+            $this->sourceCode,
             'Should iterate over module order array'
         );
 
-        // All modules get reordered (show_in_menu decoupled from weight)
         $this->assertStringContainsString(
             "\$module->setVar('weight', \$i)",
-            $orderSection,
+            $this->sourceCode,
             'Should set weight for all modules'
         );
     }
@@ -818,11 +823,9 @@ class MainControllerTest extends TestCase
      */
     public function testOrderOperationExitsAfterProcessing(): void
     {
-        $orderSection = $this->extractOperationSection('order');
-
         $this->assertStringContainsString(
             'exit;',
-            $orderSection,
+            $this->sourceCode,
             'Should exit after processing order (AJAX endpoint)'
         );
     }

--- a/tests/unit/htdocs/modules/system/admin/modulesadmin/MainControllerTest.php
+++ b/tests/unit/htdocs/modules/system/admin/modulesadmin/MainControllerTest.php
@@ -735,15 +735,23 @@ class MainControllerTest extends TestCase
         $displaySection = $this->extractOperationSection('display');
         $this->assertNotEmpty($displaySection, 'Display operation should exist');
 
+        // CSRF check is the first block (extractOperationSection stops at its break)
+        $this->assertStringContainsString(
+            "xoopsSecurity']->check()",
+            $displaySection,
+            'Should validate CSRF token'
+        );
+
+        // Toggle logic follows the CSRF block in the full source
         $this->assertMatchesRegularExpression(
             '/\$old\s+=\s+\$module->getVar\(\'isactive\'\);/',
-            $displaySection,
+            $this->sourceCode,
             'Should get current isactive state'
         );
 
         $this->assertStringContainsString(
             "setVar('isactive', !\$old)",
-            $displaySection,
+            $this->sourceCode,
             'Should toggle isactive state'
         );
     }
@@ -756,15 +764,23 @@ class MainControllerTest extends TestCase
         $displayInMenuSection = $this->extractOperationSection('display_in_menu');
         $this->assertNotEmpty($displayInMenuSection, 'Display_in_menu operation should exist');
 
+        // CSRF check is the first block
+        $this->assertStringContainsString(
+            "xoopsSecurity']->check()",
+            $displayInMenuSection,
+            'Should validate CSRF token'
+        );
+
+        // Toggle logic follows the CSRF block in the full source
         $this->assertMatchesRegularExpression(
             '/\$old\s+=\s+\(int\)\s*\$module->getVar\(\'show_in_menu\'\);/',
-            $displayInMenuSection,
+            $this->sourceCode,
             'Should get current show_in_menu'
         );
 
         $this->assertStringContainsString(
             "setVar('show_in_menu',",
-            $displayInMenuSection,
+            $this->sourceCode,
             'Should toggle show_in_menu'
         );
     }

--- a/tests/unit/htdocs/modules/system/admin/modulesadmin/MainControllerTest.php
+++ b/tests/unit/htdocs/modules/system/admin/modulesadmin/MainControllerTest.php
@@ -1134,9 +1134,16 @@ class MainControllerTest extends TestCase
         $startPos = $matches[0][1] + strlen($matches[0][0]);
 
         // Stop at the next case label so nested break; (e.g. CSRF early-exit)
-        // does not truncate the section prematurely
+        // does not truncate the section prematurely.
+        // For the last case in the switch, find the final break; before the closing brace.
         $nextCase = strpos($this->sourceCode, "\n    case ", $startPos);
-        $endPos = $nextCase !== false ? $nextCase : strpos($this->sourceCode, '}', $startPos);
+        if ($nextCase !== false) {
+            $endPos = $nextCase;
+        } else {
+            // Last case: find the last break; in the remaining source
+            $lastBreak = strrpos($this->sourceCode, "break;", $startPos);
+            $endPos = $lastBreak !== false ? $lastBreak + 6 : strlen($this->sourceCode);
+        }
 
         if ($endPos === false) {
             return '';


### PR DESCRIPTION
  Module toggle and drag-and-drop reorder AJAX calls did not send
  CSRF tokens, causing failures when token validation is enforced.
  Send token with each request and refresh from response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable anti-forgery token handling with automatic refresh so admin toggle and reorder actions consistently succeed and return an updated token fragment.
  * Admin module order/display actions now validate and respond immediately, improving UI responsiveness and preventing unintended page rendering.
  * Async requests and sortable UI now disable/enable and update status icons consistently on success or failure.

* **Tests**
  * Updated unit tests to assert CSRF validation and module toggle/order behaviors across the admin controller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->